### PR TITLE
ina228: fix input current formatting

### DIFF
--- a/app/bmc/src/main.c
+++ b/app/bmc/src/main.c
@@ -124,8 +124,9 @@ void ina228_current_update(void)
 
 	sensor_sample_fetch_chan(ina228, SENSOR_CHAN_CURRENT);
 	sensor_channel_get(ina228, SENSOR_CHAN_CURRENT, &current_sensor_val);
-	uint32_t current = (current_sensor_val.val1 << 16) |
-			   ((current_sensor_val.val2 / 100) & 0xFFFF); /* Truncate */
+
+	int32_t current =
+		(current_sensor_val.val1 << 16) + (current_sensor_val.val2 * 65536ULL) / 1000000ULL;
 
 	ARRAY_FOR_EACH_PTR(BH_CHIPS, chip) {
 		bh_chip_set_input_current(chip, &current);

--- a/include/tenstorrent/bh_chip.h
+++ b/include/tenstorrent/bh_chip.h
@@ -117,7 +117,7 @@ void bh_chip_cancel_bus_transfer_clear(struct bh_chip *chip);
 
 cm2bmMessageRet bh_chip_get_cm2bm_message(struct bh_chip *chip);
 int bh_chip_set_static_info(struct bh_chip *chip, bmStaticInfo *info);
-int bh_chip_set_input_current(struct bh_chip *chip, uint32_t *current);
+int bh_chip_set_input_current(struct bh_chip *chip, int32_t *current);
 int bh_chip_set_fan_rpm(struct bh_chip *chip, uint16_t rpm);
 int bh_chip_set_board_pwr_lim(struct bh_chip *chip, uint16_t max_pwr);
 

--- a/lib/tenstorrent/bh_arc/cm2bm_msg.c
+++ b/lib/tenstorrent/bh_arc/cm2bm_msg.c
@@ -28,7 +28,7 @@ typedef struct {
 
 static Cm2BmMsgState cm2bm_msg_state;
 static bool bmfw_ping_valid;
-static uint32_t current;
+static int32_t current;
 K_MSGQ_DEFINE(cm2bm_msg_q, sizeof(Cm2BmMsg), 4, _Alignof(Cm2BmMsg));
 
 int32_t EnqueueCm2BmMsg(const Cm2BmMsg *msg)
@@ -228,13 +228,13 @@ int32_t Bm2CmSendCurrentHandler(const uint8_t *data, uint8_t size)
 		return -1;
 	}
 
-	current = *(uint32_t *)data;
+	current = *(int32_t *)data;
 
 	return 0;
 }
 
 /* TODO: Put these somewhere else? */
-uint32_t GetInputCurrent(void)
+int32_t GetInputCurrent(void)
 {
 	return current;
 }

--- a/lib/tenstorrent/bh_arc/cm2bm_msg.h
+++ b/lib/tenstorrent/bh_arc/cm2bm_msg.h
@@ -51,7 +51,7 @@ typedef struct bmStaticInfo {
 int32_t Bm2CmSendDataHandler(const uint8_t *data, uint8_t size);
 int32_t Bm2CmPingHandler(const uint8_t *data, uint8_t size);
 int32_t Bm2CmSendCurrentHandler(const uint8_t *data, uint8_t size);
-uint32_t GetInputCurrent(void);
+int32_t GetInputCurrent(void);
 int32_t Bm2CmSendFanRPMHandler(const uint8_t *data, uint8_t size);
 
 #endif

--- a/lib/tenstorrent/bh_arc/telemetry.c
+++ b/lib/tenstorrent/bh_arc/telemetry.c
@@ -67,6 +67,16 @@ uint32_t ConvertFloatToTelemetry(float value)
 	return ret_value;
 }
 
+float ConvertTelemetryToFloat(int32_t value)
+{
+	/* Convert signed int 16.16 format to float */
+	if (value == INT32_MIN) {
+		return FLT_MAX;
+	} else {
+		return value / 65536.0;
+	}
+}
+
 static void UpdateGddrTelemetry(void)
 {
 	/* We pack multiple metrics into one field, so need to clear first. */

--- a/lib/tenstorrent/bh_arc/telemetry.h
+++ b/lib/tenstorrent/bh_arc/telemetry.h
@@ -145,6 +145,7 @@ typedef enum {
 
 void init_telemetry(uint32_t app_version);
 uint32_t ConvertFloatToTelemetry(float value);
+float ConvertTelemetryToFloat(int32_t value);
 void StartTelemetryTimer(void);
 void UpdateBmFwVersion(uint32_t bl_version, uint32_t app_version);
 void UpdateTelemetryNocTranslation(bool translation_enabled);

--- a/lib/tenstorrent/bh_arc/throttler.c
+++ b/lib/tenstorrent/bh_arc/throttler.c
@@ -10,6 +10,7 @@
 #include "cm2bm_msg.h"
 #include "fw_table.h"
 #include "telemetry_internal.h"
+#include "telemetry.h"
 
 #define kThrottlerAiclkScaleFactor 500.0F
 #define DEFAULT_BOARD_PWR_LIMIT 150
@@ -173,7 +174,7 @@ void CalculateThrottlers(void)
 	UpdateThrottler(kThrottlerFastTDC, telemetry_internal_data.vcore_current);
 	UpdateThrottler(kThrottlerTDC, telemetry_internal_data.vcore_current);
 	UpdateThrottler(kThrottlerThm, telemetry_internal_data.asic_temperature);
-	UpdateThrottler(kThrottlerBoardPwr, 12 * GetInputCurrent());
+	UpdateThrottler(kThrottlerBoardPwr, 12 * ConvertTelemetryToFloat(GetInputCurrent()));
 
 	for (ThrottlerId i = 0; i < kThrottlerCount; i++) {
 		UpdateThrottlerArb(i);

--- a/lib/tenstorrent/bh_chip/bh_chip.c
+++ b/lib/tenstorrent/bh_chip/bh_chip.c
@@ -63,7 +63,7 @@ int bh_chip_set_static_info(struct bh_chip *chip, bmStaticInfo *info)
 	return ret;
 }
 
-int bh_chip_set_input_current(struct bh_chip *chip, uint32_t *current)
+int bh_chip_set_input_current(struct bh_chip *chip, int32_t *current)
 {
 	int ret;
 


### PR DESCRIPTION
Send input current data from BMC to SMC in signed int 16.16 format. Provide input current as a float to the board power throttler.