### PR TITLE
Swapped chip boot order of p300

### DIFF
--- a/boards/tenstorrent/tt_blackhole/tt_blackhole_tt_blackhole_bmc_p300.overlay
+++ b/boards/tenstorrent/tt_blackhole/tt_blackhole_tt_blackhole_bmc_p300.overlay
@@ -84,8 +84,8 @@
 
 	chips {
 		compatible = "tenstorrent,bh-chips";
-		chips = <&chip0 &chip1>;
-		primary = <1>;
+		chips = <&chip1 &chip0>;
+		primary = <0>;
 	};
 };
 


### PR DESCRIPTION
Previously the default boot order of the p300 caused chip1 of the board to fail to enumerate when using the recovery image. The reason for this is two fold
1. The recovery image boots both pcie subsystems on the asic 0 and then 1.
2. On the p300 chip0 uses pcie subsystem 0 and chip1 uses pcie subsystem 1.

This meant that the boot would go something like;
1. chip0 boot0 [success]
2. chip0 boot1 [fail]
3. chip1 boot0 [fail]
4. chip1 boot1 [success]

The timing on the boot is so tight that taking 4 steps to fully boot pcie violated pcie bus timing for chip1.

But swapping the chip boot order
1. chip1 boot0 [fail]
2. chip1 boot1 [success]
3. chip0 boot0 [success]
4. chip0 boot1 [fail]

Shortens the total boot time for the pcie subsystems and means we no longer violate pcie bus timing for either chip0 or 1.