### PR TITLE
Add i2c auto reset

### DIFF
--- a/app/bmc/src/main.c
+++ b/app/bmc/src/main.c
@@ -37,6 +37,9 @@ static const struct gpio_dt_spec board_fault_led =
 	GPIO_DT_SPEC_GET_OR(DT_PATH(board_fault_led), gpios, {0});
 static const struct device *const ina228 = DEVICE_DT_GET_OR_NULL(DT_NODELABEL(ina228));
 
+// static struct k_timer auto_reset_timer;
+static int auto_reset_timeout = 0;
+
 int update_fw(void)
 {
 	/* To get here we are already running known good fw */
@@ -110,9 +113,17 @@ void process_cm2bm_message(struct bh_chip *chip)
 			bharc_smbus_word_data_write(&chip->config.arc, 0x21, 0xA5A5);
 			break;
 		case 0x3:
+			/* Update fan PWM */
 			if (IS_ENABLED(CONFIG_TT_FAN_CTRL)) {
 				set_fan_speed((uint8_t)message.data & 0xFF);
 			}
+			break;
+		case 0x4:
+			/* Update auto reset timeout */
+			auto_reset_timeout = message.data;
+			// if (auto_reset_timeout == 0) {
+			// 	k_timer_stop(&auto_reset_timer);
+			// }
 			break;
 		}
 	}

--- a/app/bmc/src/main.c
+++ b/app/bmc/src/main.c
@@ -37,9 +37,6 @@ static const struct gpio_dt_spec board_fault_led =
 	GPIO_DT_SPEC_GET_OR(DT_PATH(board_fault_led), gpios, {0});
 static const struct device *const ina228 = DEVICE_DT_GET_OR_NULL(DT_NODELABEL(ina228));
 
-// static struct k_timer auto_reset_timer;
-static int auto_reset_timeout = 0;
-
 int update_fw(void)
 {
 	/* To get here we are already running known good fw */
@@ -120,10 +117,22 @@ void process_cm2bm_message(struct bh_chip *chip)
 			break;
 		case 0x4:
 			/* Update auto reset timeout */
-			auto_reset_timeout = message.data;
-			// if (auto_reset_timeout == 0) {
-			// 	k_timer_stop(&auto_reset_timer);
-			// }
+			chip->data.auto_reset_timeout = message.data;
+			if (chip->data.auto_reset_timeout == 0) {
+				k_timer_stop(&chip->auto_reset_timer);
+			}
+			break;
+		case 0x5:
+			/* Update telemetry heartbeat */
+			if (chip->data.telemetry_heartbeat != message.data) {
+				/* Telemetry heartbeat is moving */
+				chip->data.telemetry_heartbeat = message.data;
+				if (chip->data.auto_reset_timeout != 0) {
+					k_timer_start(&chip->auto_reset_timer,
+						      K_MSEC(chip->data.auto_reset_timeout),
+						      K_NO_WAIT);
+				}
+			}
 			break;
 		}
 	}
@@ -307,8 +316,10 @@ int main(void)
 	}
 
 	/* No mechanism for getting bl version... yet */
-	bmStaticInfo static_info =
-		(bmStaticInfo){.version = 1, .bl_version = 0, .app_version = APPVERSION};
+	bmStaticInfo static_info = (bmStaticInfo){.version = 1,
+						  .bl_version = 0,
+						  .app_version = APPVERSION,
+						  .last_reset_was_automatic = false};
 
 	while (1) {
 		k_sleep(K_MSEC(20));
@@ -317,8 +328,11 @@ int main(void)
 		 */
 		ARRAY_FOR_EACH_PTR(BH_CHIPS, chip) {
 			if (chip->data.arc_just_reset) {
+				static_info.last_reset_was_automatic =
+					chip->data.last_reset_was_automatic;
 				if (bh_chip_set_static_info(chip, &static_info) == 0) {
 					chip->data.arc_just_reset = false;
+					chip->data.last_reset_was_automatic = false;
 				}
 				/* TODO: we don't have to read this per chip */
 				uint16_t max_pwr = detect_max_pwr();

--- a/include/tenstorrent/bh_arc.h
+++ b/include/tenstorrent/bh_arc.h
@@ -20,6 +20,7 @@ typedef struct bmStaticInfo {
 	uint32_t version;
 	uint32_t bl_version;
 	uint32_t app_version;
+	uint32_t last_reset_was_automatic;
 } __packed bmStaticInfo;
 
 typedef struct cm2bmMessage {

--- a/include/tenstorrent/bh_chip.h
+++ b/include/tenstorrent/bh_chip.h
@@ -51,12 +51,21 @@ struct bh_chip_data {
 	bool arc_just_reset;
 
 	unsigned int bus_cancel_flag;
+
+	uint32_t auto_reset_timeout;
+
+	/* Keep track of telemetry heartbeat for autoreset */
+	uint32_t telemetry_heartbeat;
+
+	/* Flag set when last reset was an autoreset */
+	bool last_reset_was_automatic;
 };
 
 struct bh_chip {
 	const struct bh_chip_config config;
 	struct bh_chip_data data;
 	struct gpio_callback therm_trip_cb;
+	struct k_timer auto_reset_timer;
 };
 
 #define DT_PHANDLE_OR_CHILD(node_id, name)                                                         \
@@ -106,6 +115,8 @@ extern struct bh_chip BH_CHIPS[BH_CHIP_COUNT];
 						.reset_lock = Z_MUTEX_INITIALIZER(                 \
 							BH_CHIPS[idx].data.reset_lock),            \
 					},                                                         \
+				.auto_reset_timer = Z_TIMER_INITIALIZER(                           \
+					BH_CHIPS[idx].auto_reset_timer, auto_reset, NULL),         \
 			},
 
 #define BH_CHIP_PRIMARY_INDEX DT_PROP(DT_PATH(chips), primary)
@@ -120,6 +131,8 @@ int bh_chip_set_static_info(struct bh_chip *chip, bmStaticInfo *info);
 int bh_chip_set_input_current(struct bh_chip *chip, uint32_t *current);
 int bh_chip_set_fan_rpm(struct bh_chip *chip, uint16_t rpm);
 int bh_chip_set_board_pwr_lim(struct bh_chip *chip, uint16_t max_pwr);
+
+void auto_reset(struct k_timer *timer);
 
 void bh_chip_assert_asic_reset(const struct bh_chip *chip);
 void bh_chip_deassert_asic_reset(const struct bh_chip *chip);

--- a/lib/tenstorrent/bh_arc/cm2bm_msg.c
+++ b/lib/tenstorrent/bh_arc/cm2bm_msg.c
@@ -125,6 +125,15 @@ void UpdateAutoRstTimeoutRequest(uint32_t timeout)
 	EnqueueCm2BmMsg(&msg);
 }
 
+void UpdateTelemHeartbeatRequest(uint32_t heartbeat)
+{
+	Cm2BmMsg msg = {
+		.msg_id = kCm2BmMsgTelemHeartbeatUpdate,
+		.data = heartbeat /* in ms */
+	};
+	EnqueueCm2BmMsg(&msg);
+}
+
 /* Report the current message and automatically acknowledge it. */
 int32_t ResetBoardByte(uint8_t *data, uint8_t size)
 {

--- a/lib/tenstorrent/bh_arc/cm2bm_msg.c
+++ b/lib/tenstorrent/bh_arc/cm2bm_msg.c
@@ -116,6 +116,15 @@ void UpdateFanSpeedRequest(uint32_t fan_speed)
 	EnqueueCm2BmMsg(&msg);
 }
 
+void UpdateAutoRstTimeoutRequest(uint32_t timeout)
+{
+	Cm2BmMsg msg = {
+		.msg_id = kCm2BmMsgIdAutoRstTimeoutUpdate,
+		.data = timeout /* in ms */
+	};
+	EnqueueCm2BmMsg(&msg);
+}
+
 /* Report the current message and automatically acknowledge it. */
 int32_t ResetBoardByte(uint8_t *data, uint8_t size)
 {

--- a/lib/tenstorrent/bh_arc/cm2bm_msg.h
+++ b/lib/tenstorrent/bh_arc/cm2bm_msg.h
@@ -14,6 +14,7 @@ typedef enum {
 	kCm2BmMsgIdResetReq = 1,
 	kCm2BmMsgIdPing = 2,
 	kCm2BmMsgIdFanSpeedUpdate = 3,
+	kCm2BmMsgIdAutoRstTimeoutUpdate = 4,
 } Cm2BmMsgId;
 
 typedef struct {
@@ -39,6 +40,7 @@ int32_t ResetBoardByte(uint8_t *data, uint8_t size);
 
 void ChipResetRequest(void *arg);
 void UpdateFanSpeedRequest(uint32_t fan_speed);
+void UpdateAutoRstTimeoutRequest(uint32_t timeout);
 
 typedef struct bmStaticInfo {
 	/* Non-zero for valid data */

--- a/lib/tenstorrent/bh_arc/cm2bm_msg.h
+++ b/lib/tenstorrent/bh_arc/cm2bm_msg.h
@@ -15,6 +15,7 @@ typedef enum {
 	kCm2BmMsgIdPing = 2,
 	kCm2BmMsgIdFanSpeedUpdate = 3,
 	kCm2BmMsgIdAutoRstTimeoutUpdate = 4,
+	kCm2BmMsgTelemHeartbeatUpdate = 5,
 } Cm2BmMsgId;
 
 typedef struct {
@@ -41,6 +42,7 @@ int32_t ResetBoardByte(uint8_t *data, uint8_t size);
 void ChipResetRequest(void *arg);
 void UpdateFanSpeedRequest(uint32_t fan_speed);
 void UpdateAutoRstTimeoutRequest(uint32_t timeout);
+void UpdateTelemHeartbeatRequest(uint32_t heartbeat);
 
 typedef struct bmStaticInfo {
 	/* Non-zero for valid data */

--- a/lib/tenstorrent/bh_arc/telemetry.c
+++ b/lib/tenstorrent/bh_arc/telemetry.c
@@ -46,6 +46,8 @@ static struct k_timer telem_update_timer;
 static struct k_work telem_update_worker;
 static int telem_update_interval = 100;
 
+static int auto_reset_timeout;
+
 uint32_t ConvertFloatToTelemetry(float value)
 {
 	/* Convert float to signed int 16.16 format */
@@ -194,6 +196,9 @@ static void telemetry_work_handler(struct k_work *work)
 {
 	/* Repeat fetching of dynamic telemetry values */
 	update_telemetry();
+	if (auto_reset_timeout != 0) {
+		UpdateTelemHeartbeatRequest(telemetry[TIMER_HEARTBEAT]);
+	}
 }
 static void telemetry_timer_handler(struct k_timer *timer)
 {
@@ -236,6 +241,7 @@ void UpdateBmFwVersion(uint32_t bl_version, uint32_t app_version)
 {
 	telemetry[BM_BL_FW_VERSION] = bl_version;
 	telemetry[BM_APP_FW_VERSION] = app_version;
+	/* TODO: Add reset reason to telemetry */
 }
 
 void UpdateTelemetryNocTranslation(bool translation_enabled)

--- a/lib/tenstorrent/bh_chip/bh_chip.c
+++ b/lib/tenstorrent/bh_chip/bh_chip.c
@@ -95,6 +95,14 @@ int bh_chip_set_board_pwr_lim(struct bh_chip *chip, uint16_t max_pwr)
 	return ret;
 }
 
+void auto_reset(struct k_timer *timer)
+{
+	struct bh_chip *chip = CONTAINER_OF(timer, struct bh_chip, auto_reset_timer);
+
+	chip->data.last_reset_was_automatic = true;
+	bh_chip_reset_chip(chip, true);
+}
+
 void bh_chip_assert_asic_reset(const struct bh_chip *chip)
 {
 	gpio_pin_set_dt(&chip->config.asic_reset, 1);


### PR DESCRIPTION
This PR adds the following:

- a cm2bm message allowing an auto reset timeout to be set per chip in BMC FW
- a cm2bm message updating telemetry heartbeat for each chip in BMC FW
- auto reset timer per chip in BMC FW
- reset reason in bmStaticInfo

Still to do:

- Add default auto reset timeout to SPI and mechanism to change it during runtime
- Add reset reason to telemetry table
- Create some test cases. Flash FW to SMC that won't respond to BMC FW, create common hang scenarios like accessing harvested cores, accessing invalid noc nodes, out of bounds accesses on real noc nodes