### PR TITLE
hotfix: revert commits causing CI failures

### DIFF
--- a/lib/tenstorrent/bh_arc/dw_apb_i2c.c
+++ b/lib/tenstorrent/bh_arc/dw_apb_i2c.c
@@ -85,7 +85,6 @@
 /* IC abort source */
 /* starting from bit21, bit20-0 is reserved. */
 #define IC_ABRT_A3_STATE (0x1 << 21)
-#define IC_VERIFY_FAIL (0x1 << 22)
 
 #define GET_I2C_OFFSET(REG_NAME) DW_APB_I2C_##REG_NAME##_REG_OFFSET
 
@@ -547,47 +546,6 @@ uint32_t I2CReadBytes(uint32_t id, uint16_t command, uint32_t command_byte_size,
 		FlipBytes(p_read_buf, data_byte_size);
 	}
 	return ic_error;
-}
-
-/**
- * @brief I2C Read-Modify-Write-Verify
- */
-uint32_t I2CRMWV(uint32_t id, uint16_t command, uint32_t command_byte_size, const uint8_t *p_data,
-		 const uint8_t *p_mask, uint32_t data_byte_size)
-{
-	uint32_t ic_error;
-	uint8_t buffer[data_byte_size];
-
-	/* Read */
-	ic_error = I2CReadBytes(id, command, command_byte_size, buffer, data_byte_size, 0);
-	if (ic_error) {
-		return ic_error;
-	}
-
-	/* Modify */
-	for (uint32_t i = 0; i < data_byte_size; i++) {
-		buffer[i] = (buffer[i] & ~p_mask[i]) | (p_data[i] & p_mask[i]);
-	}
-
-	/* Write */
-	ic_error = I2CWriteBytes(id, command, command_byte_size, buffer, data_byte_size);
-	if (ic_error) {
-		return ic_error;
-	}
-
-	/* Verify */
-	ic_error = I2CReadBytes(id, command, command_byte_size, buffer, data_byte_size, 0);
-	if (ic_error) {
-		return ic_error;
-	}
-
-	for (uint32_t i = 0; i < data_byte_size; i++) {
-		if ((buffer[i] & p_mask[i]) != (p_data[i] & p_mask[i])) {
-			return IC_VERIFY_FAIL;
-		}
-	}
-
-	return 0;
 }
 
 void SetI2CSlaveCallbacks(uint32_t id, const struct i2c_target_callbacks *cb)

--- a/lib/tenstorrent/bh_arc/dw_apb_i2c.h
+++ b/lib/tenstorrent/bh_arc/dw_apb_i2c.h
@@ -33,8 +33,6 @@ uint32_t I2CWriteBytes(uint32_t id, uint16_t command, uint32_t command_byte_size
 		       const uint8_t *p_write_buf, uint32_t data_byte_size);
 uint32_t I2CReadBytes(uint32_t id, uint16_t command, uint32_t command_byte_size,
 		      uint8_t *p_read_buf, uint32_t data_byte_size, uint8_t flip_bytes);
-uint32_t I2CRMWV(uint32_t id, uint16_t command, uint32_t command_byte_size, const uint8_t *p_data,
-			const uint8_t *p_mask, uint32_t data_byte_size);
 void SetI2CSlaveCallbacks(uint32_t id, const struct i2c_target_callbacks *cb);
 void PollI2CSlave(uint32_t id);
 #endif

--- a/lib/tenstorrent/bh_arc/init.c
+++ b/lib/tenstorrent/bh_arc/init.c
@@ -458,11 +458,7 @@ static int InitHW(void)
 	/* Initiate AVS interface and switch vout control to AVSBus */
 	SetPostCode(POST_CODE_SRC_CMFW, POST_CODE_ARC_INIT_STEPC);
 	if (!IS_ENABLED(CONFIG_TT_SMC_RECOVERY)) {
-		if (RegulatorInit(get_pcb_type())) {
-			LOG_ERR("Failed to initialize regulators.\n");
-			error_status0.f.regulator_init_error = 1;
-			init_errors = true;
-		}
+		RegulatorInit(get_pcb_type());
 		AVSInit();
 		SwitchVoutControl(AVSVoutCommand);
 	}

--- a/lib/tenstorrent/bh_arc/regulator.c
+++ b/lib/tenstorrent/bh_arc/regulator.c
@@ -223,45 +223,26 @@ void SwitchVoutControl(VoltageCmdSource source)
 
 void RegulatorInit(PcbType board_type)
 {
-	if (board_type == PcbTypeP150) {
-		/* VCORE */
-		I2CInit(I2CMst, P0V8_VCORE_ADDR, I2CFastMode, PMBUS_MST_ID);
+	/* VCORE */
+	I2CInit(I2CMst, P0V8_VCORE_ADDR, I2CFastMode, PMBUS_MST_ID);
 
-		static const uint8_t vcore_b0[] = {0x15, 0x09, 0x3c, 0x08, 0x0a, 0x02, 0x0f, 0x00,
-						   0x11, 0x00, 0x00, 0x00, 0x00, 0x41, 0x03, 0x00,
-						   0x00, 0x0f, 0x0d, 0x0a, 0x00, 0x00};
-		static const uint8_t vcore_ca[] = {0x04, 0x78, 0x3c, 0x0f, 0x00};
-		static const uint8_t vcore_cb[] = {0x05, 0x50, 0x0e, 0x64, 0x28, 0x00};
-		static const uint8_t vcore_d3[] = {0x00};
-		static const uint8_t vcore_38[] = {0x08, 0x00};
-		static const uint8_t vcore_39[] = {0x0c, 0x00};
-		static const uint8_t vcore_e7[] = {0x01};
+	static const uint8_t vcore_b0[] = {0x15, 0x09, 0x3c, 0x08, 0x0a, 0x02, 0x0f, 0x00,
+					   0x11, 0x00, 0x00, 0x00, 0x00, 0x41, 0x03, 0x00,
+					   0x00, 0x0f, 0x0d, 0x0a, 0x00, 0x00};
+	static const uint8_t vcore_ca[] = {0x04, 0x78, 0x3c, 0x0f, 0x00};
+	static const uint8_t vcore_cb[] = {0x05, 0x50, 0x0e, 0x64, 0x28, 0x00};
+	static const uint8_t vcore_d3[] = {0x00};
+	static const uint8_t vcore_38[] = {0x08, 0x00};
+	static const uint8_t vcore_39[] = {0x0c, 0x00};
+	static const uint8_t vcore_e7[] = {0x01};
 
-		I2CWriteBytes(PMBUS_MST_ID, 0xb0, PMBUS_CMD_BYTE_SIZE, vcore_b0, sizeof(vcore_b0));
-		I2CWriteBytes(PMBUS_MST_ID, 0xca, PMBUS_CMD_BYTE_SIZE, vcore_ca, sizeof(vcore_ca));
-		I2CWriteBytes(PMBUS_MST_ID, 0xcb, PMBUS_CMD_BYTE_SIZE, vcore_cb, sizeof(vcore_cb));
-		I2CWriteBytes(PMBUS_MST_ID, 0xd3, PMBUS_CMD_BYTE_SIZE, vcore_d3, sizeof(vcore_d3));
-		I2CWriteBytes(PMBUS_MST_ID, 0x38, PMBUS_CMD_BYTE_SIZE, vcore_38, sizeof(vcore_38));
-		I2CWriteBytes(PMBUS_MST_ID, 0x39, PMBUS_CMD_BYTE_SIZE, vcore_39, sizeof(vcore_39));
-		I2CWriteBytes(PMBUS_MST_ID, 0xe7, PMBUS_CMD_BYTE_SIZE, vcore_e7, sizeof(vcore_e7));
-
-		/* VCOREM */
-		static const uint8_t vcorem_b0[] = {0x0f, 0x19, 0x2b, 0x08, 0x17, 0x07, 0x0f, 0x00,
-						0x09, 0x63, 0x09, 0x00, 0x00, 0x3f, 0x3d, 0x3a};
-		static const uint8_t vcorem_38[] = {0x08, 0x00};
-		static const uint8_t vcorem_39[] = {0x0c, 0x00};
-		static const uint8_t vcorem_e7[] = {0x10};
-
-		I2CInit(I2CMst, P0V8_VCOREM_ADDR, I2CFastMode, PMBUS_MST_ID);
-		I2CWriteBytes(PMBUS_MST_ID, 0xb0, PMBUS_CMD_BYTE_SIZE, vcorem_b0,
-			sizeof(vcorem_b0));
-		I2CWriteBytes(PMBUS_MST_ID, 0x38, PMBUS_CMD_BYTE_SIZE, vcorem_38,
-			sizeof(vcorem_38));
-		I2CWriteBytes(PMBUS_MST_ID, 0x39, PMBUS_CMD_BYTE_SIZE, vcorem_39,
-			sizeof(vcorem_39));
-		I2CWriteBytes(PMBUS_MST_ID, 0xe7, PMBUS_CMD_BYTE_SIZE, vcorem_e7,
-			sizeof(vcorem_e7));
-	}
+	I2CWriteBytes(PMBUS_MST_ID, 0xb0, PMBUS_CMD_BYTE_SIZE, vcore_b0, sizeof(vcore_b0));
+	I2CWriteBytes(PMBUS_MST_ID, 0xca, PMBUS_CMD_BYTE_SIZE, vcore_ca, sizeof(vcore_ca));
+	I2CWriteBytes(PMBUS_MST_ID, 0xcb, PMBUS_CMD_BYTE_SIZE, vcore_cb, sizeof(vcore_cb));
+	I2CWriteBytes(PMBUS_MST_ID, 0xd3, PMBUS_CMD_BYTE_SIZE, vcore_d3, sizeof(vcore_d3));
+	I2CWriteBytes(PMBUS_MST_ID, 0x38, PMBUS_CMD_BYTE_SIZE, vcore_38, sizeof(vcore_38));
+	I2CWriteBytes(PMBUS_MST_ID, 0x39, PMBUS_CMD_BYTE_SIZE, vcore_39, sizeof(vcore_39));
+	I2CWriteBytes(PMBUS_MST_ID, 0xe7, PMBUS_CMD_BYTE_SIZE, vcore_e7, sizeof(vcore_e7));
 
 	/* GDDRIO */
 	if (board_type == PcbTypeUBB) {

--- a/lib/tenstorrent/bh_arc/regulator.c
+++ b/lib/tenstorrent/bh_arc/regulator.c
@@ -10,15 +10,12 @@
 #include <float.h> /* for FLT_MAX */
 #include <stdint.h>
 #include <zephyr/kernel.h>
-#include <zephyr/logging/log.h>
 #include <tenstorrent/msg_type.h>
 #include <tenstorrent/msgqueue.h>
 
 #include "avs.h"
 #include "dw_apb_i2c.h"
 #include "timer.h"
-
-LOG_MODULE_REGISTER(regulator);
 
 #define LINEAR_FORMAT_CONSTANT (1 << 9)
 #define SCALE_LOOP             0.335f
@@ -224,171 +221,46 @@ void SwitchVoutControl(VoltageCmdSource source)
 	vout_cmd_source = source;
 }
 
-uint32_t RegulatorInit(PcbType board_type)
+void RegulatorInit(PcbType board_type)
 {
-	/* Helpers used in this function */
-	#define REGULATOR_DATA(regulator, cmd) \
-		{0x##cmd, regulator##_##cmd##_data, regulator##_##cmd##_mask, \
-		sizeof(regulator##_##cmd##_data)}
-
-	typedef struct {
-		uint8_t cmd;
-		const uint8_t *data;
-		const uint8_t *mask;
-		uint32_t size;
-	} RegulatorData;
-
-	uint32_t aggregate_i2c_errors = 0;
-	uint32_t i2c_error = 0;
-
 	if (board_type == PcbTypeP150) {
 		/* VCORE */
-		static const uint8_t vcore_b0_data[] = {
-			0x00, 0x00, 0x00, 0x00,
-			0x00, 0x02, 0x00, 0x00,
-			0x11, 0x00, 0x00, 0x00,
-			0x00, 0x41, 0x00, 0x00,
-			0x00, 0x00, 0x00, 0x00,
-			0x00, 0x00};
-		static const uint8_t vcore_b0_mask[] = {
-			0x00, 0x00, 0x00, 0x00,
-			0x00, 0x1f, 0x00, 0x00,
-			0x1f, 0x00, 0x00, 0x00,
-			0x00, 0x7f, 0x00, 0x00,
-			0x00, 0x00, 0x00, 0x00,
-			0x00, 0x00};
-
-		BUILD_ASSERT(sizeof(vcore_b0_data) == sizeof(vcore_b0_mask));
-
-		static const uint8_t vcore_cb_data[] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
-		static const uint8_t vcore_cb_mask[] = {0x00, 0x07, 0x00, 0x00, 0x00, 0x00};
-
-		BUILD_ASSERT(sizeof(vcore_cb_data) == sizeof(vcore_cb_mask));
-
-		static const uint8_t vcore_d3_data[] = {0x00};
-		static const uint8_t vcore_d3_mask[] = {0x80};
-
-		BUILD_ASSERT(sizeof(vcore_d3_data) == sizeof(vcore_d3_mask));
-
-		static const uint8_t vcore_ca_data[] = {0x00, 0x78, 0x00, 0x00, 0x00};
-		static const uint8_t vcore_ca_mask[] = {0x00, 0xff, 0x00, 0x00, 0x00};
-
-		BUILD_ASSERT(sizeof(vcore_ca_data) == sizeof(vcore_ca_mask));
-
-		static const uint8_t vcore_38_data[] = {0x08, 0x00};
-		static const uint8_t vcore_38_mask[] = {0xff, 0x00};
-
-		BUILD_ASSERT(sizeof(vcore_38_data) == sizeof(vcore_38_mask));
-
-		static const uint8_t vcore_39_data[] = {0x0c, 0x00};
-		static const uint8_t vcore_39_mask[] = {0xff, 0x00};
-
-		BUILD_ASSERT(sizeof(vcore_39_data) == sizeof(vcore_39_mask));
-
-		static const uint8_t vcore_e7_data[] = {0x01};
-		static const uint8_t vcore_e7_mask[] = {0x07};
-
-		BUILD_ASSERT(sizeof(vcore_e7_data) == sizeof(vcore_e7_mask));
-
-		static const RegulatorData vcore_data[] = {
-			REGULATOR_DATA(vcore, b0),
-			REGULATOR_DATA(vcore, cb),
-			REGULATOR_DATA(vcore, d3),
-			REGULATOR_DATA(vcore, ca),
-			REGULATOR_DATA(vcore, 38),
-			REGULATOR_DATA(vcore, 39),
-			REGULATOR_DATA(vcore, e7),
-		};
-
 		I2CInit(I2CMst, P0V8_VCORE_ADDR, I2CFastMode, PMBUS_MST_ID);
 
-		ARRAY_FOR_EACH_PTR(vcore_data, regulator_data) {
-			LOG_DBG("Vcore regulator init on cmd %#x", regulator_data->cmd);
-			i2c_error = I2CRMWV(PMBUS_MST_ID, regulator_data->cmd,
-				PMBUS_CMD_BYTE_SIZE, regulator_data->data,
-				regulator_data->mask, regulator_data->size);
+		static const uint8_t vcore_b0[] = {0x15, 0x09, 0x3c, 0x08, 0x0a, 0x02, 0x0f, 0x00,
+						   0x11, 0x00, 0x00, 0x00, 0x00, 0x41, 0x03, 0x00,
+						   0x00, 0x0f, 0x0d, 0x0a, 0x00, 0x00};
+		static const uint8_t vcore_ca[] = {0x04, 0x78, 0x3c, 0x0f, 0x00};
+		static const uint8_t vcore_cb[] = {0x05, 0x50, 0x0e, 0x64, 0x28, 0x00};
+		static const uint8_t vcore_d3[] = {0x00};
+		static const uint8_t vcore_38[] = {0x08, 0x00};
+		static const uint8_t vcore_39[] = {0x0c, 0x00};
+		static const uint8_t vcore_e7[] = {0x01};
 
-			if (i2c_error) {
-				LOG_WRN("Vcore regulator init retried on cmd %#x with error %#x",
-					regulator_data->cmd, i2c_error);
-				/* Retry once */
-				i2c_error = I2CRMWV(PMBUS_MST_ID, regulator_data->cmd,
-					PMBUS_CMD_BYTE_SIZE, regulator_data->data,
-					regulator_data->mask, regulator_data->size);
-				if (i2c_error) {
-					LOG_ERR("Vcore regulator init failed on cmd %#x "
-						"with error %#x",
-						regulator_data->cmd, i2c_error);
-					aggregate_i2c_errors |= i2c_error;
-				} else {
-					LOG_INF("Vcore regulator init succeeded on cmd %#x",
-						regulator_data->cmd);
-				}
-			}
-		}
+		I2CWriteBytes(PMBUS_MST_ID, 0xb0, PMBUS_CMD_BYTE_SIZE, vcore_b0, sizeof(vcore_b0));
+		I2CWriteBytes(PMBUS_MST_ID, 0xca, PMBUS_CMD_BYTE_SIZE, vcore_ca, sizeof(vcore_ca));
+		I2CWriteBytes(PMBUS_MST_ID, 0xcb, PMBUS_CMD_BYTE_SIZE, vcore_cb, sizeof(vcore_cb));
+		I2CWriteBytes(PMBUS_MST_ID, 0xd3, PMBUS_CMD_BYTE_SIZE, vcore_d3, sizeof(vcore_d3));
+		I2CWriteBytes(PMBUS_MST_ID, 0x38, PMBUS_CMD_BYTE_SIZE, vcore_38, sizeof(vcore_38));
+		I2CWriteBytes(PMBUS_MST_ID, 0x39, PMBUS_CMD_BYTE_SIZE, vcore_39, sizeof(vcore_39));
+		I2CWriteBytes(PMBUS_MST_ID, 0xe7, PMBUS_CMD_BYTE_SIZE, vcore_e7, sizeof(vcore_e7));
 
 		/* VCOREM */
-		static const uint8_t vcorem_b0_data[] = {
-			0x00, 0x00, 0x2b, 0x00,
-			0x00, 0x07, 0x00, 0x00,
-			0x09, 0x00, 0x09, 0x00,
-			0x00, 0x00, 0x00, 0x00};
-		static const uint8_t vcorem_b0_mask[] = {
-			0x00, 0x00, 0x3f, 0x00,
-			0x00, 0x1f, 0x00, 0x00,
-			0x1f, 0x00, 0x0f, 0x00,
-			0x00, 0x00, 0x00, 0x00};
-
-		BUILD_ASSERT(sizeof(vcorem_b0_data) == sizeof(vcorem_b0_mask));
-
-		static const uint8_t vcorem_38_data[] = {0x08, 0x00};
-		static const uint8_t vcorem_38_mask[] = {0xff, 0x00};
-
-		BUILD_ASSERT(sizeof(vcorem_38_data) == sizeof(vcorem_38_mask));
-
-		static const uint8_t vcorem_39_data[] = {0x0c, 0x00};
-		static const uint8_t vcorem_39_mask[] = {0xff, 0x00};
-
-		BUILD_ASSERT(sizeof(vcorem_39_data) == sizeof(vcorem_39_mask));
-
-		static const uint8_t vcorem_e7_data[] = {0x04};
-		static const uint8_t vcorem_e7_mask[] = {0x07};
-
-		BUILD_ASSERT(sizeof(vcorem_e7_data) == sizeof(vcorem_e7_mask));
-
-		static const RegulatorData vcorem_data[] = {
-			REGULATOR_DATA(vcorem, b0),
-			REGULATOR_DATA(vcorem, 38),
-			REGULATOR_DATA(vcorem, 39),
-			REGULATOR_DATA(vcorem, e7),
-		};
+		static const uint8_t vcorem_b0[] = {0x0f, 0x19, 0x2b, 0x08, 0x17, 0x07, 0x0f, 0x00,
+						0x09, 0x63, 0x09, 0x00, 0x00, 0x3f, 0x3d, 0x3a};
+		static const uint8_t vcorem_38[] = {0x08, 0x00};
+		static const uint8_t vcorem_39[] = {0x0c, 0x00};
+		static const uint8_t vcorem_e7[] = {0x10};
 
 		I2CInit(I2CMst, P0V8_VCOREM_ADDR, I2CFastMode, PMBUS_MST_ID);
-
-		ARRAY_FOR_EACH_PTR(vcorem_data, regulator_data) {
-			LOG_DBG("Vcorem regulator init on cmd %#x", regulator_data->cmd);
-			i2c_error = I2CRMWV(PMBUS_MST_ID, regulator_data->cmd,
-				PMBUS_CMD_BYTE_SIZE, regulator_data->data,
-				regulator_data->mask, regulator_data->size);
-
-			if (i2c_error) {
-				LOG_WRN("Vcorem regulator init retried on cmd %#x with error %#x",
-					regulator_data->cmd, i2c_error);
-				/* Retry once */
-				i2c_error = I2CRMWV(PMBUS_MST_ID, regulator_data->cmd,
-					PMBUS_CMD_BYTE_SIZE, regulator_data->data,
-					regulator_data->mask, regulator_data->size);
-				if (i2c_error) {
-					LOG_ERR("Vcorem regulator init failed on cmd %#x "
-						"with error %#x",
-						regulator_data->cmd, i2c_error);
-					aggregate_i2c_errors |= i2c_error;
-				} else {
-					LOG_INF("Vcorem regulator init succeeded on cmd %#x",
-						regulator_data->cmd);
-				}
-			}
-		}
+		I2CWriteBytes(PMBUS_MST_ID, 0xb0, PMBUS_CMD_BYTE_SIZE, vcorem_b0,
+			sizeof(vcorem_b0));
+		I2CWriteBytes(PMBUS_MST_ID, 0x38, PMBUS_CMD_BYTE_SIZE, vcorem_38,
+			sizeof(vcorem_38));
+		I2CWriteBytes(PMBUS_MST_ID, 0x39, PMBUS_CMD_BYTE_SIZE, vcorem_39,
+			sizeof(vcorem_39));
+		I2CWriteBytes(PMBUS_MST_ID, 0xe7, PMBUS_CMD_BYTE_SIZE, vcorem_e7,
+			sizeof(vcorem_e7));
 	}
 
 	/* GDDRIO */
@@ -424,7 +296,6 @@ uint32_t RegulatorInit(PcbType board_type)
 				      &mfr_ctrl_ops, MFR_CTRL_OPS_DATA_BYTE_SIZE);
 		}
 	}
-	return aggregate_i2c_errors;
 }
 
 static uint8_t set_voltage_handler(uint32_t msg_code, const struct request *request,

--- a/lib/tenstorrent/bh_arc/regulator.h
+++ b/lib/tenstorrent/bh_arc/regulator.h
@@ -25,5 +25,5 @@ void set_gddr_vddr(PcbType board_type, uint32_t voltage_in_mv);
 float GetVcoreCurrent(void);
 float GetVcorePower(void);
 void SwitchVoutControl(VoltageCmdSource source);
-uint32_t RegulatorInit(PcbType board_type);
+void RegulatorInit(PcbType board_type);
 #endif


### PR DESCRIPTION
From my best-effort bisect, these commits appear to be causing the CI hangs on the P100 platform. The CI hang seen can be reproduced as follows:
- build fwbundle for the P100 card: `west build -p always -b tt_blackhole@p100/tt_blackhole/smc tt-zephyr-platforms/app/smc/ --sysbuild`
- flash fwbundle using `west flash -r tt_flash --force`
- Make sure BMFW is updated by running `west flash -d build/bmc`
- reset the SMC repeatedly by running `west rtt -d build/bmc`. After 10-20 invocations, the message "BMFW VERSION 0.3.2" should fail to appear

If attaching with a debugger, you will see that the BMFW is stuck waiting for PGOOD to go high on the card. This can be solved by toggling A/C power to the system, but the issue will reappear within CI eventually.