### PR TITLE
dvfs: restore 1 ms period

### DIFF
--- a/lib/tenstorrent/bh_arc/dvfs.c
+++ b/lib/tenstorrent/bh_arc/dvfs.c
@@ -51,5 +51,5 @@ void InitDVFS(void)
 
 void StartDVFSTimer(void)
 {
-	k_timer_start(&dvfs_timer, K_MSEC(10), K_MSEC(10));
+	k_timer_start(&dvfs_timer, K_MSEC(1), K_MSEC(1));
 }


### PR DESCRIPTION
The 1 ms period should no longer starve CPU time, due to the reduction in TS polling time in #54.