### PR TITLE
tenstorrent: bh_arc: init boot_freq even when aiclk_ppm is disabled

### DIFF
--- a/lib/tenstorrent/bh_arc/aiclk_ppm.c
+++ b/lib/tenstorrent/bh_arc/aiclk_ppm.c
@@ -111,6 +111,12 @@ uint32_t GetMaxAiclkForVoltage(uint32_t voltage)
 	return low_freq - 1;
 }
 
+void InitArbMaxVoltage(void)
+{
+	/* ArbMaxVoltage is statically set to the frequency of the maximum voltage */
+	SetAiclkArbMax(kAiclkArbMaxVoltage, GetMaxAiclkForVoltage(voltage_arbiter.vdd_max));
+}
+
 void InitAiclkPPM(void)
 {
 	aiclk_ppm.boot_freq = GetAICLK();
@@ -128,9 +134,6 @@ void InitAiclkPPM(void)
 	for (int i = 0; i < kAiclkArbMaxCount; i++) {
 		aiclk_ppm.arbiter_max[i] = aiclk_ppm.fmax;
 	}
-
-	/* ArbMaxVoltage is statically set to the frequency of the maximum voltage */
-	SetAiclkArbMax(kAiclkArbMaxVoltage, GetMaxAiclkForVoltage(voltage_arbiter.vdd_max));
 
 	for (int i = 0; i < kAiclkArbMinCount; i++) {
 		aiclk_ppm.arbiter_min[i] = aiclk_ppm.fmin;

--- a/lib/tenstorrent/bh_arc/aiclk_ppm.h
+++ b/lib/tenstorrent/bh_arc/aiclk_ppm.h
@@ -43,6 +43,7 @@ void SetAiclkArbMin(AiclkArbMin arb_min, float freq);
 void CalculateTargAiclk(void);
 void DecreaseAiclk(void);
 void IncreaseAiclk(void);
+void InitArbMaxVoltage(void);
 void InitAiclkPPM(void);
 uint8_t ForceAiclk(uint32_t freq);
 

--- a/lib/tenstorrent/bh_arc/dvfs.c
+++ b/lib/tenstorrent/bh_arc/dvfs.c
@@ -44,7 +44,7 @@ void InitDVFS(void)
 {
 	InitVFCurve();
 	InitVoltagePPM();
-	InitAiclkPPM();
+	InitArbMaxVoltage();
 	InitThrottlers();
 	dvfs_enabled = true;
 }

--- a/lib/tenstorrent/bh_arc/init.c
+++ b/lib/tenstorrent/bh_arc/init.c
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include "aiclk_ppm.h"
 #include "avs.h"
 #include "cat.h"
 #include "dvfs.h"
@@ -353,6 +354,8 @@ static int InitHW(void)
 		/* Deassert RISC reset from reset_unit */
 		DeassertRiscvResets();
 		PLLInit();
+		/* Initialize some AICLK tracking variables */
+		InitAiclkPPM();
 	}
 
 	/* Initialize the serdes based on board type and asic location - data will be in fw_table */


### PR DESCRIPTION
This was causing an issue where unforcing the frequency with aiclk_ppm disabled caused CMFW to attempt setting an AICLK frequency of 0, which hangs the chip.