### PR TITLE
ci: hardware-long: clean before applying patches with west

### DIFF
--- a/.github/workflows/hardware-long.yml
+++ b/.github/workflows/hardware-long.yml
@@ -70,7 +70,8 @@ jobs:
 
       - name: Apply patches
         run: |
-          west -v patch apply
+          west patch clean
+          west -v patch apply -r
 
       - name: Checkout pyluwen
         uses: actions/checkout@v4


### PR DESCRIPTION
There was an error in the hardware-long CI workflow

```
reading patch file zephyr/twister-rtt-support.patch
checking patch integrity... OK
error: patch failed: scripts/pylib/twister/twisterlib/env...:855
error: scripts/pylib/twister/twisterlib...: patch does not apply
error: patch failed: scripts/pylib/twister/twisterlib/hand...:16
error: scripts/pylib/twister/twisterlib...: patch does not apply
error: patch failed: scripts/pylib/twister/twisterlib/env...:921
error: scripts/pylib/twister/twisterlib...: patch does not apply
error: patch failed: scripts/pylib/twister/twisterlib/har...:213
error: scripts/pylib/twister/twisterlib...: patch does not apply
error: patch failed: scripts/west_commands/runners/jlink.py:89
error: scripts/west_commands/runners/jl...: patch does not apply
error: patch failed: scripts/west_commands/runners/openocd.py:59
error: scripts/west_commands/runners/op...: patch does not apply
patching zephyr... FAIL
ERROR: None
FATAL ERROR: failed to apply patch zephyr/twister-rtt-support.patch
```

Clean patches with west before applying.