### PR TITLE
scripts: requirements: add tt-flash to pip requirements

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,2 +1,6 @@
+# for spi flash tables
 protobuf
 grpcio-tools
+
+# tenstorrent utilities (note: pyluwen is a dependency)
+tt-flash @ git+https://github.com/tenstorrent/tt-flash


### PR DESCRIPTION
Dependencies can be installed via `pip install -r requirments.txt`.