### PR TITLE
version: report bundle version in telemetry

### DIFF
--- a/app/smc/pytest/pytest.ini
+++ b/app/smc/pytest/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    flash: mark test to only run after a full flash

--- a/app/smc/sample.yaml
+++ b/app/smc/sample.yaml
@@ -16,6 +16,7 @@ tests:
         - pytest/e2e_smoke.py
       pytest_args:
         - "--dut-scope=session"
+        - "-m not flash"
   app.e2e-smoke-flash:
     tags: e2e-flash
     harness: pytest

--- a/cmake/bundle_version.cmake
+++ b/cmake/bundle_version.cmake
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Get the bundle version
+set(VERSION_FILE ${ZEPHYR_CURRENT_MODULE_DIR}/VERSION)
+set(VERSION_TYPE BUNDLE)
+include(${ZEPHYR_BASE}/cmake/modules/version.cmake)
+string(REGEX REPLACE "[^0-9]+" "" BUNDLE_VERSION_EXTRA_NUM "${BUNDLE_VERSION_EXTRA}")
+set(BUNDLE_VERSION_STRING "${BUNDLE_VERSION_MAJOR}.${BUNDLE_VERSION_MINOR}.${BUNDLE_PATCHLEVEL}.${BUNDLE_VERSION_EXTRA_NUM}")
+if("${BUNDLE_VERSION_STRING}" STREQUAL "...")
+  message(FATAL_ERROR "Unable to extract bundle version")
+endif()
+
+message(STATUS "Bundle Version: ${BUNDLE_VERSION_STRING} (${BUNDLE_VERSION_NUMBER})")

--- a/lib/tenstorrent/bh_arc/CMakeLists.txt
+++ b/lib/tenstorrent/bh_arc/CMakeLists.txt
@@ -90,23 +90,28 @@ if(NOT DEFINED CONFIG_TT_SMC_RECOVERY)
 
 	message(STATUS "Generating rom configuration binary files for ${PROD_NAME}")
 
+	include(${ZEPHYR_CURRENT_MODULE_DIR}/cmake/bundle_version.cmake)
+
 	# variable is needed to avoid protobuf version clashing
 	if (PROD_NAME MATCHES "^P300")
 	set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
 		COMMAND PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python
 		  ${PYTHON_EXECUTABLE} ${ZEPHYR_CURRENT_MODULE_DIR}/scripts/encode_spirom_bins.py
 		  --board ${PROD_NAME}_L --build-dir ${CMAKE_BINARY_DIR} --output ${CMAKE_BINARY_DIR}/generated_board_cfg
+		  --bundle-version ${BUNDLE_VERSION_STRING}
 	)
 	set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
 		COMMAND PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python
 		  ${PYTHON_EXECUTABLE} ${ZEPHYR_CURRENT_MODULE_DIR}/scripts/encode_spirom_bins.py
 		  --board ${PROD_NAME}_R --build-dir ${CMAKE_BINARY_DIR} --output ${CMAKE_BINARY_DIR}/generated_board_cfg
+		  --bundle-version ${BUNDLE_VERSION_STRING}
 	)
 	else()
 	set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
 		COMMAND PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python
 		  ${PYTHON_EXECUTABLE} ${ZEPHYR_CURRENT_MODULE_DIR}/scripts/encode_spirom_bins.py
 		  --board ${PROD_NAME} --build-dir ${CMAKE_BINARY_DIR} --output ${CMAKE_BINARY_DIR}/generated_board_cfg
+		  --bundle-version ${BUNDLE_VERSION_STRING}
 	)
 	endif()
 endif()

--- a/scripts/manual-release.sh
+++ b/scripts/manual-release.sh
@@ -46,7 +46,7 @@ PRELEASE="$MAJOR.$MINOR.$PATCH.$EXTRAVERSION_NUMBER"
 echo "Building release $RELEASE / pack $PRELEASE"
 
 for REV in $BOARD_REVS; do
-  BOARD="tt_blackhole@$REV/tt_blackhole/smc";;
+  BOARD="tt_blackhole@$REV/tt_blackhole/smc"
 
   echo "Building $BOARD"
   west build -d "$TEMP_DIR/$REV" --sysbuild -p -b "$BOARD" app/smc >/dev/null 2>&1


### PR DESCRIPTION
Change the format of the bundle version to use: major.minor.patch.tweak from the VERSION file. Compile this version number into the fw_table and the manifest.json of the update.fwbundle. Also update manual-release.sh to name the file according to the new scheme.

Add an e2e test to check that the bundle version matches the VERSION file in the repo.

Output of `manual-release.sh`, `tt-flash`, and `tt-smi`:
```
[2254] afong:yyz-syseng-16 /localdev/afong/work/zephyrproject/tt-zephyr-platforms.git > ./scripts/manual-release.sh 
Created TEMP_DIR
Building release 80.16.111.111-rc1 / pack 80.16.111.111
Building tt_blackhole@p100/tt_blackhole/smc
Building tt_blackhole@p100a/tt_blackhole/smc
Building tt_blackhole@p150a/tt_blackhole/smc
Building tt_blackhole@p150b/tt_blackhole/smc
Building tt_blackhole@p150c/tt_blackhole/smc
Building tt_blackhole@p300a/tt_blackhole/smc
Building tt_blackhole@p300b/tt_blackhole/smc
Building tt_blackhole@p300c/tt_blackhole/smc
Creating fw_pack-80.16.111.111.fwbundle
Wrote fwbundle to fw_pack-80.16.111.111.fwbundle
Removed TEMP_DIR

[2254] afong:yyz-syseng-16 /localdev/afong/work/zephyrproject/tt-zephyr-platforms.git > tar -Oxf fw_pack-80.16.111.111.fwbundle ./manifest.json
{"version": "1.0.0", "bundle_version": {"fwId": 80, "releaseId": 16, "patch": 111, "debug": 111}}

[2264] afong:yyz-syseng-16 /localdev/afong/work/zephyrproject/tt-zephyr-platforms.git > tt-flash --force --fw-tar fw_pack-80.16.111.111.fwbundle 
Stage: SETUP
        Searching for default sys-config path
        Checking /etc/tenstorrent/config.json: not found
        Checking ~/.config/tenstorrent/config.json: not found

        Could not find config in default search locations, if you need it, either pass it in explicitly or generate one
        Warning: continuing without sys-config, galaxy systems will not be reset
Stage: DETECT
Stage: FLASH
        Sub Stage: VERIFY
                Verifying fw-package can be flashed: complete
                Verifying Blackhole[0] can be flashed
        Stage: FLASH
                Sub Stage FLASH Step 1: Blackhole[0]
                        Looks like you are running a very old set of fw, assuming that it needs an update
                        Now flashing tt-flash version: (80, 16, 111, 111)
                        Forced ROM update requested. ROM will now be updated.
                Sub Stage FLASH Step 2: Blackhole[0] {P100A-1}
                        Writing new firmware... SUCCESS
                        Firmware verification... SUCCESS
Stage: RESET
 Starting PCI link reset on BH devices at PCI indices: 0 
Waiting for up to 60 seconds for asic to come back after reset
 Config space reset completed for device 0 
 Finishing PCI link reset on BH devices at PCI indices: 0 
FLASH SUCCESS

[2266] afong:yyz-syseng-16 /localdev/afong/work/zephyrproject/tt-zephyr-platforms.git > tt-smi -s | grep fw_bundle_version
                "fw_bundle_version": "80.16.111.111",

```