### PR TITLE
fw_table: enable aiclk_ppm and ddr_train flags

### DIFF
--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/GALAXY/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/GALAXY/fw_table.txt
@@ -18,7 +18,7 @@ chip_limits {
 feature_enable {
   cg_en: true
   noc_translation_en: false
-  ddr_train_en: false
+  ddr_train_en: true
   aiclk_ppm_en: false
   watchdog_en: false
   smbus_en: false

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/ORION/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/ORION/fw_table.txt
@@ -19,7 +19,7 @@ chip_limits {
 feature_enable {
   cg_en: true
   noc_translation_en: false
-  ddr_train_en: false
+  ddr_train_en: true
   aiclk_ppm_en: false
   watchdog_en: false
   smbus_en: false

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P100/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P100/fw_table.txt
@@ -19,8 +19,8 @@ chip_limits {
 feature_enable {
   cg_en: true
   noc_translation_en: false
-  ddr_train_en: false
-  aiclk_ppm_en: false
+  ddr_train_en: true
+  aiclk_ppm_en: true
   watchdog_en: false
   smbus_en: false
 }

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P100A/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P100A/fw_table.txt
@@ -19,8 +19,8 @@ chip_limits {
 feature_enable {
   cg_en: true
   noc_translation_en: false
-  ddr_train_en: false
-  aiclk_ppm_en: false
+  ddr_train_en: true
+  aiclk_ppm_en: true
   watchdog_en: false
   smbus_en: false
 }

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P150/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P150/fw_table.txt
@@ -19,8 +19,8 @@ chip_limits {
 feature_enable {
   cg_en: true
   noc_translation_en: false
-  ddr_train_en: false
-  aiclk_ppm_en: false
+  ddr_train_en: true
+  aiclk_ppm_en: true
   watchdog_en: false
   smbus_en: false
 }

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P150A/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P150A/fw_table.txt
@@ -19,8 +19,8 @@ chip_limits {
 feature_enable {
   cg_en: true
   noc_translation_en: false
-  ddr_train_en: false
-  aiclk_ppm_en: false
+  ddr_train_en: true
+  aiclk_ppm_en: true
   watchdog_en: false
   smbus_en: false
 }

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P150C/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P150C/fw_table.txt
@@ -19,8 +19,8 @@ chip_limits {
 feature_enable {
   cg_en: true
   noc_translation_en: false
-  ddr_train_en: false
-  aiclk_ppm_en: false
+  ddr_train_en: true
+  aiclk_ppm_en: true
   watchdog_en: false
   smbus_en: false
 }

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300A_L/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300A_L/fw_table.txt
@@ -19,7 +19,7 @@ chip_limits {
 feature_enable {
   cg_en: true
   noc_translation_en: false
-  ddr_train_en: false
+  ddr_train_en: true
   aiclk_ppm_en: false
   watchdog_en: false
   smbus_en: false

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300A_R/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300A_R/fw_table.txt
@@ -19,7 +19,7 @@ chip_limits {
 feature_enable {
   cg_en: true
   noc_translation_en: false
-  ddr_train_en: false
+  ddr_train_en: true
   aiclk_ppm_en: false
   watchdog_en: false
   smbus_en: false

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300C_L/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300C_L/fw_table.txt
@@ -19,7 +19,7 @@ chip_limits {
 feature_enable {
   cg_en: true
   noc_translation_en: false
-  ddr_train_en: false
+  ddr_train_en: true
   aiclk_ppm_en: false
   watchdog_en: false
   smbus_en: false

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300C_R/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300C_R/fw_table.txt
@@ -19,7 +19,7 @@ chip_limits {
 feature_enable {
   cg_en: true
   noc_translation_en: false
-  ddr_train_en: false
+  ddr_train_en: true
   aiclk_ppm_en: false
   watchdog_en: false
   smbus_en: false

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300_L/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300_L/fw_table.txt
@@ -19,7 +19,7 @@ chip_limits {
 feature_enable {
   cg_en: true
   noc_translation_en: false
-  ddr_train_en: false
+  ddr_train_en: true
   aiclk_ppm_en: false
   watchdog_en: false
   smbus_en: false

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300_R/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300_R/fw_table.txt
@@ -19,7 +19,7 @@ chip_limits {
 feature_enable {
   cg_en: true
   noc_translation_en: false
-  ddr_train_en: false
+  ddr_train_en: true
   aiclk_ppm_en: false
   watchdog_en: false
   smbus_en: false


### PR DESCRIPTION
aiclk_ppm is enabled for all p100 and p150.
ddr_train is enabled for all boards, although the flag is currently ignored by FW.

These are the settings that were updated in the internal repo and not reflected here.