### PR TITLE
ci: make `prepare-zephyr` workflow reusable across jobs

### DIFF
--- a/.github/workflows/build-fw.yml
+++ b/.github/workflows/build-fw.yml
@@ -25,7 +25,11 @@ jobs:
           - p150a
     steps:
       - uses: actions/checkout@v4
-      - uses: ./.github/workflows/prepare-zephyr
+        with:
+          path: tt-zephyr-platforms
+      - uses: ./tt-zephyr-platforms/.github/workflows/prepare-zephyr
+        with:
+          app-path: tt-zephyr-platforms
 
       - name: Generate BOARD
         shell: bash
@@ -61,7 +65,7 @@ jobs:
             --sysbuild \
             -p \
             -b $BOARD \
-            app/smc \
+            tt-zephyr-platforms/app/smc \
             -- \
               -DCONFIG_COMPILER_WARNINGS_AS_ERRORS=y \
               -DCONFIG_MCUBOOT_SIGNATURE_KEY_FILE=\"\$SIGNATURE_KEY_FILE\"
@@ -87,7 +91,11 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-      - uses: ./.github/workflows/prepare-zephyr
+        with:
+          path: tt-zephyr-platforms
+      - uses: ./tt-zephyr-platforms/.github/workflows/prepare-zephyr
+        with:
+          app-path: tt-zephyr-platforms
 
       - name: Build recovery firmware
         shell: bash
@@ -96,7 +104,7 @@ jobs:
             -d build-recovery \
             -p auto \
             -b tt_blackhole/tt_blackhole/smc \
-            app/smc \
+            tt-zephyr-platforms/app/smc \
             -- \
               -DEXTRA_CONF_FILE=recovery.conf \
               -DCONFIG_COMPILER_WARNINGS_AS_ERRORS=y

--- a/.github/workflows/hardware-smoke.yml
+++ b/.github/workflows/hardware-smoke.yml
@@ -22,76 +22,21 @@ jobs:
             runs-on:
               - yyz-zephyr-lab-p100a
     runs-on: ${{ matrix.config.runs-on }}
-    env:
-      "ZEPHYR_SDK_INSTALL_DIR": /opt/toolchains
     container:
       image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.27.4.20241026
       volumes:
         - /dev/hugepages-1G:/dev/hugepages-1G
-        - /opt/SEGGER:/opt/SEGGER
         - /opt/tenstorrent/fw/stable:/opt/tenstorrent/fw/stable
         - /opt/tenstorrent/twister:/opt/tenstorrent/twister
         - /opt/tenstorrent/bin/openocd-rtt:/opt/tenstorrent/bin/openocd-rtt
-      options: '--device /dev/tenstorrent --device /dev/bus/usb'
+      options: '--device /dev/tenstorrent --device /dev/bus/usb --privileged'
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          # FIXME: would be nice to either use the default here or a built-in github environment
-          # variable, since shouldn't need to be specific to the tt-zephyr-platforms module.
           path: tt-zephyr-platforms
-          fetch-depth: 0
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - uses: ./tt-zephyr-platforms/.github/workflows/prepare-zephyr
         with:
-          python-version: 3.11
-
-      - name: Rebase onto the target branch
-        env:
-          BASE_REF: ${{ github.base_ref }}
-        run: |
-          cd tt-zephyr-platforms
-          git config --global user.email "you@example.com"
-          git config --global user.name "Your Name"
-          git remote -v
-          # Update the remote ref
-          git fetch origin
-          # Ensure there's no merge commits in the PR
-          if [ $(git rev-list --merges --count origin/${BASE_REF}..) -ne 0 ]; then
-            echo "::error ::Merge commits not allowed, rebase instead"
-            exit 1
-          fi
-          rm -fr ".git/rebase-apply"
-          rm -fr ".git/rebase-merge"
-          git rebase origin/${BASE_REF}
-          git clean -f -d
-          # debug
-          git log  --pretty=oneline | head -n 10
-
-      - name: Install west
-        run: |
-          pip install west
-
-      - name: west setup
-        # FIXME: would be ideal to use a built-in github environment variable
-        # instead of tt-zephyr-platforms
-        run: |
-          west init -l tt-zephyr-platforms
-
-      - name: Setup Zephyr modules
-        run: |
-          west config manifest.group-filter -- +optional
-          west update
-
-          # need to install protoc manually here, for some reason
-          pip install -r zephyr/scripts/requirements.txt
-          pip install protobuf grpcio-tools
-
-      - name: Apply patches
-        run: |
-          west -v patch apply
+          app-path: tt-zephyr-platforms
 
       - name: Generate board names
         shell: bash
@@ -114,13 +59,6 @@ jobs:
       - name: run-bmc-tests
         working-directory: zephyr
         run: |
-          # This needs to be added to the github runner
-          export PATH=$PATH:/opt/SEGGER/JLink/
-
-          # The '-q' argument to west (which '--device-serial-pty rtt' depends on) was only added to west
-          # as of v1.3.0, v1.2.0 does not have it, so we need to update west here.
-          pip install west -U &>/dev/null
-
           # Run tests tagged with "smoke"
           ./scripts/twister -i --retry-failed 3 \
             -p $BMC_BOARD --device-testing \
@@ -158,10 +96,6 @@ jobs:
             -T ../tt-zephyr-platforms/app -ll DEBUG \
             --outdir twister-bmc-e2e
 
-          # The '-q' argument to west (which '--device-serial-pty rtt' depends on) was only added to west
-          # as of v1.3.0, v1.2.0 does not have it, so we need to update west here.
-          pip install west -U &>/dev/null
-
           # Run tests tagged with "smoke"
           ./scripts/twister -i --retry-failed 3 \
             -p $SMC_BOARD --device-testing \
@@ -186,15 +120,6 @@ jobs:
             zephyr/twister-smc-smoke/twister.log
             zephyr/twister-smc-smoke/twister.json
 
-      - name: cleanup
-        if: ${{ always() }}
-        run: |
-          # Clean up patched Zephyr repo
-          west patch clean
-          # Cleanup the checked out repo, we can leave everything else
-          rm -rf tt-zephyr-platforms
-          rm -rf .west
-
   smoke-e2e-test:
     if: github.repository_owner == 'tenstorrent'
     strategy:
@@ -213,47 +138,17 @@ jobs:
       image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.27.4.20241026
       volumes:
         - /dev/hugepages-1G:/dev/hugepages-1G
-        - /opt/SEGGER:/opt/SEGGER
         - /opt/tenstorrent/fw/stable:/opt/tenstorrent/fw/stable
         - /opt/tenstorrent/twister:/opt/tenstorrent/twister
         - /opt/tenstorrent/bin/openocd-rtt:/opt/tenstorrent/bin/openocd-rtt
       options: '--device /dev/tenstorrent --device /dev/bus/usb --privileged'
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          # FIXME: would be nice to either use the default here or a built-in github environment
-          # variable, since shouldn't need to be specific to the tt-zephyr-platforms module.
           path: tt-zephyr-platforms
-          fetch-depth: 0
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - uses: ./tt-zephyr-platforms/.github/workflows/prepare-zephyr
         with:
-          python-version: 3.11
-
-      - name: Rebase onto the target branch
-        env:
-          BASE_REF: ${{ github.base_ref }}
-        run: |
-          cd tt-zephyr-platforms
-          git config --global user.email "you@example.com"
-          git config --global user.name "Your Name"
-          git remote -v
-          # Update the remote ref
-          git fetch origin
-          # Ensure there's no merge commits in the PR
-          if [ $(git rev-list --merges --count origin/${BASE_REF}..) -ne 0 ]; then
-            echo "::error ::Merge commits not allowed, rebase instead"
-            exit 1
-          fi
-          rm -fr ".git/rebase-apply"
-          rm -fr ".git/rebase-merge"
-          git rebase origin/${BASE_REF}
-          git clean -f -d
-          # debug
-          git log  --pretty=oneline | head -n 10
+          app-path: tt-zephyr-platforms
 
       - name: Generate board names
         shell: bash
@@ -273,63 +168,9 @@ jobs:
           echo "SMC_BOARD=$SMC_BOARD" >> "$GITHUB_ENV"
           echo "BMC_BOARD=$BMC_BOARD" >> "$GITHUB_ENV"
 
-      - name: Install west
-        run: |
-          pip install west
-
-      - name: west setup
-        # FIXME: would be ideal to use a built-in github environment variable
-        # instead of tt-zephyr-platforms
-        run: |
-          west init -l tt-zephyr-platforms
-
-      - name: Setup Zephyr modules
-        run: |
-          west config manifest.group-filter -- +optional
-          west update
-
-          # need to install protoc manually here, for some reason
-          pip install -r zephyr/scripts/requirements.txt
-          pip install protobuf grpcio-tools
-
-      - name: Apply patches
-        run: |
-          west -v patch apply
-
-      - name: Checkout pyluwen
-        uses: actions/checkout@v4
-        with:
-          repository: tenstorrent/luwen
-          path: luwen
-
-      - name: Build pyluwen
-        run: |
-          # Setup cargo, since we run with a different $HOME
-          HOME=/root . /root/.cargo/env
-          # Install maturin for build (we already have cargo)
-          pip install maturin
-          cd luwen/crates/pyluwen
-          maturin build --release
-          pip install ../../target/wheels/*
-
-      - name: Checkout tt-flash
-        uses: actions/checkout@v4
-        with:
-          repository: tenstorrent/tt-flash
-          path: tt-flash
-
-      - name: Install tt-flash
-        run: |
-          # Setup cargo, since we run with a different $HOME
-          HOME=/root . /root/.cargo/env
-          pip install ./tt-flash
-
       - name: run-e2e-tests
         working-directory: zephyr
         run: |
-          # This needs to be added to the github runner
-          export PATH=$PATH:/opt/SEGGER/JLink/
-
           # TODO: ideally we would use one twister command to build and
           # flash BMC and SMC firmware, but since each chip uses a separate
           # debug adapter this doesn't work. For now, just flash BMC
@@ -384,14 +225,3 @@ jobs:
           name: E2E Flash results (${{ matrix.config.board }})
           path: |
             zephyr/twister-e2e-flash/**/update.fwbundle
-
-      - name: cleanup
-        if: ${{ always() }}
-        run: |
-          # Clean up patched Zephyr repo
-          west patch clean
-          # Cleanup pyluwen build
-          rm -rf luwen
-          # Cleanup the checked out repo, we can leave everything else
-          rm -rf tt-zephyr-platforms
-          rm -rf .west

--- a/.github/workflows/prepare-zephyr/action.yml
+++ b/.github/workflows/prepare-zephyr/action.yml
@@ -1,7 +1,13 @@
 name: Zephyr Environment Setup (Composite)
 description: |
   This workflow prepares the Zephyr environment for building, testing, or other tasks. It is
-  intended to be used as a reusable (composite) step in other workflows.
+  intended to be used as a reusable (composite) step in other workflows, and must
+  be run within a container that includes the Zephyr SDK installation.
+
+inputs:
+  app-path:
+    description: 'Path to the Zephyr application to build'
+    required: true
 
 runs:
   using: composite
@@ -9,20 +15,59 @@ runs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: 3.11
+        python-version: '3.10'
+
+    - name: Install west
+      shell: bash
+      run: |
+        pip install west
+
+    - name: Install curl
+      shell: bash
+      run: |
+        if ! command -v curl &> /dev/null ; then
+          apt-get update
+          apt-get install -y curl
+        fi
+
+    - name: Install Rust
+      uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        rustflags: '-A warnings'
+
+    # This step is required because stateful runners (e.g. self-hosted runners) may have
+    # a stale copy of the repos in the manifest. This step ensures that all state
+    # repos are cleaned out before the manifest is cloned.
+    - name: Remove existing data
+      shell: bash
+      run: |
+        if [ -d ".west" ]; then
+          echo "Cleaning out old west manifest directories"
+          for dir in $(west list -f "{path"}); do
+            if [ $dir != ${{ inputs.app-path }} ]; then
+              echo "Removing $dir"
+              rm -rf $dir
+            fi
+          done
+          rm -rf ".west"
+        fi
+        if [ -d "zephyr-sdk" ]; then
+          echo "Cleaning out old zephyr-sdk directory"
+          rm -rf zephyr-sdk
+        fi
 
     # TODO: potentially improve caching strategy
     # Note: this step performs "west init", "west update", and installs zephyr python dependencies
     - name: Set up Zephyr project
       uses: zephyrproject-rtos/action-zephyr-setup@v1
       with:
-        app-path: .
+        app-path: ${{ inputs.app-path }}
         toolchains: arm-zephyr-eabi:riscv64-zephyr-elf:x86_64-zephyr-elf:arc-zephyr-elf
 
     - name: Install additional python dependencies
       shell: bash
       run: |
-        pip install -r scripts/requirements.txt
+        pip install -r ${{ inputs.app-path }}/scripts/requirements.txt
 
     - name: Verify binary blobs
       shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,11 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-      - uses: ./.github/workflows/prepare-zephyr
+        with:
+          path: tt-zephyr-platforms
+      - uses: ./tt-zephyr-platforms/.github/workflows/prepare-zephyr
+        with:
+          app-path: tt-zephyr-platforms
 
       - name: Get the version
         id: get_version

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -13,13 +13,17 @@ jobs:
   unit-test:
     env:
       platforms: -p unit_testing -p native_sim
-      roots: -T tests -T samples
+      roots: -T tt-zephyr-platforms/tests -T tt-zephyr-platforms/samples
     strategy:
       fail-fast: false
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-      - uses: ./.github/workflows/prepare-zephyr
+        with:
+          path: tt-zephyr-platforms
+      - uses: ./tt-zephyr-platforms/.github/workflows/prepare-zephyr
+        with:
+          app-path: tt-zephyr-platforms
 
       - id: build
         shell: bash
@@ -52,14 +56,18 @@ jobs:
     env:
       platforms: -p native_sim/native/64
       tags: --tag tt_sim
-      configroots: --alt-config-root test-conf
-      roots: -T ../zephyr
+      configroots: --alt-config-root tt-zephyr-platforms/test-conf
+      roots: -T zephyr
     strategy:
       fail-fast: false
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-      - uses: ./.github/workflows/prepare-zephyr
+        with:
+          path: tt-zephyr-platforms
+      - uses: ./tt-zephyr-platforms/.github/workflows/prepare-zephyr
+        with:
+          app-path: tt-zephyr-platforms
 
       - name: build and run
         shell: bash


### PR DESCRIPTION
Make the `prepare-zephyr` workflow reusable across jobs, and use it wherever possible within CI