### PR TITLE
bh_arc: do not enable aiclk_ppm if regulator init fails

### DIFF
--- a/lib/tenstorrent/bh_arc/status_reg.h
+++ b/lib/tenstorrent/bh_arc/status_reg.h
@@ -47,4 +47,14 @@ typedef union {
 	uint32_t val;
 	STATUS_BOOT_STATUS0_reg_t f;
 } STATUS_BOOT_STATUS0_reg_u;
+
+typedef struct {
+	uint32_t regulator_init_error: 1;
+} STATUS_ERROR_STATUS0_reg_t;
+
+typedef union {
+	uint32_t val;
+	STATUS_ERROR_STATUS0_reg_t f;
+} STATUS_ERROR_STATUS0_reg_u;
+
 #endif


### PR DESCRIPTION
It is potentially unsafe to enable aiclk_ppm if the regulator init fails. Report this scenario via LOG_ERR and into a status register.

This needs #49 to be merged first.