### PR TITLE
app: smc: pytest: rescan PCIE if pyluwen can't detect chip

### DIFF
--- a/app/smc/pytest/e2e-smoke.py
+++ b/app/smc/pytest/e2e-smoke.py
@@ -75,7 +75,12 @@ def arc_chip(unlaunched_dut: DeviceAdapter):
         )
     unlaunched_dut._flash_and_run()
     time.sleep(1)
-    chips = pyluwen.detect_chips()
+    try:
+        chips = pyluwen.detect_chips()
+    except Exception:
+        print("Warning- SMC firmware requires a reset. Rescanning PCIe bus")
+        rescan_pcie()
+        chips = pyluwen.detect_chips()
     if len(chips) == 0:
         raise RuntimeError("PCIe card was not detected on this system")
     chip = chips[0]


### PR DESCRIPTION
pyluwen now throws an exception during the detect_chip() call if a PCIE rescan is needed. Handle this exception by rescanning the PCIE bus