### PR TITLE
tenstorrent: qsfp_dd: enable active qsfp-dd on p150a

### DIFF
--- a/app/bmc/boards/tt_blackhole_tt_blackhole_bmc_p150a.conf
+++ b/app/bmc/boards/tt_blackhole_tt_blackhole_bmc_p150a.conf
@@ -1,0 +1,2 @@
+# enable active qsfp
+CONFIG_TT_QSFP_DD=y

--- a/app/dmc/src/main.c
+++ b/app/dmc/src/main.c
@@ -11,6 +11,7 @@
 #include <tenstorrent/bist.h>
 #include <tenstorrent/fan_ctrl.h>
 #include <tenstorrent/fwupdate.h>
+#include <tenstorrent/qsfp_dd.h>
 #include <zephyr/devicetree.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/i2c.h>
@@ -344,6 +345,14 @@ int main(void)
 
 	if (IS_ENABLED(CONFIG_TT_ASSEMBLY_TEST) && board_fault_led.port != NULL) {
 		gpio_pin_set_dt(&board_fault_led, 1);
+	}
+
+	if (IS_ENABLED(CONFIG_TT_QSFP_DD)) {
+		ret = enable_active_qsfp_dd();
+		if (ret != 0) {
+			LOG_ERR("%s() failed: %d", "enable_active_qsfp_dd", ret);
+			return ret;
+		}
 	}
 
 	/* No mechanism for getting bl version... yet */

--- a/boards/tenstorrent/tt_blackhole/tt_blackhole_dmc.dtsi
+++ b/boards/tenstorrent/tt_blackhole/tt_blackhole_dmc.dtsi
@@ -71,6 +71,12 @@
 		label = "Board ID 0 indicator";
 		gpios = <&gpioa 2 GPIO_ACTIVE_HIGH>;
 	};
+
+	mcu_conn_i2c_en {
+		compatible = "zephyr,gpio-line";
+		label = "I2C enable for QSFP-DD GPIO expander";
+		gpios = <&gpiod 2 GPIO_ACTIVE_HIGH>;
+	};
 };
 
 &clk_lsi {

--- a/include/tenstorrent/qsfp_dd.h
+++ b/include/tenstorrent/qsfp_dd.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2025 Tenstorrent AI ULC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define GPIO_XP_REG_INPUT_PORT 0x0 /* Read input values */
+#define GPIO_XP_REG_OUTPUT_PORT 0x1 /* Read/write output values */
+#define GPIO_XP_REG_POLARITY_INV 0x2
+#define GPIO_XP_REG_CONFIG 0x3 /* Configure GPIOs, output = 0 and input = 1 */
+
+/**
+ * @brief Set up GPIOs on GPIO expander to enable high power mode on QSFP module
+ *
+ * @retval 0 on success.
+ * @retval -EIO	if an I/O error occurs.
+ */
+int enable_active_qsfp_dd(void);

--- a/lib/tenstorrent/CMakeLists.txt
+++ b/lib/tenstorrent/CMakeLists.txt
@@ -10,4 +10,5 @@ add_subdirectory_ifdef(CONFIG_TT_EVENT event)
 add_subdirectory_ifdef(CONFIG_TT_FAN_CTRL fan_ctrl)
 add_subdirectory_ifdef(CONFIG_TT_FWUPDATE fwupdate)
 add_subdirectory_ifdef(CONFIG_TT_JTAG_BOOTROM jtag_bootrom)
+add_subdirectory_ifdef(CONFIG_TT_QSFP_DD qsfp_dd)
 # zephyr-keep-sorted-stop

--- a/lib/tenstorrent/Kconfig
+++ b/lib/tenstorrent/Kconfig
@@ -13,6 +13,7 @@ rsource "event/Kconfig"
 rsource "fan_ctrl/Kconfig"
 rsource "fwupdate/Kconfig"
 rsource "jtag_bootrom/Kconfig"
+rsource "qsfp_dd/Kconfig"
 # zephyr-keep-sorted-stop
 
 endmenu

--- a/lib/tenstorrent/qsfp_dd/CMakeLists.txt
+++ b/lib/tenstorrent/qsfp_dd/CMakeLists.txt
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_library()
+zephyr_library_sources(qsfp_dd.c)

--- a/lib/tenstorrent/qsfp_dd/Kconfig
+++ b/lib/tenstorrent/qsfp_dd/Kconfig
@@ -1,0 +1,11 @@
+# Copyright (c) 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+config TT_QSFP_DD
+	bool "Communicate with QSFP-DD module and GPIO expander"
+	help
+	  Communicate with QSFP-DD module and GPIO expander.
+
+module = TT_QSFP_DD
+module-str = TT QSFP DD
+source "subsys/logging/Kconfig.template.log_config"

--- a/lib/tenstorrent/qsfp_dd/qsfp_dd.c
+++ b/lib/tenstorrent/qsfp_dd/qsfp_dd.c
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2025 Tenstorrent AI ULC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <tenstorrent/qsfp_dd.h>
+
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/i2c.h>
+
+static const struct device *const i2c3 = DEVICE_DT_GET_OR_NULL(DT_NODELABEL(i2c3));
+static const struct gpio_dt_spec mcu_conn_i2c_en =
+	GPIO_DT_SPEC_GET_OR(DT_PATH(mcu_conn_i2c_en), gpios, {0});
+
+uint8_t gpio_xp_addrs[] = {0x38, 0x39, 0x3a, 0x3b};
+
+int gpio_xp_set_config(uint8_t addr, uint8_t val)
+{
+	uint8_t cmd_data[2] = {GPIO_XP_REG_CONFIG, val};
+
+	return i2c_write(i2c3, cmd_data, 2, addr);
+}
+
+int gpio_xp_set_output(uint8_t addr, uint8_t val)
+{
+	uint8_t cmd_data[2] = {GPIO_XP_REG_OUTPUT_PORT, val};
+
+	return i2c_write(i2c3, cmd_data, 2, addr);
+}
+
+int enable_active_qsfp_dd(void)
+{
+	int ret;
+
+	/* Enable communication with GPIO expander */
+	ret = gpio_pin_configure_dt(&mcu_conn_i2c_en, GPIO_OUTPUT_ACTIVE);
+	if (ret != 0) {
+		return ret;
+	}
+
+	for (int i = 0; i < ARRAY_SIZE(gpio_xp_addrs); i++) {
+		/* Configure RST (P1), MODSEL (P2), LPMODE (P3) as output */
+		ret = gpio_xp_set_config(gpio_xp_addrs[i], 0xf1);
+		if (ret != 0) {
+			return ret;
+		}
+		/* Set RST (P1) output to high */
+		ret = gpio_xp_set_output(gpio_xp_addrs[i], 0x2);
+		if (ret != 0) {
+			return ret;
+		}
+	}
+
+	/* Disable communication with GPIO expander */
+	ret = gpio_pin_configure_dt(&mcu_conn_i2c_en, GPIO_OUTPUT_INACTIVE);
+	if (ret != 0) {
+		return ret;
+	}
+
+	return ret;
+}


### PR DESCRIPTION
Add qsfp_dd library that enables I2C communication with GPIO expanders connected to several control and status pins on QSFP-DD modules.

Enable QSFP-DD high power mode on P150A.