### PR TITLE
ci: release: add bmc fw artifacts and combined bundle

### DIFF
--- a/.github/workflows/build-fw.yml
+++ b/.github/workflows/build-fw.yml
@@ -23,6 +23,9 @@ jobs:
           - p100
           - p100a
           - p150a
+        target:
+          - bmc
+          - smc
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/workflows/prepare-zephyr
@@ -31,9 +34,9 @@ jobs:
         shell: bash
         run: |
           case "${{ matrix.board }}" in
-            p100) BOARD=tt_blackhole@p100/tt_blackhole/smc;;
-            p100a) BOARD=tt_blackhole@p100a/tt_blackhole/smc;;
-            p150a) BOARD=tt_blackhole@p150a/tt_blackhole/smc;;
+            p100) BOARD=tt_blackhole@p100/tt_blackhole/${{ matrix.target }};;
+            p100a) BOARD=tt_blackhole@p100a/tt_blackhole/${{ matrix.target }};;
+            p150a) BOARD=tt_blackhole@p150a/tt_blackhole/${{ matrix.target }};;
             *) echo "Unknown board: ${{ matrix.board }}"; exit 1;;
           esac
           echo "BOARD=$BOARD" | tee "$GITHUB_ENV"
@@ -45,10 +48,14 @@ jobs:
           echo "${{ secrets.SIGNATURE_KEY }}" | base64 -d > "$SIGNATURE_KEY_FILE"
           SZ=$(wc -c "$SIGNATURE_KEY_FILE" | awk '{print $1}')
           if [ $SZ -gt 42 ]; then
+            # use a custom signature key file
             echo "SIGNATURE_KEY_FILE=$SIGNATURE_KEY_FILE" >> "$GITHUB_ENV"
+          else
+            # use the default / insecure signature key file
+            echo "SIGNATURE_KEY_FILE=$(realpath $PWD/../bootloader/mcuboot/root-rsa-2048.pem)" >> "$GITHUB_ENV"
           fi
 
-      - name: Build firmware bundle
+      - name: Build firmware
         shell: bash
         run: |
           if [ "$BOARD" = "" ]; then
@@ -57,23 +64,25 @@ jobs:
           fi
 
           west build \
-            -d build-${{ matrix.board }} \
+            -d build-${{ matrix.board }}/$${{ matrix.target }} \
             --sysbuild \
             -p \
             -b $BOARD \
-            app/smc \
+            app/${{ matrix.target }} \
             -- \
               -DCONFIG_COMPILER_WARNINGS_AS_ERRORS=y \
-              -DCONFIG_MCUBOOT_SIGNATURE_KEY_FILE=\"\$SIGNATURE_KEY_FILE\"
+              -DSB_CONFIG_BOOT_SIGNATURE_KEY_FILE=\"$SIGNATURE_KEY_FILE\"
 
       - name: Upload firmware assets
+        if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: firmware-${{ matrix.board }}
+          name: firmware-${{ matrix.board }}-${{ matrix.target }}
           path: |
-            build-${{ matrix.board }}/update.fwbundle
             build-${{ matrix.board }}/**/.config
             build-${{ matrix.board }}/**/devicetree_generated.h
+            build-${{ matrix.board }}/**/devicetree_gene
+            build-${{ matrix.board }}/**/update.fwbundle
             build-${{ matrix.board }}/**/zephyr.bin
             build-${{ matrix.board }}/**/zephyr.dts
             build-${{ matrix.board }}/**/zephyr.elf

--- a/.github/workflows/prepare-zephyr/action.yml
+++ b/.github/workflows/prepare-zephyr/action.yml
@@ -17,16 +17,26 @@ runs:
         app-path: .
         toolchains: arm-zephyr-eabi:riscv64-zephyr-elf:x86_64-zephyr-elf:arc-zephyr-elf
 
-    - name: Set up Zephyr modules
+    - if: ${{ steps.cache-npm.outputs.cache-hit != 'true' }}
+      name: Set up Zephyr modules
       shell: bash
       run: |
         west config manifest.group-filter -- +optional
         west update
 
+    - name: Cache Zephyr modules
+      id: cache-zephyr-modules
+      uses: actions/cache@v4
+      with:
+        path: |
+          ../zephyr
+          ../modules
+          ../bootloader
+        key: ${{ hashFiles('west.yml') }}
+  
     - name: Install additional dependencies
       shell: bash
       run: |
-        # need to install protoc manually here, for some reason
         pip install protobuf grpcio-tools
 
     - name: Verify binary blobs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,30 +42,37 @@ jobs:
         with:
           name: firmware-p100
           path: assets/p100
+          pattern: firmare-p100-*
+          merge-multiple: true
 
       - name: Download firmware artifact (p100a)
         uses: actions/download-artifact@v4
         with:
           name: firmware-p100a
           path: assets/p100a
+          pattern: firmare-p100a-*
+          merge-multiple: true
 
       - name: Download firmware artifact (p150a)
         uses: actions/download-artifact@v4
         with:
           name: firmware-p150a
           path: assets/p150a
+          pattern: firmare-p150a-*
+          merge-multiple: true
 
       - name: Package firmware artifacts
         run: |
-          cp assets/p100/update.fwbundle p100.fwbundle
-          cp assets/p100a/update.fwbundle p100a.fwbundle
-          cp assets/p150a/update.fwbundle p150a.fwbundle
+          mkdir -p fw_pack
+          cat assets/p100/smc/update.fwbundle | tar xpzf - -C fw_pack
+          cat assets/p100a/smc/update.fwbundle | tar xpzf - -C fw_pack
+          cat assets/p150a/smc/update.fwbundle | tar xpzf - -C fw_pack
+          cd fw_pack
+          tar czf ../fw_pack-${{ steps.get_version.outputs.TRIMMED_VERSION }}.fwbundle .
+          cd ..
 
           cd assets
-          zip -r -9 ../tt-zephyr-platforms-${{ steps.get_version.outputs.VERSION }}.zip \
-            p100 \
-            p100a \
-            p150a
+          zip -r -9 ../tt-zephyr-platforms-assets-${{ steps.get_version.outputs.VERSION }}.zip .
 
       - name: Create empty release notes body
         run: |
@@ -79,8 +86,6 @@ jobs:
           draft: true
           prerelease: true
           files: |
-            p100.fwbundle
-            p100a.fwbundle
-            p150a.fwbundle
-            tt-zephyr-platforms-${{ steps.get_version.outputs.VERSION }}.zip
+            fw_pack-${{ steps.get_version.outputs.TRIMMED_VERSION }}.fwbundle
+            tt-zephyr-platforms-assets-${{ steps.get_version.outputs.VERSION }}.zip
             tt-zephyr-platforms-${{ steps.get_version.outputs.VERSION }}.spdx

--- a/app/bmc/prj.conf
+++ b/app/bmc/prj.conf
@@ -31,4 +31,3 @@ CONFIG_REBOOT=y
 
 # We always expect MCUBoot to be the primary bootloader
 CONFIG_BOOTLOADER_MCUBOOT=y
-CONFIG_MCUBOOT_SIGNATURE_KEY_FILE="bootloader/mcuboot/root-rsa-2048.pem"


### PR DESCRIPTION
Add a target component to the build matrix that supports both bmc and smc.

Combine firmware bundles for releases.