### PR TITLE
boards: fw_table: update soft harvesting according to product specs

### DIFF
--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/GALAXY/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/GALAXY/fw_table.txt
@@ -63,3 +63,9 @@ eth_property_table {
   eth_disable_mask: 0
   eth_disable_mask_en: false
 }
+
+product_spec_harvesting {
+  dram_disable_count: 0
+  eth_disabled: false
+  tensix_col_disable_count: 1
+}

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P100/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P100/fw_table.txt
@@ -64,3 +64,9 @@ eth_property_table {
   eth_disable_mask: 0x3fff
   eth_disable_mask_en: true
 }
+
+product_spec_harvesting {
+  dram_disable_count: 0
+  eth_disabled: false
+  tensix_col_disable_count: 0
+}

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P100A/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P100A/fw_table.txt
@@ -64,3 +64,9 @@ eth_property_table {
   eth_disable_mask: 0x3fff
   eth_disable_mask_en: true
 }
+
+product_spec_harvesting {
+  dram_disable_count: 1
+  eth_disabled: true
+  tensix_col_disable_count: 2
+}

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P150/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P150/fw_table.txt
@@ -64,3 +64,9 @@ eth_property_table {
   eth_disable_mask: 0
   eth_disable_mask_en: false
 }
+
+product_spec_harvesting {
+  dram_disable_count: 0
+  eth_disabled: false
+  tensix_col_disable_count: 0
+}

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P150A/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P150A/fw_table.txt
@@ -64,3 +64,9 @@ eth_property_table {
   eth_disable_mask: 0
   eth_disable_mask_en: false
 }
+
+product_spec_harvesting {
+  dram_disable_count: 0
+  eth_disabled: false
+  tensix_col_disable_count: 0
+}

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P150C/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P150C/fw_table.txt
@@ -64,3 +64,9 @@ eth_property_table {
   eth_disable_mask: 0
   eth_disable_mask_en: false
 }
+
+product_spec_harvesting {
+  dram_disable_count: 0
+  eth_disabled: false
+  tensix_col_disable_count: 0
+}

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300A_L/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300A_L/fw_table.txt
@@ -64,3 +64,9 @@ eth_property_table {
   eth_disable_mask: 0x0243
   eth_disable_mask_en: true
 }
+
+product_spec_harvesting {
+  dram_disable_count: 0
+  eth_disabled: false
+  tensix_col_disable_count: 2
+}

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300A_R/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300A_R/fw_table.txt
@@ -64,3 +64,9 @@ eth_property_table {
   eth_disable_mask: 0x3480
   eth_disable_mask_en: true
 }
+
+product_spec_harvesting {
+  dram_disable_count: 0
+  eth_disabled: false
+  tensix_col_disable_count: 2
+}

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300C_L/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300C_L/fw_table.txt
@@ -64,3 +64,9 @@ eth_property_table {
   eth_disable_mask: 0x0243
   eth_disable_mask_en: true
 }
+
+product_spec_harvesting {
+  dram_disable_count: 0
+  eth_disabled: false
+  tensix_col_disable_count: 2
+}

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300C_R/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300C_R/fw_table.txt
@@ -64,3 +64,9 @@ eth_property_table {
   eth_disable_mask: 0x3480
   eth_disable_mask_en: true
 }
+
+product_spec_harvesting {
+  dram_disable_count: 0
+  eth_disabled: false
+  tensix_col_disable_count: 2
+}

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300_L/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300_L/fw_table.txt
@@ -64,3 +64,9 @@ eth_property_table {
   eth_disable_mask: 0x0243
   eth_disable_mask_en: true
 }
+
+product_spec_harvesting {
+  dram_disable_count: 0
+  eth_disabled: false
+  tensix_col_disable_count: 2
+}

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300_R/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300_R/fw_table.txt
@@ -64,3 +64,9 @@ eth_property_table {
   eth_disable_mask: 0x3480
   eth_disable_mask_en: true
 }
+
+product_spec_harvesting {
+  dram_disable_count: 0
+  eth_disabled: false
+  tensix_col_disable_count: 2
+}


### PR DESCRIPTION
This makes sure that all boards of the same type look the same, despite different harvesting configurations.

Note that this setting doesn't actually have any effect until feature_enable.harvesting_en is enabled in the fw_tables.