### PR TITLE
Add GDDR HW Memory test

### DIFF
--- a/app/smc/pytest/e2e_smoke.py
+++ b/app/smc/pytest/e2e_smoke.py
@@ -16,6 +16,7 @@ logger = logging.getLogger(__name__)
 
 # Constant memory addresses we can read from SMC
 ARC_STATUS = 0x80030060
+BOOT_STATUS = 0x80030408
 
 # ARC messages
 ARC_MSG_TYPE_TEST = 0x90
@@ -123,3 +124,13 @@ def test_bmc_msg(arc_chip):
     assert response[0] == 1, "BMC did not respond to ping from SMC"
     assert response[1] == 0, "SMC response invalid"
     logger.info('BMC ping message response "%d"', response[0])
+
+
+def test_boot_status(arc_chip):
+    """
+    Validates the boot status of the ARC firmware
+    """
+    # Read the boot status register and validate that it is correct
+    status = arc_chip.axi_read32(BOOT_STATUS)
+    assert (status >> 1) & 0x3 == 0x2, "SMC HW boot status is not valid"
+    logger.info('SMC boot status "%d"', status)

--- a/lib/tenstorrent/bh_arc/gddr.c
+++ b/lib/tenstorrent/bh_arc/gddr.c
@@ -14,6 +14,7 @@
 #include "harvesting.h"
 
 #include <zephyr/logging/log.h>
+#include <zephyr/kernel.h>
 
 /* This is the noc2axi instance we want to run the MRISC FW on */
 #define MRISC_FW_NOC2AXI_PORT 0
@@ -40,6 +41,15 @@ uint32_t MriscL1Read32(uint8_t gddr_inst, uint32_t addr)
 	GetGddrNocCoords(gddr_inst, MRISC_FW_NOC2AXI_PORT, 0, &x, &y);
 	NOC2AXITlbSetup(0, MRISC_SETUP_TLB, x, y, MRISC_L1_ADDR);
 	return NOC2AXIRead32(0, MRISC_SETUP_TLB, MRISC_L1_ADDR + addr);
+}
+
+void MriscL1Write32(uint8_t gddr_inst, uint32_t addr, uint32_t val)
+{
+	uint8_t x, y;
+
+	GetGddrNocCoords(gddr_inst, MRISC_FW_NOC2AXI_PORT, 0, &x, &y);
+	NOC2AXITlbSetup(0, MRISC_SETUP_TLB, x, y, MRISC_L1_ADDR);
+	NOC2AXIWrite32(0, MRISC_SETUP_TLB, MRISC_L1_ADDR + addr, val);
 }
 
 uint32_t MriscRegRead32(uint8_t gddr_inst, uint32_t addr)
@@ -144,4 +154,69 @@ uint32_t GetDramMask(void)
 		dram_mask &= get_fw_table()->dram_table.dram_mask;
 	}
 	return dram_mask;
+}
+
+int StartHwMemtest(uint8_t gddr_inst, uint32_t addr_bits, uint32_t start_addr, uint32_t mask)
+{
+	uint32_t msg_args[3] = {addr_bits, start_addr, mask};
+
+	/* Only run if MRISC FW support it. Must be > 2.6 */
+	gddr_telemetry_table_t gddr_telemetry;
+
+	if (read_gddr_telemetry_table(gddr_inst, &gddr_telemetry) < 0) {
+		LOG_WRN("Failed to read GDDR telemetry table while starting memtest");
+		return -ENOTSUP;
+	}
+	if (gddr_telemetry.mrisc_fw_version_major < 2 ||
+	    (gddr_telemetry.mrisc_fw_version_major == 2 &&
+	     gddr_telemetry.mrisc_fw_version_minor < 7)) {
+		LOG_WRN("GDDR %d MRISC FW version %d.%d does not support memtest.\n", gddr_inst,
+			gddr_telemetry.mrisc_fw_version_major,
+			gddr_telemetry.mrisc_fw_version_minor);
+		return -ENOTSUP;
+	}
+
+	/*
+	 * Messaging should not be done concurrently to the same GDDR instance, but still do sanity
+	 * check if the message buffer is free.
+	 */
+	uint32_t status = MriscRegRead32(gddr_inst, MRISC_MSG_REGISTER);
+
+	if (status != MRISC_MSG_TYPE_NONE) {
+		LOG_WRN("GDDR %d message buffer is not free. Current value: 0x%x\n", gddr_inst,
+			status);
+		return -EBUSY;
+	}
+	if (addr_bits > 26) {
+		LOG_WRN("Invalid number of address bits for memory test. Expected <= 26, got %d\n",
+			addr_bits);
+		return -EINVAL;
+	}
+	for (int i = 0; i < 3; i++) {
+		MriscL1Write32(gddr_inst, GDDR_MSG_STRUCT_ADDR + i * 4, msg_args[i]);
+	}
+	MriscRegWrite32(gddr_inst, MRISC_MSG_REGISTER, MRISC_MSG_TYPE_RUN_MEMTEST);
+	return 0;
+}
+
+int CheckHwMemtestResult(uint8_t gddr_inst, k_timepoint_t timeout)
+{
+	/* This should only be called after StartHwMemtest() has already been called. */
+	while (MriscRegRead32(gddr_inst, MRISC_MSG_REGISTER) != 0) {
+		/* Wait for the message to be processed */
+		if (sys_timepoint_expired(timeout)) {
+			LOG_ERR("Timeout after %d ms waiting for GDDR instance %d to run "
+				"memtest.\n",
+				MRISC_MEMTEST_TIMEOUT, gddr_inst);
+			return -ETIMEDOUT;
+		}
+	}
+	uint32_t pass = MriscL1Read32(gddr_inst, GDDR_MSG_STRUCT_ADDR + 8 * 4);
+
+	if (pass != 0) {
+		LOG_ERR("GDDR %d memory test failed.\n", gddr_inst);
+		return -EIO;
+	}
+	LOG_DBG("GDDR %d memory test passed.\n", gddr_inst);
+	return 0;
 }

--- a/lib/tenstorrent/bh_arc/gddr.h
+++ b/lib/tenstorrent/bh_arc/gddr.h
@@ -8,6 +8,8 @@
 
 #include "gddr_telemetry_table.h"
 
+#include <zephyr/sys_clock.h>
+
 #define MIN_GDDR_SPEED             12000
 #define MAX_GDDR_SPEED             20000
 #define GDDR_SPEED_TO_MEMCLK_RATIO 16
@@ -15,18 +17,25 @@
 
 /* MRISC FW telemetry base addr */
 #define GDDR_TELEMETRY_TABLE_ADDR 0x8000
+#define GDDR_MSG_STRUCT_ADDR      0x6000
 
 #define RISC_CTRL_A_SCRATCH_0__REG_ADDR 0xFFB14010
 #define RISC_CTRL_A_SCRATCH_1__REG_ADDR 0xFFB14014
+#define RISC_CTRL_A_SCRATCH_2__REG_ADDR 0xFFB14018
 #define MRISC_INIT_STATUS               RISC_CTRL_A_SCRATCH_0__REG_ADDR
 #define MRISC_POST_CODE                 RISC_CTRL_A_SCRATCH_1__REG_ADDR
+#define MRISC_MSG_REGISTER              RISC_CTRL_A_SCRATCH_2__REG_ADDR
 
+#define MRISC_INIT_FINISHED   0xdeadbeef
+#define MRISC_INIT_FAILED     0xfa11
+#define MRISC_INIT_BEFORE     0x11111111
+#define MRISC_INIT_STARTED    0x0
+#define MRISC_INIT_TIMEOUT    1000 /* In ms */
+#define MRISC_MEMTEST_TIMEOUT 1000 /* In ms */
 
-#define MRISC_INIT_FINISHED 0xdeadbeef
-#define MRISC_INIT_FAILED   0xfa11
-#define MRISC_INIT_BEFORE   0x11111111
-#define MRISC_INIT_STARTED  0x0
-#define MRISC_INIT_TIMEOUT  1000 /* In ms */
+/* Defined by MRISC FW */
+#define MRISC_MSG_TYPE_NONE        0
+#define MRISC_MSG_TYPE_RUN_MEMTEST 8
 
 int read_gddr_telemetry_table(uint8_t gddr_inst, gddr_telemetry_table_t *gddr_telemetry);
 void SetAxiEnable(uint8_t gddr_inst, uint8_t noc2axi_port, bool axi_enable);
@@ -42,5 +51,7 @@ static inline uint32_t GetGddrSpeedFromCfg(uint8_t *fw_cfg_image)
 uint32_t MriscRegRead32(uint8_t gddr_inst, uint32_t addr);
 void MriscRegWrite32(uint8_t gddr_inst, uint32_t addr, uint32_t val);
 uint32_t GetDramMask(void);
+int CheckHwMemtestResult(uint8_t gddr_inst, k_timepoint_t timeout);
+int StartHwMemtest(uint8_t gddr_inst, uint32_t addr_bits, uint32_t start_addr, uint32_t mask);
 
 #endif


### PR DESCRIPTION
- CI: Adds check in e2e test that hw_init status is "done" at the end
- GDDR: Adds triggering HW memory test core via MRISC FW at end of init. Will only run if MRISC FW supports this. Version >= 2.7 (not yet released). 