### PR TITLE
regulator: apply init settings to p100

### DIFF
--- a/lib/tenstorrent/bh_arc/regulator.c
+++ b/lib/tenstorrent/bh_arc/regulator.c
@@ -241,7 +241,7 @@ uint32_t RegulatorInit(PcbType board_type)
 	uint32_t aggregate_i2c_errors = 0;
 	uint32_t i2c_error = 0;
 
-	if (board_type == PcbTypeP150) {
+	if (board_type == PcbTypeP150 || board_type == PcbTypeP100) {
 		/* VCORE */
 		static const uint8_t vcore_b0_data[] = {
 			0x00, 0x00, 0x00, 0x00,


### PR DESCRIPTION
Before #49, regulator settings were applying to all PCB types. In #75, @danieldegrasse suspects one of the changes in #49 to be causing p100 CI failures related to PGOOD.

Try to also apply regulator init settings to the p100 PCB Type. This should be ok according to our board team.