### PR TITLE
ci: use fork of zephyr-setup action

### DIFF
--- a/.github/workflows/hardware-smoke.yml
+++ b/.github/workflows/hardware-smoke.yml
@@ -43,6 +43,7 @@ jobs:
       - uses: ./tt-zephyr-platforms/.github/workflows/prepare-zephyr
         with:
           app-path: tt-zephyr-platforms
+          skip-dependencies: true
 
       - name: Generate board names
         shell: bash
@@ -156,6 +157,7 @@ jobs:
       - uses: ./tt-zephyr-platforms/.github/workflows/prepare-zephyr
         with:
           app-path: tt-zephyr-platforms
+          skip-dependencies: true
 
       - name: Generate board names
         shell: bash

--- a/.github/workflows/prepare-zephyr/action.yml
+++ b/.github/workflows/prepare-zephyr/action.yml
@@ -8,6 +8,10 @@ inputs:
   app-path:
     description: 'Path to the Zephyr application to build'
     required: true
+  skip-dependencies:
+    description: 'Skip installing Zephyr dependencies'
+    required: false
+    default: false
 
 runs:
   using: composite
@@ -64,6 +68,7 @@ runs:
       with:
         app-path: ${{ inputs.app-path }}
         toolchains: arm-zephyr-eabi:riscv64-zephyr-elf:x86_64-zephyr-elf:arc-zephyr-elf
+        skip-dependencies: ${{ inputs.skip-dependencies }}
 
     - name: Install additional python dependencies
       shell: bash

--- a/.github/workflows/prepare-zephyr/action.yml
+++ b/.github/workflows/prepare-zephyr/action.yml
@@ -58,8 +58,9 @@ runs:
 
     # TODO: potentially improve caching strategy
     # Note: this step performs "west init", "west update", and installs zephyr python dependencies
+    # Todo- once this feature branch is merged, we should use the mainline Zephyr action
     - name: Set up Zephyr project
-      uses: zephyrproject-rtos/action-zephyr-setup@v1
+      uses: danieldegrasse/action-zephyr-setup@feature/skip-dependencies
       with:
         app-path: ${{ inputs.app-path }}
         toolchains: arm-zephyr-eabi:riscv64-zephyr-elf:x86_64-zephyr-elf:arc-zephyr-elf


### PR DESCRIPTION
Use a fork of the Zephyr setup action, with the ability to skip dependencies