### PR TITLE
Reset both p300 chips if pcie is already booted

### DIFF
--- a/lib/tenstorrent/jtag_bootrom/jtag_bootrom.c
+++ b/lib/tenstorrent/jtag_bootrom/jtag_bootrom.c
@@ -165,18 +165,18 @@ int jtag_bootrom_init(struct bh_chip *chip)
 		gpio_init_callback(&preset_cb_data, gpio_asic_reset_callback,
 				   BIT(preset_trigger.pin));
 		gpio_add_callback(preset_trigger.port, &preset_cb_data);
+	}
 
-		/* Active LOW, so will be false if high */
-		if (!gpio_pin_get_dt(&preset_trigger)) {
-			/* If the preset trigger started high, then we came out of reset with the
-			 * system
-			 */
-			/* thinking that pcie is ready to go. We need to forcibly apply the
-			 * workaround to
-			 * ensure this remains true.
-			 */
-			chip->data.needs_reset = true;
-		}
+	/* Active LOW, so will be false if high */
+	if (!gpio_pin_get_dt(&preset_trigger)) {
+		/* If the preset trigger started high, then we came out of reset with the
+		 * system
+		 */
+		/* thinking that pcie is ready to go. We need to forcibly apply the
+		 * workaround to
+		 * ensure this remains true.
+		 */
+		chip->data.needs_reset = true;
 	}
 #endif /* IS_ENABLED(CONFIG_JTAG_LOAD_ON_PRESET) */
 


### PR DESCRIPTION
If we detect that pcie has already started its boot when we are initializing the bmfw we previously only reset the primary chip. This happens to work on the p1x0 boards because the primary chip is the only asic, but on the p300 with two asics one asic wouldn't recover post tt-flash reset.