### PR TITLE
ci: ensure workflows run after push to main

### DIFF
--- a/.github/workflows/build-fw.yml
+++ b/.github/workflows/build-fw.yml
@@ -5,6 +5,10 @@ on:
     secrets:
       SIGNATURE_KEY:
         required: true
+  push:
+    branches:
+      - main
+      - v*-branch
   pull_request:
     types:
       - opened
@@ -12,6 +16,7 @@ on:
       - synchronize
     branches:
       - main
+      - v*-branch
 
 jobs:
   build:

--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -7,11 +7,11 @@ jobs:
     runs-on: ubuntu-22.04
     name: Build tt-console
     steps:
-    - name: Checkout the code
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-    - name: Run the script
-      run: |
-        gcc -Iinclude -O0 -g -Wall -Wextra -Werror -std=gnu11 -o tt-console \
-          scripts/tt-console/console.c
+      - name: Checkout the code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Run the script
+        run: |
+          gcc -Iinclude -O0 -g -Wall -Wextra -Werror -std=gnu11 -o tt-console \
+            scripts/tt-console/console.c

--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -1,6 +1,18 @@
 name: Build tt-native
 
-on: [pull_request]
+on:
+  push:
+    branches:
+      - main
+      - v*-branch
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+    branches:
+      - main
+      - v*-branch
 
 jobs:
   build-tt-console:

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -10,6 +10,7 @@ on:
       - edited
     branches:
       - main
+      - v*-branch
 
 jobs:
   check_compliance:

--- a/.github/workflows/copyright-check.yml
+++ b/.github/workflows/copyright-check.yml
@@ -1,6 +1,10 @@
 name: Copyright Check
 
 on:
+  push:
+    branches:
+      - main
+      - v*-branch
   pull_request:
     types:
       - opened
@@ -8,6 +12,7 @@ on:
       - synchronize
     branches:
       - main
+      - v*-branch
 
 jobs:
   copyright_check_job:

--- a/.github/workflows/hardware-long.yml
+++ b/.github/workflows/hardware-long.yml
@@ -9,6 +9,7 @@ jobs:
   hardware-metal-test:
     if: github.repository_owner == 'tenstorrent'
     strategy:
+      fail-fast: false
       matrix:
         config:
           - board: p100

--- a/.github/workflows/hardware-smoke.yml
+++ b/.github/workflows/hardware-smoke.yml
@@ -1,6 +1,10 @@
 name: Hardware Smoke Tests
 
 on:
+  push:
+    branches:
+      - main
+      - v*-branch
   pull_request:
     types:
       - opened
@@ -8,6 +12,7 @@ on:
       - synchronize
     branches:
       - main
+      - v*-branch
 
 jobs:
   hardware-smoke-test:

--- a/.github/workflows/hardware-smoke.yml
+++ b/.github/workflows/hardware-smoke.yml
@@ -13,6 +13,7 @@ jobs:
   hardware-smoke-test:
     if: github.repository_owner == 'tenstorrent'
     strategy:
+      fail-fast: false
       matrix:
         config:
           - board: p100
@@ -123,6 +124,7 @@ jobs:
   smoke-e2e-test:
     if: github.repository_owner == 'tenstorrent'
     strategy:
+      fail-fast: false
       matrix:
         config:
           - board: p100

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -1,6 +1,10 @@
 name: Scancode
 
 on:
+  push:
+    branches:
+      - main
+      - v*-branch
   pull_request:
     types:
       - opened
@@ -8,6 +12,7 @@ on:
       - synchronize
     branches:
       - main
+      - v*-branch
 
 jobs:
   scancode_job:

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -1,6 +1,10 @@
 name: Run Unit Tests
 
 on:
+  push:
+    branches:
+      - main
+      - v*-branch
   pull_request:
     types:
       - opened
@@ -8,6 +12,7 @@ on:
       - synchronize
     branches:
       - main
+      - v*-branch
 
 jobs:
   unit-test:


### PR DESCRIPTION
We ideally would prefer to see runner history on `main` instead of just on PR history. This will allow us to more easily determine the last successful CI run, and thus help narrow-down PRs that cause regressions, without having to do a full git bisect.

Additionally, run checks whenever PRs (backported bugfixes) have been made or merged to version branches.

Additionally, disable fast-failing for hardware tests so that we can see which platforms pass or fail tests independently. Without this, if one platform fails tests, the job is cancelled for all platforms.