### PR TITLE
boards: pad bmfw to nearest 2048 byte boundary

### DIFF
--- a/boards/tenstorrent/tt_blackhole/bootfs/p100-bootfs.yaml
+++ b/boards/tenstorrent/tt_blackhole/bootfs/p100-bootfs.yaml
@@ -41,6 +41,7 @@ images:
 
   # Board Mgmt FW
   - name: bmfw
+    padto: 0xb000
     binary: $BUILD_DIR/bmc/zephyr/zephyr.signed.bin
 
   # Meta data about the flashing process

--- a/boards/tenstorrent/tt_blackhole/bootfs/p100a-bootfs.yaml
+++ b/boards/tenstorrent/tt_blackhole/bootfs/p100a-bootfs.yaml
@@ -41,6 +41,7 @@ images:
 
   # Board Mgmt FW
   - name: bmfw
+    padto: 0xb000
     binary: $BUILD_DIR/bmc/zephyr/zephyr.signed.bin
 
   # Meta data about the flashing process

--- a/boards/tenstorrent/tt_blackhole/bootfs/p150a-bootfs.yaml
+++ b/boards/tenstorrent/tt_blackhole/bootfs/p150a-bootfs.yaml
@@ -41,6 +41,7 @@ images:
 
   # Board Mgmt FW
   - name: bmfw
+    padto: 0xb000
     binary: $BUILD_DIR/bmc/zephyr/zephyr.signed.bin
 
   # Meta data about the flashing process

--- a/scripts/tt_boot_fs.py
+++ b/scripts/tt_boot_fs.py
@@ -290,6 +290,7 @@ class BootImage:
                 raise ValueError(
                     f"{tag} padto value {padto} is < the binary size {len(binary)}"
                 )
+            binary += bytes(padto - len(binary))
         # We always need to pad binaries to 4 byte offsets for checksum verification
         binary += bytes((len(binary) % 8))
 


### PR DESCRIPTION
Due to a bug in the update code for BMFW 0.3.1, the erase size is determined by the size of the image rounded to the nearest write size boundary. On the STM32 based BMC, the write size != the erase size, so erases will fail based on this rounding (and updates will not work)

To work around this, pad the BMFW image to a 2048 byte boundary in the tt_boot_fs. This will enable updates to work, at the cost of a bit more flash space used