### PR TITLE
boards: tenstorrent: add definition for SPI DW driver in openocd on ARC

### DIFF
--- a/boards/tenstorrent/tt_blackhole/support/tt_blackhole_smc.cfg
+++ b/boards/tenstorrent/tt_blackhole/support/tt_blackhole_smc.cfg
@@ -108,6 +108,12 @@ arc-em.cpu4 configure -gdb-port disabled
 # execute at boot.
 arc-em.cpu1 configure -event reset-end "bh_reset_end"
 
+# Add definition for SPI DW memory. This bank can only be accessed by
+# openocd `flash` commands, as it is not memory mapped on the ARC
+flash bank 0 spi_dw 0x0 0x0 0 0 arc-em.cpu1 0x80070000 50
+# Disable arc slow memory. Required for the SPI DW driver to function.
+arc jtag set-slow-mem off
+
 # Use hard breakpoints- the ROM copies over the memory in CSM during boot,
 # so soft breakpoints won't work
 gdb_breakpoint_override hard


### PR DESCRIPTION
Add definition for SPI DW driver within openocd on ARC. This driver will enable programming the SPI DW flash via the ARC JTAG interface, provided a patched version of openocd is used with the driver included