### PR TITLE
ci: fix hardware-metal-test failure to run west init

### DIFF
--- a/.github/workflows/hardware-long.yml
+++ b/.github/workflows/hardware-long.yml
@@ -56,6 +56,7 @@ jobs:
         # FIXME: would be ideal to use a built-in github environment variable
         # instead of tt-zephyr-platforms
         run: |
+          rm -Rf .west
           west init -l tt-zephyr-platforms
 
       - name: Setup Zephyr modules


### PR DESCRIPTION
`west init` was failing in CI due to the directory already being configured.

Remove the `.west/` subdirectory before trying to reinitialize.

Testing Done (manually reproduced and remedied issue locally):
```shell
west init -l tt-zephyr-platforms
FATAL ERROR: already initialized in /home/cfriedt/tt-zephyr-platforms-work, aborting.
Note:
    In your environment, ZEPHYR_BASE is set to:
    /home/cfriedt/tt-zephyr-platforms-work/zephyr

    This forces west to search for a workspace there.
    Try unsetting ZEPHYR_BASE and re-running this command.
(.venv) cfriedt@yyz-syseng-13:~/tt-zephyr-platforms-work$ rm -Rf .west
(.venv) cfriedt@yyz-syseng-13:~/tt-zephyr-platforms-work$ west init -l tt-zephyr-platforms
=== Initializing from existing manifest repository tt-zephyr-platforms
--- Creating /home/cfriedt/tt-zephyr-platforms-work/.west and local configuration file
=== Initialized. Now run "west update" inside /home/cfriedt/tt-zephyr-platforms-work.
```

Fixes #81