### PR TITLE
bh_arc: Implement voltage and margin frequency

### DIFF
--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/GALAXY/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/GALAXY/fw_table.txt
@@ -5,7 +5,7 @@ chip_limits {
   asic_fmax: 1000
   vdd_max: 0
   vdd_min: 0
-  voltage_margin: 0
+  voltage_margin: 50
   tdp_limit: 0
   tdc_limit: 0
   thm_limit: 0

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/ORION/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/ORION/fw_table.txt
@@ -6,7 +6,7 @@ chip_limits {
   asic_fmin: 800
   vdd_max: 0
   vdd_min: 0
-  voltage_margin: 0
+  voltage_margin: 50
   tdp_limit: 150
   tdc_limit: 200
   thm_limit: 90

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P100/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P100/fw_table.txt
@@ -6,7 +6,7 @@ chip_limits {
   asic_fmin: 800
   vdd_max: 0
   vdd_min: 0
-  voltage_margin: 0
+  voltage_margin: 50
   tdp_limit: 150
   tdc_limit: 200
   thm_limit: 90

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P100A/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P100A/fw_table.txt
@@ -6,7 +6,7 @@ chip_limits {
   asic_fmin: 800
   vdd_max: 0
   vdd_min: 0
-  voltage_margin: 0
+  voltage_margin: 50
   tdp_limit: 150
   tdc_limit: 200
   thm_limit: 90

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P150/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P150/fw_table.txt
@@ -6,7 +6,7 @@ chip_limits {
   asic_fmin: 800
   vdd_max: 0
   vdd_min: 0
-  voltage_margin: 0
+  voltage_margin: 50
   tdp_limit: 150
   tdc_limit: 200
   thm_limit: 90

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P150A/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P150A/fw_table.txt
@@ -6,7 +6,7 @@ chip_limits {
   asic_fmin: 800
   vdd_max: 0
   vdd_min: 0
-  voltage_margin: 0
+  voltage_margin: 50
   tdp_limit: 150
   tdc_limit: 200
   thm_limit: 90

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P150C/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P150C/fw_table.txt
@@ -6,7 +6,7 @@ chip_limits {
   asic_fmin: 800
   vdd_max: 0
   vdd_min: 0
-  voltage_margin: 0
+  voltage_margin: 50
   tdp_limit: 150
   tdc_limit: 200
   thm_limit: 90

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300A_L/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300A_L/fw_table.txt
@@ -6,7 +6,7 @@ chip_limits {
   asic_fmin: 800
   vdd_max: 0
   vdd_min: 0
-  voltage_margin: 0
+  voltage_margin: 50
   tdp_limit: 150
   tdc_limit: 200
   thm_limit: 90

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300A_R/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300A_R/fw_table.txt
@@ -6,7 +6,7 @@ chip_limits {
   asic_fmin: 800
   vdd_max: 0
   vdd_min: 0
-  voltage_margin: 0
+  voltage_margin: 50
   tdp_limit: 150
   tdc_limit: 200
   thm_limit: 90

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300C_L/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300C_L/fw_table.txt
@@ -6,7 +6,7 @@ chip_limits {
   asic_fmin: 800
   vdd_max: 0
   vdd_min: 0
-  voltage_margin: 0
+  voltage_margin: 50
   tdp_limit: 150
   tdc_limit: 200
   thm_limit: 90

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300C_R/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300C_R/fw_table.txt
@@ -6,7 +6,7 @@ chip_limits {
   asic_fmin: 800
   vdd_max: 0
   vdd_min: 0
-  voltage_margin: 0
+  voltage_margin: 50
   tdp_limit: 150
   tdc_limit: 200
   thm_limit: 90

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300_L/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300_L/fw_table.txt
@@ -6,7 +6,7 @@ chip_limits {
   asic_fmin: 800
   vdd_max: 0
   vdd_min: 0
-  voltage_margin: 0
+  voltage_margin: 50
   tdp_limit: 150
   tdc_limit: 200
   thm_limit: 90

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300_R/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300_R/fw_table.txt
@@ -6,7 +6,7 @@ chip_limits {
   asic_fmin: 800
   vdd_max: 0
   vdd_min: 0
-  voltage_margin: 0
+  voltage_margin: 50
   tdp_limit: 150
   tdc_limit: 200
   thm_limit: 90

--- a/lib/tenstorrent/bh_arc/spirom_protobufs/fw_table.proto
+++ b/lib/tenstorrent/bh_arc/spirom_protobufs/fw_table.proto
@@ -23,14 +23,14 @@ message FwTable {
     uint32 asic_fmax = 1;
     uint32 vdd_max = 2;
     uint32 vdd_min = 3;
-    uint32 voltage_margin = 4;
+    int32 voltage_margin = 4;
     uint32 tdp_limit = 5;
     uint32 tdc_limit = 6;
     uint32 thm_limit = 7;
     uint32 tdc_fast_limit = 8;
     uint32 therm_trip_l1_limit = 9;
     uint32 bus_peak_limit = 10;
-    uint32 frequency_margin = 11;
+    int32 frequency_margin = 11;
     uint32 asic_fmin = 12;
   }
 

--- a/lib/tenstorrent/bh_arc/vf_curve.c
+++ b/lib/tenstorrent/bh_arc/vf_curve.c
@@ -6,10 +6,23 @@
 
 #include <zephyr/sys/util.h>
 #include "vf_curve.h"
+#include "fw_table.h"
+
+/* Bounds checks for frequency and voltage margin */
+#define FREQ_MARGIN_MAX    300.0F
+#define FREQ_MARGIN_MIN    -300.0F
+#define VOLTAGE_MARGIN_MAX 150.0F
+#define VOLTAGE_MARGIN_MIN -150.0F
+
+static float freq_margin_mhz;
+static float voltage_margin_mv;
 
 void InitVFCurve(void)
 {
-	/* Do nothing for now */
+	freq_margin_mhz = CLAMP(get_fw_table()->chip_limits.frequency_margin, FREQ_MARGIN_MIN,
+				FREQ_MARGIN_MAX);
+	voltage_margin_mv = CLAMP(get_fw_table()->chip_limits.voltage_margin, VOLTAGE_MARGIN_MIN,
+				  VOLTAGE_MARGIN_MAX);
 }
 
 /**
@@ -20,7 +33,9 @@ void InitVFCurve(void)
  */
 float VFCurve(float freq_mhz)
 {
-	float voltage_mv = 0.00031395F * freq_mhz * freq_mhz - 0.43953F * freq_mhz + 828.83F;
+	float freq_with_margin_mhz = freq_mhz + freq_margin_mhz;
+	float voltage_mv = 0.00031395F * freq_with_margin_mhz * freq_with_margin_mhz -
+			   0.43953F * freq_with_margin_mhz + 828.83F;
 
-	return voltage_mv + 50.0F; /* Add 50 mV of margin */
+	return voltage_mv + voltage_margin_mv;
 }


### PR DESCRIPTION
This updates voltage frequency curve to use voltage and frequency margins from firmware table.
Sets placeholder voltage margin as 50mV for each board type