### PR TITLE
bh_arc: Check GDDR telemetry table version

### DIFF
--- a/lib/tenstorrent/bh_arc/gddr.h
+++ b/lib/tenstorrent/bh_arc/gddr.h
@@ -28,7 +28,7 @@
 #define MRISC_INIT_STARTED  0x0
 #define MRISC_INIT_TIMEOUT  1000 /* In ms */
 
-void read_gddr_telemetry_table(uint8_t gddr_inst, gddr_telemetry_table_t *gddr_telemetry);
+int read_gddr_telemetry_table(uint8_t gddr_inst, gddr_telemetry_table_t *gddr_telemetry);
 void SetAxiEnable(uint8_t gddr_inst, uint8_t noc2axi_port, bool axi_enable);
 int LoadMriscFw(uint8_t gddr_inst, uint8_t *fw_image, uint32_t fw_size);
 int LoadMriscFwCfg(uint8_t gddr_inst, uint8_t *fw_cfg_image, uint32_t fw_cfg_size);


### PR DESCRIPTION
This change will check the GDDR telemetry table version and ensure it matches the gddr_telemetry_table.h version. If not, it will log warning message and keep all the GDDR telemetry fields as 0. 
Justification is in case we ever have a mismatch in MRISC and SMC FWs, we don't want to make assumptions that may no longer hold.