### PR TITLE
boards: correct twister ID to handle revisions correctly

### DIFF
--- a/.github/workflows/hardware-long.yml
+++ b/.github/workflows/hardware-long.yml
@@ -90,13 +90,13 @@ jobs:
           ./scripts/twister -i --retry-failed 3 \
             --retry-interval 5 \
             --tag e2e \
-            -p tt_blackhole/tt_blackhole/bmc --device-testing \
+            -p tt_blackhole@p100/tt_blackhole/bmc --device-testing \
             --hardware-map /opt/tenstorrent/twister/hw-map.yml --west-flash \
             -T ../tt-zephyr-platforms/app -ll DEBUG
           # Run E2E test to verify BMC and SMC firmware boot, and that
           # the SMC firmware sets up PCIe and ARC messages
           ./scripts/twister -i --retry-failed 3 \
-            -p tt_blackhole/tt_blackhole/smc --device-testing \
+            -p tt_blackhole@p100/tt_blackhole/smc --device-testing \
             --tag e2e \
             --hardware-map /opt/tenstorrent/twister/hw-map.yml --west-flash \
             -T ../tt-zephyr-platforms/app -ll DEBUG

--- a/.github/workflows/hardware-smoke.yml
+++ b/.github/workflows/hardware-smoke.yml
@@ -102,7 +102,7 @@ jobs:
 
           # Run tests tagged with "smoke"
           ./scripts/twister -i --retry-failed 3 \
-            -p tt_blackhole/tt_blackhole/bmc --device-testing \
+            -p tt_blackhole@p100/tt_blackhole/bmc --device-testing \
             --hardware-map /opt/tenstorrent/twister/hw-map.yml --west-flash \
             --tag smoke \
             --alt-config-root ../tt-zephyr-platforms/test-conf/samples \
@@ -138,7 +138,7 @@ jobs:
           ./scripts/twister -i --retry-failed 3 \
             --retry-interval 5 \
             --tag e2e \
-            -p tt_blackhole/tt_blackhole/bmc --device-testing \
+            -p tt_blackhole@p100/tt_blackhole/bmc --device-testing \
             --hardware-map /opt/tenstorrent/twister/hw-map.yml --west-flash \
             -T ../tt-zephyr-platforms/app -ll DEBUG \
             --outdir twister-bmc-e2e
@@ -149,7 +149,7 @@ jobs:
 
           # Run tests tagged with "smoke"
           ./scripts/twister -i --retry-failed 3 \
-            -p tt_blackhole/tt_blackhole/smc --device-testing \
+            -p tt_blackhole@p100/tt_blackhole/smc --device-testing \
             --hardware-map /opt/tenstorrent/twister/hw-map.yml --west-flash \
             --tag smoke \
             --alt-config-root ../tt-zephyr-platforms/test-conf/samples \
@@ -295,14 +295,14 @@ jobs:
           ./scripts/twister -i --retry-failed 3 \
             --retry-interval 5 \
             --tag e2e \
-            -p tt_blackhole/tt_blackhole/bmc --device-testing \
+            -p tt_blackhole@p100/tt_blackhole/bmc --device-testing \
             --hardware-map /opt/tenstorrent/twister/hw-map.yml --west-flash \
             -T ../tt-zephyr-platforms/app -ll DEBUG \
             --outdir twister-bmc-e2e
           # Run E2E test to verify BMC and SMC firmware boot, and that
           # the SMC firmware sets up PCIe and ARC messages
           ./scripts/twister -i --retry-failed 3 \
-            -p tt_blackhole/tt_blackhole/smc --device-testing \
+            -p tt_blackhole@p100/tt_blackhole/smc --device-testing \
             --tag e2e \
             --hardware-map /opt/tenstorrent/twister/hw-map.yml --west-flash \
             -T ../tt-zephyr-platforms/app -ll DEBUG \

--- a/app/bmc/sample.yaml
+++ b/app/bmc/sample.yaml
@@ -6,7 +6,9 @@ tests:
     extra_configs:
       - CONFIG_TT_FWUPDATE=n
     platform_allow:
-      - tt_blackhole/tt_blackhole/bmc
+      - tt_blackhole@p100/tt_blackhole/bmc
+      - tt_blackhole@p100a/tt_blackhole/bmc
+      - tt_blackhole@p150a/tt_blackhole/bmc
     tags: e2e
     harness: console
     harness_config:

--- a/app/smc/sample.yaml
+++ b/app/smc/sample.yaml
@@ -3,7 +3,9 @@ sample:
   name: bh-cmfw
 common:
   platform_allow:
-    - tt_blackhole/tt_blackhole/smc
+    - tt_blackhole@p100/tt_blackhole/smc
+    - tt_blackhole@p100a/tt_blackhole/smc
+    - tt_blackhole@p150a/tt_blackhole/smc
 tests:
   app.default: {}
   app.e2e-smoke:

--- a/boards/tenstorrent/tt_blackhole/tt_blackhole_tt_blackhole_bmc_p100.yaml
+++ b/boards/tenstorrent/tt_blackhole/tt_blackhole_tt_blackhole_bmc_p100.yaml
@@ -1,0 +1,20 @@
+identifier: tt_blackhole@p100/tt_blackhole/bmc
+name: Tenstorrent Blackhole P100 board (BMC)
+type: mcu
+arch: arm
+toolchain:
+  - zephyr
+  - gnuarmemb
+  - xtools
+sysbuild: true
+ram: 144
+flash: 512
+supported:
+  - gpio
+  - counter
+  - watchdog
+  - pwm
+  - adc
+  - i2c
+  - dma
+vendor: tenstorrent

--- a/boards/tenstorrent/tt_blackhole/tt_blackhole_tt_blackhole_bmc_p100a.yaml
+++ b/boards/tenstorrent/tt_blackhole/tt_blackhole_tt_blackhole_bmc_p100a.yaml
@@ -1,0 +1,20 @@
+identifier: tt_blackhole@p100a/tt_blackhole/bmc
+name: Tenstorrent Blackhole P100A board (BMC)
+type: mcu
+arch: arm
+toolchain:
+  - zephyr
+  - gnuarmemb
+  - xtools
+sysbuild: true
+ram: 144
+flash: 512
+supported:
+  - gpio
+  - counter
+  - watchdog
+  - pwm
+  - adc
+  - i2c
+  - dma
+vendor: tenstorrent

--- a/boards/tenstorrent/tt_blackhole/tt_blackhole_tt_blackhole_bmc_p150a.yaml
+++ b/boards/tenstorrent/tt_blackhole/tt_blackhole_tt_blackhole_bmc_p150a.yaml
@@ -1,5 +1,5 @@
-identifier: tt_blackhole/tt_blackhole/bmc
-name: Tenstorrent Blackhole board (BMC)
+identifier: tt_blackhole@p150a/tt_blackhole/bmc
+name: Tenstorrent Blackhole P150a board (BMC)
 type: mcu
 arch: arm
 toolchain:

--- a/boards/tenstorrent/tt_blackhole/tt_blackhole_tt_blackhole_smc_p100.yaml
+++ b/boards/tenstorrent/tt_blackhole/tt_blackhole_tt_blackhole_smc_p100.yaml
@@ -1,0 +1,19 @@
+# Copyright (c) 2024 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+identifier: tt_blackhole@p100/tt_blackhole/smc
+name: Tenstorrent Blackhole P100 board (SMC)
+type: mcu
+arch: arc
+toolchain:
+  - zephyr
+  - cross-compile
+  - xtools
+  - arcmwdt
+supported:
+  - smp
+testing:
+  ignore_tags:
+    - net
+    - bluetooth
+vendor: tenstorrent

--- a/boards/tenstorrent/tt_blackhole/tt_blackhole_tt_blackhole_smc_p100a.yaml
+++ b/boards/tenstorrent/tt_blackhole/tt_blackhole_tt_blackhole_smc_p100a.yaml
@@ -1,0 +1,19 @@
+# Copyright (c) 2024 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+identifier: tt_blackhole@p100a/tt_blackhole/smc
+name: Tenstorrent Blackhole P100a board (SMC)
+type: mcu
+arch: arc
+toolchain:
+  - zephyr
+  - cross-compile
+  - xtools
+  - arcmwdt
+supported:
+  - smp
+testing:
+  ignore_tags:
+    - net
+    - bluetooth
+vendor: tenstorrent

--- a/boards/tenstorrent/tt_blackhole/tt_blackhole_tt_blackhole_smc_p150a.yaml
+++ b/boards/tenstorrent/tt_blackhole/tt_blackhole_tt_blackhole_smc_p150a.yaml
@@ -1,8 +1,8 @@
 # Copyright (c) 2024 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
 
-identifier: tt_blackhole/tt_blackhole/smc
-name: Tenstorrent Blackhole board (SMC)
+identifier: tt_blackhole@p150a/tt_blackhole/smc
+name: Tenstorrent Blackhole P150a board (SMC)
 type: mcu
 arch: arc
 toolchain:

--- a/samples/boards/tt_blackhole/vuart/sample.yaml
+++ b/samples/boards/tt_blackhole/vuart/sample.yaml
@@ -3,7 +3,9 @@ sample:
   name: virtual pcie uart
 common:
   platform_allow:
-    - tt_blackhole/tt_blackhole/smc
+    - tt_blackhole@p100/tt_blackhole/smc
+    - tt_blackhole@p100a/tt_blackhole/smc
+    - tt_blackhole@p150a/tt_blackhole/smc
 tests:
   boards.tt_blackhole.vuart:
     build_only: true

--- a/test-conf/tests/boot/test_mcuboot/testcase.yaml
+++ b/test-conf/tests/boot/test_mcuboot/testcase.yaml
@@ -11,7 +11,9 @@ common:
 tests:
   bootloader.mcuboot.rtt:
     platform_allow:
-      - tt_blackhole/tt_blackhole/bmc
+      - tt_blackhole@p100/tt_blackhole/bmc
+      - tt_blackhole@p100a/tt_blackhole/bmc
+      - tt_blackhole@p150a/tt_blackhole/bmc
     tags:
       - rtt
     filter: CONFIG_HAS_SEGGER_RTT

--- a/test-conf/tests/drivers/flash/common/testcase.yaml
+++ b/test-conf/tests/drivers/flash/common/testcase.yaml
@@ -6,7 +6,9 @@ tests:
   drivers.flash.common.rtt:
     tags: smoke
     platform_allow:
-      - tt_blackhole/tt_blackhole/smc
+      - tt_blackhole@p100/tt_blackhole/smc
+      - tt_blackhole@p100a/tt_blackhole/smc
+      - tt_blackhole@p150a/tt_blackhole/smc
     extra_configs:
       - CONFIG_SEGGER_RTT_BUFFER_SIZE_UP=4096
     extra_args:
@@ -14,6 +16,18 @@ tests:
          ../../../../../tt-zephyr-platforms/test-conf/tests/drivers/flash/\
          common/tt_blackhole_tt_blackhole_smc.overlay"
       - "platform:tt_blackhole@p100/tt_blackhole/smc:EXTRA_CONF_FILE=\
+         ../../../../../tt-zephyr-platforms/test-conf/tests/drivers/flash/\
+         common/tt_blackhole_tt_blackhole_smc.conf"
+      - "platform:tt_blackhole@p100a/tt_blackhole/smc:DTC_OVERLAY_FILE=\
+         ../../../../../tt-zephyr-platforms/test-conf/tests/drivers/flash/\
+         common/tt_blackhole_tt_blackhole_smc.overlay"
+      - "platform:tt_blackhole@p100a/tt_blackhole/smc:EXTRA_CONF_FILE=\
+         ../../../../../tt-zephyr-platforms/test-conf/tests/drivers/flash/\
+         common/tt_blackhole_tt_blackhole_smc.conf"
+      - "platform:tt_blackhole@p150a/tt_blackhole/smc:DTC_OVERLAY_FILE=\
+         ../../../../../tt-zephyr-platforms/test-conf/tests/drivers/flash/\
+         common/tt_blackhole_tt_blackhole_smc.overlay"
+      - "platform:tt_blackhole@p150a/tt_blackhole/smc:EXTRA_CONF_FILE=\
          ../../../../../tt-zephyr-platforms/test-conf/tests/drivers/flash/\
          common/tt_blackhole_tt_blackhole_smc.conf"
     required_snippets:


### PR DESCRIPTION
Correct twister identifiers to handle revisions correctly.