### PR TITLE
lib: tenstorrent: add I2C timeouts on all operations, and fix DVFS library issue with VUART

### DIFF
--- a/lib/tenstorrent/bh_arc/dvfs.c
+++ b/lib/tenstorrent/bh_arc/dvfs.c
@@ -51,5 +51,5 @@ void InitDVFS(void)
 
 void StartDVFSTimer(void)
 {
-	k_timer_start(&dvfs_timer, K_MSEC(1), K_MSEC(1));
+	k_timer_start(&dvfs_timer, K_MSEC(10), K_MSEC(10));
 }


### PR DESCRIPTION
This PR fixes two issues blocking CI:
- Add bus timeouts to *all* I2C operations that can hang, and recover the I2C bus when they do. This is admittedly a bit of voodoo- all I can say is without this change I saw the CMFW hanging during I2C transactions during init, and with it I don't. Solves issues like those seen here: https://github.com/tenstorrent/tt-zephyr-platforms/actions/runs/14138868875/job/39616640036
- Increase the scheduling deadline for DVFS polling to 10ms. This was done because it appears that DVFS polling itself takes over 1 ms, so rescheduling it this frequently was causing VUART to fail.