### PR TITLE
fw_table: enable fan control for P100A and P150A

### DIFF
--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/GALAXY/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/GALAXY/fw_table.txt
@@ -22,6 +22,7 @@ feature_enable {
   aiclk_ppm_en: false
   watchdog_en: false
   smbus_en: false
+  fan_ctrl_en: false
 }
 
 fan_table {

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/ORION/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/ORION/fw_table.txt
@@ -23,6 +23,7 @@ feature_enable {
   aiclk_ppm_en: false
   watchdog_en: false
   smbus_en: false
+  fan_ctrl_en: false
 }
 
 fan_table {

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P100/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P100/fw_table.txt
@@ -23,6 +23,7 @@ feature_enable {
   aiclk_ppm_en: true
   watchdog_en: false
   smbus_en: false
+  fan_ctrl_en: false
 }
 
 fan_table {

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P100A/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P100A/fw_table.txt
@@ -23,6 +23,7 @@ feature_enable {
   aiclk_ppm_en: true
   watchdog_en: false
   smbus_en: false
+  fan_ctrl_en: true
 }
 
 fan_table {

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P150A/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P150A/fw_table.txt
@@ -23,6 +23,7 @@ feature_enable {
   aiclk_ppm_en: true
   watchdog_en: false
   smbus_en: false
+  fan_ctrl_en: true
 }
 
 fan_table {

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P150B/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P150B/fw_table.txt
@@ -23,6 +23,7 @@ feature_enable {
   aiclk_ppm_en: true
   watchdog_en: false
   smbus_en: false
+  fan_ctrl_en: false
 }
 
 fan_table {

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P150C/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P150C/fw_table.txt
@@ -23,6 +23,7 @@ feature_enable {
   aiclk_ppm_en: true
   watchdog_en: false
   smbus_en: false
+  fan_ctrl_en: false
 }
 
 fan_table {

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300A_L/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300A_L/fw_table.txt
@@ -23,6 +23,7 @@ feature_enable {
   aiclk_ppm_en: false
   watchdog_en: false
   smbus_en: false
+  fan_ctrl_en: false
 }
 
 fan_table {

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300A_R/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300A_R/fw_table.txt
@@ -23,6 +23,7 @@ feature_enable {
   aiclk_ppm_en: false
   watchdog_en: false
   smbus_en: false
+  fan_ctrl_en: false
 }
 
 fan_table {

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300B_L/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300B_L/fw_table.txt
@@ -23,6 +23,7 @@ feature_enable {
   aiclk_ppm_en: false
   watchdog_en: false
   smbus_en: false
+  fan_ctrl_en: false
 }
 
 fan_table {

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300B_R/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300B_R/fw_table.txt
@@ -23,6 +23,7 @@ feature_enable {
   aiclk_ppm_en: false
   watchdog_en: false
   smbus_en: false
+  fan_ctrl_en: false
 }
 
 fan_table {

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300C_L/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300C_L/fw_table.txt
@@ -23,6 +23,7 @@ feature_enable {
   aiclk_ppm_en: false
   watchdog_en: false
   smbus_en: false
+  fan_ctrl_en: false
 }
 
 fan_table {

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300C_R/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300C_R/fw_table.txt
@@ -23,6 +23,7 @@ feature_enable {
   aiclk_ppm_en: false
   watchdog_en: false
   smbus_en: false
+  fan_ctrl_en: false
 }
 
 fan_table {


### PR DESCRIPTION
Configure fan_ctrl_en flag in the fw_table to enable/disable fan curve for each board type. Enable for P100A and P150A, but keep disabled for all other boards.