### PR TITLE
bh_arc: fw_table: add kconfig to mock fwtable

### DIFF
--- a/app/smc/sample.yaml
+++ b/app/smc/sample.yaml
@@ -17,6 +17,8 @@ tests:
       pytest_args:
         - "--dut-scope=session"
         - "-m not flash"
+    extra_configs:
+      - CONFIG_TT_FWTABLE_MOCK=y
   app.e2e-smoke-flash:
     tags: e2e-flash
     harness: pytest
@@ -51,3 +53,5 @@ tests:
       - vuart.overlay
     extra_overlay_confs:
       - vuart.conf
+    extra_configs:
+      - CONFIG_TT_FWTABLE_MOCK=y

--- a/cmake/board_revision_ifdef.cmake
+++ b/cmake/board_revision_ifdef.cmake
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# This is how we define e.g. BOARD_REVISION_P100 so that
+# "#ifdef BOARD_REVISION_P100" works in C.
+
+if(NOT DEFINED BOARD_REVISION)
+  return()
+endif()
+
+string(TOUPPER ${BOARD_REVISION} BOARD_REVISION_DEF)
+
+string(REGEX MATCH "^[A-Z0-9_]+$" BOARD_REVISION_DEF ${BOARD_REVISION_DEF})
+if(NOT BOARD_REVISION_DEF)
+  message(FATAL_ERROR "BOARD_REVISION must only use letters, numbers, and underscores")
+endif()
+
+set(BOARD_REVISION_DEF "BOARD_REVISION_${BOARD_REVISION_DEF}")
+message(STATUS "Added Compile Definition: -D${BOARD_REVISION_DEF}")
+
+zephyr_compile_definitions(${BOARD_REVISION_DEF})

--- a/lib/tenstorrent/bh_arc/CMakeLists.txt
+++ b/lib/tenstorrent/bh_arc/CMakeLists.txt
@@ -59,6 +59,12 @@ if(CONFIG_ARC)
   zephyr_library_link_libraries(${ZEPHYR_CURRENT_MODULE_DIR}/zephyr/blobs/tt_blackhole_libpciesd.a)
 endif()
 
+include(${ZEPHYR_CURRENT_MODULE_DIR}/cmake/bundle_version.cmake)
+zephyr_library_compile_definitions(BUNDLE_VERSION_NUMBER=${BUNDLE_VERSION_NUMBER})
+zephyr_library_compile_definitions(BUNDLE_VERSION_STRING="${BUNDLE_VERSION_STRING}")
+
+include(${ZEPHYR_CURRENT_MODULE_DIR}/cmake/board_revision_ifdef.cmake)
+
 list(APPEND CMAKE_MODULE_PATH ${ZEPHYR_BASE}/modules/nanopb)
 include(nanopb)
 zephyr_nanopb_sources(bh_arc spirom_protobufs/fw_table.proto)
@@ -114,4 +120,62 @@ if(NOT DEFINED CONFIG_TT_SMC_RECOVERY)
 		  --bundle-version ${BUNDLE_VERSION_STRING}
 	)
 	endif()
+endif()
+
+if(NOT CONFIG_TT_SMC_RECOVERY)
+if(CONFIG_TT_FWTABLE_MOCK)
+  set(MY_BOARD_DIR ${BOARD_DIR})
+  if(NOT BOARD STREQUAL "tt_blackhole")
+    set(MY_BOARD_DIR ${ZEPHYR_CURRENT_MODULE_DIR}/boards/tenstorrent/tt_blackhole)
+  endif()
+
+  # Inputs
+  set(FW_TABLE_TXT ${MY_BOARD_DIR}/spirom_data_tables/${PROD_NAME}/fw_table.txt)
+  set(FW_TABLE_PROTO ${SPIROM_PROTOBUFS}/fw_table.proto)
+
+  # Paths
+  set(FW_TABLE_GEN_DIR ${ZEPHYR_BINARY_DIR}/bh_arc)
+  set(FW_TABLE_MOCK_PATH ${FW_TABLE_GEN_DIR}/include)
+  set(FW_TABLE_PYPATH ${FW_TABLE_GEN_DIR}/fw_table)
+
+  # Outputs
+  set(FW_TABLE_MOCK_INC ${FW_TABLE_MOCK_PATH}/tenstorrent/fw_table_mock.inc)
+  set(FW_TABLE_PYLIB ${FW_TABLE_PYPATH}/fw_table_pb2.py)
+
+  # Generate fw_table_pb2.py from fw_table.proto
+  # Note: this is done as part of the build process, not as "extra_post_build_commands"
+  add_custom_command(
+    OUTPUT ${FW_TABLE_PYLIB}
+    COMMAND
+    ${PROTOC}
+    --python_out=${FW_TABLE_PYPATH}
+    ${FW_TABLE_PROTO}
+    -I ${SPIROM_PROTOBUFS}
+    DEPENDS ${FW_TABLE_PROTO}
+  )
+  MESSAGE(STATUS "Generated ${FW_TABLE_PYLIB}")
+
+  # Generate fw_table_mock.inc from fw_table.txt using fw_table_pb2.py
+  add_custom_command(
+    OUTPUT ${FW_TABLE_MOCK_INC}
+    COMMAND
+    PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python
+    ${PYTHON_EXECUTABLE}
+    ${ZEPHYR_CURRENT_MODULE_DIR}/scripts/encode_fwtable_mock.py
+    --python-path=${FW_TABLE_PYPATH}
+    --bundle-version=${BUNDLE_VERSION_NUMBER}
+    --input ${FW_TABLE_TXT}
+    --output ${FW_TABLE_MOCK_INC}
+    DEPENDS ${FW_TABLE_PYLIB}
+  )
+  MESSAGE(STATUS "Generated ${FW_TABLE_MOCK_INC}")
+
+  # Create a dynamic cmake target for the generated file (required because file is not present at cmake time)
+  generate_unique_target_name_from_filename(${FW_TABLE_MOCK_INC} FW_TABLE_MOCK_INC_TGT)
+  add_custom_target(${FW_TABLE_MOCK_INC_TGT} DEPENDS ${FW_TABLE_MOCK_INC})
+
+  # Add the generated file as a dependency of the bh_arc library (and update include paths)
+  add_dependencies(bh_arc ${FW_TABLE_MOCK_INC_TGT})
+  zephyr_library_include_directories(bh_arc ${FW_TABLE_MOCK_PATH})
+endif()
 endif()

--- a/lib/tenstorrent/bh_arc/Kconfig
+++ b/lib/tenstorrent/bh_arc/Kconfig
@@ -67,6 +67,7 @@ config TT_BH_ARC_SYSINIT
 
 config TT_FWTABLE_MOCK
 	bool "Mock SPI flash firmware tables"
+	default y if ZTEST
 	help
 	  Mock values from the firmware table in SPI flash directly in firmware. This optional
 	  can help ensure testing is more consistent without the need to flash all images to SPI.

--- a/lib/tenstorrent/bh_arc/Kconfig
+++ b/lib/tenstorrent/bh_arc/Kconfig
@@ -64,3 +64,9 @@ config TT_BH_ARC_SYSINIT
 	  Initialize blackhole firmware and hardware prior to starting the application.
 
 	  This allows our library drivers to work better with Zephyr's driver model.
+
+config TT_FWTABLE_MOCK
+	bool "Mock SPI flash firmware tables"
+	help
+	  Mock values from the firmware table in SPI flash directly in firmware. This optional
+	  can help ensure testing is more consistent without the need to flash all images to SPI.

--- a/lib/tenstorrent/bh_arc/fw_table.c
+++ b/lib/tenstorrent/bh_arc/fw_table.c
@@ -6,34 +6,44 @@
 
 #include "fw_table.h"
 
+#include <errno.h>
+#include <stdbool.h>
+#include <string.h>
+
 #include <pb_decode.h>
 #include <tenstorrent/tt_boot_fs.h>
+#include <zephyr/sys/util.h>
 
-static FwTable fw_table;
+static FwTable fw_table = {
+#ifdef CONFIG_TT_FWTABLE_MOCK
+#include "tenstorrent/fw_table_mock.inc"
+#endif
+};
 
 /* Loader function that deserializes the fw table bin from the SPI filesystem */
 int load_fw_table(uint8_t *buffer_space, uint32_t buffer_size)
 {
+	if (IS_ENABLED(CONFIG_TT_FWTABLE_MOCK)) {
+		return 0;
+	}
+
 	static const char fwTableTag[TT_BOOT_FS_IMAGE_TAG_SIZE] = "cmfwcfg";
 	size_t bin_size = 0;
 
 	if (tt_boot_fs_get_file(&boot_fs_data, fwTableTag, buffer_space, buffer_size, &bin_size) !=
 	    TT_BOOT_FS_OK) {
-		/* Error */
-		/* TODO: Handle more gracefully */
-		return -1;
+		return -EIO;
 	}
 	/* Convert the binary data to a pb_istream_t that is expected by decode */
 	pb_istream_t stream = pb_istream_from_buffer(buffer_space, bin_size);
-	/* PB_DECODE_NULLTERMINATED: Expect the message to be terminated with zero tag */
 	bool status = pb_decode_ex(&stream, &FwTable_msg, &fw_table, PB_DECODE_NULLTERMINATED);
 
 	if (!status) {
-		/* Clear the table since a failed decode can leave it in an inconsistent state */
+		/* Clear the table to avoid an inconsistent state */
 		memset(&fw_table, 0, sizeof(fw_table));
-		/* Return -1 that should propagate up the stack */
-		return -1;
+		return -EIO;
 	}
+
 	return 0;
 }
 

--- a/scripts/encode_fwtable_mock.py
+++ b/scripts/encode_fwtable_mock.py
@@ -1,0 +1,110 @@
+# Copyright (c) 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+import argparse
+
+from pathlib import Path
+from typing import Any
+from google.protobuf import text_format
+
+
+def obj_to_inc(obj: Any, bundle_version: int) -> str:
+    """Convert a fw_table_pb2.FwTable object to a C struct declaration.
+    Note: the object argument is of type Any due to dynamic python imports.
+    """
+    s = ""
+    for descriptor in obj.DESCRIPTOR.fields:
+        if descriptor.name == "fw_bundle_version":
+            value = bundle_version
+        else:
+            value = getattr(obj, descriptor.name)
+        if descriptor.type == descriptor.TYPE_MESSAGE:
+            s += f".{descriptor.name} = {{"
+            if descriptor.label == descriptor.LABEL_REPEATED:
+                s += map(obj_to_inc, value, bundle_version)
+            else:
+                s += obj_to_inc(value, bundle_version)
+            s += "},"
+        else:
+            if isinstance(value, bool):
+                value = "1" if value else "0"
+            s += f".{descriptor.name} = {value},"
+
+    return s
+
+
+def convert_proto_txt_to_inc_file(input, output, bundle_version):
+    """Convert a text representation of a FwTable to a C struct declaration and write it to the
+    output file."""
+    try:
+        import fw_table_pb2
+    except ImportError as e:
+        print(f"Error importing protobuf modules: {e}")
+        print("Ensure the protobuf files are generated and the path is correct.")
+        sys.exit(1)
+
+    fw_table_txt = ""
+
+    # Read the text representation of the FwTable
+    with open(input, "r") as f:
+        fw_table_txt = f.read()
+
+    # Parse the text representation into a FwTable object
+    fw_table_obj = fw_table_pb2.FwTable()
+    fw_table = text_format.Parse(fw_table_txt, fw_table_obj)
+
+    # Convert the FwTable object to a C struct declaration
+    inc = obj_to_inc(fw_table, bundle_version)
+
+    # Write the C struct declaration to the output file
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with open(output, "w") as f:
+        f.write(inc)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Encode SPIROM bins", allow_abbrev=False
+    )
+    parser.add_argument(
+        "-i",
+        "--input",
+        type=Path,
+        help="Path to input fw_table.txt file",
+        required=True,
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        help="Path to output .inc file of FwTable content",
+        required=True,
+    )
+    parser.add_argument(
+        "-p",
+        "--python-path",
+        type=Path,
+        action="append",
+        default=[],
+        metavar="PYTHON_PATH",
+        help="Additional python path to search for fw_table_pb2. May be specified more than once",
+    )
+    parser.add_argument(
+        "-v",
+        "--bundle-version",
+        type=lambda x: int(x, 0),
+        help="Bundle version number expressed as an integer",
+        required=True,
+    )
+    args = parser.parse_args()
+
+    for p in args.python_path:
+        if p not in sys.path:
+            sys.path.append(str(p))
+
+    convert_proto_txt_to_inc_file(args.input, args.output, args.bundle_version)
+
+
+if __name__ == "__main__":
+    main()

--- a/test-conf/tests/drivers/flash/common/testcase.yaml
+++ b/test-conf/tests/drivers/flash/common/testcase.yaml
@@ -12,6 +12,7 @@ tests:
       - tt_blackhole@p300a/tt_blackhole/smc
     extra_configs:
       - CONFIG_SEGGER_RTT_BUFFER_SIZE_UP=4096
+      - CONFIG_TT_FWTABLE_MOCK=y
     extra_args:
       - "platform:tt_blackhole@p100/tt_blackhole/smc:DTC_OVERLAY_FILE=\
          ../../../../../tt-zephyr-platforms/test-conf/tests/drivers/flash/\


### PR DESCRIPTION
We do not flash fw tables during the normal CI process.

This has the unfortunate consequence of introducing regressions if there is inadequate test coverage.

If we use a Kconfig option to enable or disable loading the firmware table from SPI, then we can be sure there is no hidden state (in fw tables) from one build to the next. That does not account for read-only tables of course.

This is a stop-gap solution until we have a complete unbrickable firmware update process, and a process by which we tightly couple the smc firmware image with firmware tables.
