### PR TITLE
ci: flash a stable copy of BMFW and CMFW prior to HW CI runs

### DIFF
--- a/.github/workflows/hardware-smoke.yml
+++ b/.github/workflows/hardware-smoke.yml
@@ -33,7 +33,7 @@ jobs:
         - /dev/hugepages-1G:/dev/hugepages-1G
         - /opt/tenstorrent/fw/stable:/opt/tenstorrent/fw/stable
         - /opt/tenstorrent/twister:/opt/tenstorrent/twister
-        - /opt/tenstorrent/bin/openocd-rtt:/opt/tenstorrent/bin/openocd-rtt
+        - /opt/tenstorrent/bin:/opt/tenstorrent/bin
       options: '--device /dev/tenstorrent --device /dev/bus/usb --privileged'
     steps:
       - uses: actions/checkout@v4
@@ -43,6 +43,11 @@ jobs:
       - uses: ./tt-zephyr-platforms/.github/workflows/prepare-zephyr
         with:
           app-path: tt-zephyr-platforms
+
+      - uses: ./tt-zephyr-platforms/.github/workflows/prepare-hardware
+        with:
+          board: ${{ matrix.config.board }}
+          version: '80.15.0.0'
 
       - name: Generate board names
         shell: bash
@@ -147,7 +152,7 @@ jobs:
         - /dev/hugepages-1G:/dev/hugepages-1G
         - /opt/tenstorrent/fw/stable:/opt/tenstorrent/fw/stable
         - /opt/tenstorrent/twister:/opt/tenstorrent/twister
-        - /opt/tenstorrent/bin/openocd-rtt:/opt/tenstorrent/bin/openocd-rtt
+        - /opt/tenstorrent/bin:/opt/tenstorrent/bin
       options: '--device /dev/tenstorrent --device /dev/bus/usb --privileged'
     steps:
       - uses: actions/checkout@v4
@@ -157,6 +162,11 @@ jobs:
       - uses: ./tt-zephyr-platforms/.github/workflows/prepare-zephyr
         with:
           app-path: tt-zephyr-platforms
+
+      - uses: ./tt-zephyr-platforms/.github/workflows/prepare-hardware
+        with:
+          board: ${{ matrix.config.board }}
+          version: '80.15.0.0'
 
       - name: Generate board names
         shell: bash

--- a/.github/workflows/prepare-hardware/action.yml
+++ b/.github/workflows/prepare-hardware/action.yml
@@ -1,0 +1,28 @@
+name: Prepare Hardware for CI run
+description: |
+  This workflow restores a stable BMFW and CMFW image to the hardware before
+  executing CI jobs. It is intended to be used as a reusable (composite) step
+  in other workflows, and must be run on a self-hosted runner that
+  includes the stable firmware images
+
+inputs:
+  board:
+    description: 'Board name (e.g., p100, p100a)'
+    required: true
+  version:
+    description: 'Firmware version (e.g., 80.15.0.0)'
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Restore stable bmfw
+      working-directory: ${{ inputs.app-path }}
+      shell: bash
+      run: |
+        # Restore stable BMFW
+        /opt/tenstorrent/bin/flash-bmfw.sh ${{ inputs.board }} ${{ inputs.version }}
+        # Restore stable CMFW
+        tt-flash --fw-tar \
+          /opt/tenstorrent/fw/stable/${{ inputs.board }}/${{ inputs.version }}.fwbundle \
+          --force


### PR DESCRIPTION
Flash a stable copy of BMFW and CMFW prior to HW smoke and e2e tests, so any bad state from a prior PR run is fixed.