### PR TITLE
ci: simplify prepare-zephyr reusable workflow

### DIFF
--- a/.github/workflows/prepare-zephyr/action.yml
+++ b/.github/workflows/prepare-zephyr/action.yml
@@ -11,23 +11,18 @@ runs:
       with:
         python-version: 3.11
 
+    # TODO: potentially improve caching strategy
+    # Note: this step performs "west init", "west update", and installs zephyr python dependencies
     - name: Set up Zephyr project
       uses: zephyrproject-rtos/action-zephyr-setup@v1
       with:
         app-path: .
         toolchains: arm-zephyr-eabi:riscv64-zephyr-elf:x86_64-zephyr-elf:arc-zephyr-elf
 
-    - name: Set up Zephyr modules
+    - name: Install additional python dependencies
       shell: bash
       run: |
-        west config manifest.group-filter -- +optional
-        west update
-
-    - name: Install additional dependencies
-      shell: bash
-      run: |
-        # need to install protoc manually here, for some reason
-        pip install protobuf grpcio-tools
+        pip install -r scripts/requirements.txt
 
     - name: Verify binary blobs
       shell: bash

--- a/README.md
+++ b/README.md
@@ -25,9 +25,6 @@ MODULE=tt-zephyr-platforms
 west init -m https://github.com/tenstorrent/tt-zephyr-platforms.git ~/$MODULE-work
 cd ~/$MODULE-work
 
-# Enable optional modules
-west config manifest.group-filter -- +optional
-
 # Fetch Zephyr modules
 west update
 

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,2 @@
+protobuf
+grpcio-tools

--- a/west.yml
+++ b/west.yml
@@ -18,3 +18,6 @@ manifest:
           - mcuboot
           - nanopb
           - segger
+
+  group-filter:
+    - +optional


### PR DESCRIPTION
* move manifest group filter to manifest file
* remove west update step, since it duplicates zephyr action
* move local python deps to scripts/requirements.txt