### PR TITLE
readme: hard-code branch to main for status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,11 @@ west blobs fetch
 # Apply local patches
 west patch apply
 
-# Go to the main Zephyr directory
-cd zephyr
-source zephyr-env.sh
+# Set up Zephyr environment
+source zephyr/zephyr-env.sh
+
+# Enter the module
+cd $MODULE.git
 ```
 
 ### Build, Flash, Debug & Test BMC FW
@@ -48,7 +50,7 @@ BOARD=tt_blackhole/tt_blackhole/bmc
 BOARD_SANITIZED=tt_blackhole_tt_blackhole_bmc
 
 # Build BMC firmware
-west build --sysbuild -p -S rtt-console -b $BOARD ../$MODULE.git/app/bmc
+west build --sysbuild -p -S rtt-console -b $BOARD app/bmc
 
 # Flash mcuboot and the app
 west flash
@@ -109,7 +111,7 @@ The file `fw.hex` is a concatenation of the mcuboot `zephyr.bin` and the `app/sm
 BOARD=tt_blackhole/tt_blackhole/smc
 
 # Build SMC firmware
-west build -p -S rtt-console -b $BOARD ../$MODULE.git/app/smc
+west build -p -S rtt-console -b $BOARD app/smc
 
 # Flash mcuboot and the app
 west flash

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # TT-ZEPHYR-PLATFORMS
 
-[![Build](https://github.com/tenstorrent/tt-zephyr-platforms/actions/workflows/build-fw.yml/badge.svg)](https://github.com/tenstorrent/tt-zephyr-platforms/actions/workflows/build-fw.yml)
-[![Unit Tests](https://github.com/tenstorrent/tt-zephyr-platforms/actions/workflows/run-unit-tests.yml/badge.svg)](https://github.com/tenstorrent/tt-zephyr-platforms/actions/workflows/run-unit-tests.yml)
-[![HW Smoke](https://github.com/tenstorrent/tt-zephyr-platforms/actions/workflows/hardware-smoke.yml/badge.svg)](https://github.com/tenstorrent/tt-zephyr-platforms/actions/workflows/hardware-smoke.yml)
-[![HW Soak](https://github.com/tenstorrent/tt-zephyr-platforms/actions/workflows/hardware-long.yml/badge.svg)](https://github.com/tenstorrent/tt-zephyr-platforms/actions/workflows/hardware-long.yml)
+[![Build](https://github.com/tenstorrent/tt-zephyr-platforms/actions/workflows/build-fw.yml/badge.svg?branch=main)](https://github.com/tenstorrent/tt-zephyr-platforms/actions/workflows/build-fw.yml)
+[![Run Unit Tests](https://github.com/tenstorrent/tt-zephyr-platforms/actions/workflows/run-unit-tests.yml/badge.svg?branch=main)](https://github.com/tenstorrent/tt-zephyr-platforms/actions/workflows/run-unit-tests.yml)
+[![HW Smoke](https://github.com/tenstorrent/tt-zephyr-platforms/actions/workflows/hardware-smoke.yml/badge.svg?branch=main)](https://github.com/tenstorrent/tt-zephyr-platforms/actions/workflows/hardware-smoke.yml)
+[![HW Soak](https://github.com/tenstorrent/tt-zephyr-platforms/actions/workflows/hardware-long.yml/badge.svg?branch=main)](https://github.com/tenstorrent/tt-zephyr-platforms/actions/workflows/hardware-long.yml)
 
 Welcome to TT-Zephyr-Platforms!
 


### PR DESCRIPTION
Hard-code branch to main for status badges.

Previously, the "default" was used which is to show the most recent status from any branch for a given action, which is not what we're interested in.