### PR TITLE
tenstorrent: bh_arc: add gddr throttler

### DIFF
--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/GALAXY/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/GALAXY/fw_table.txt
@@ -13,6 +13,7 @@ chip_limits {
   therm_trip_l1_limit: 0
   bus_peak_limit: 0
   frequency_margin: 0
+  gddr_thm_limit: 85
 }
 
 feature_enable {

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/ORION/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/ORION/fw_table.txt
@@ -14,6 +14,7 @@ chip_limits {
   therm_trip_l1_limit: 0
   bus_peak_limit: 0
   frequency_margin: 0
+  gddr_thm_limit: 85
 }
 
 feature_enable {

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P100/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P100/fw_table.txt
@@ -14,6 +14,7 @@ chip_limits {
   therm_trip_l1_limit: 0
   bus_peak_limit: 0
   frequency_margin: 0
+  gddr_thm_limit: 85
 }
 
 feature_enable {

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P100A/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P100A/fw_table.txt
@@ -14,6 +14,7 @@ chip_limits {
   therm_trip_l1_limit: 0
   bus_peak_limit: 0
   frequency_margin: 0
+  gddr_thm_limit: 85
 }
 
 feature_enable {

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P150A/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P150A/fw_table.txt
@@ -14,6 +14,7 @@ chip_limits {
   therm_trip_l1_limit: 0
   bus_peak_limit: 0
   frequency_margin: 0
+  gddr_thm_limit: 85
 }
 
 feature_enable {

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P150B/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P150B/fw_table.txt
@@ -14,6 +14,7 @@ chip_limits {
   therm_trip_l1_limit: 0
   bus_peak_limit: 0
   frequency_margin: 0
+  gddr_thm_limit: 85
 }
 
 feature_enable {

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P150C/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P150C/fw_table.txt
@@ -14,6 +14,7 @@ chip_limits {
   therm_trip_l1_limit: 0
   bus_peak_limit: 0
   frequency_margin: 0
+  gddr_thm_limit: 85
 }
 
 feature_enable {

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300A_L/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300A_L/fw_table.txt
@@ -14,6 +14,7 @@ chip_limits {
   therm_trip_l1_limit: 0
   bus_peak_limit: 0
   frequency_margin: 0
+  gddr_thm_limit: 85
 }
 
 feature_enable {

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300A_R/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300A_R/fw_table.txt
@@ -14,6 +14,7 @@ chip_limits {
   therm_trip_l1_limit: 0
   bus_peak_limit: 0
   frequency_margin: 0
+  gddr_thm_limit: 85
 }
 
 feature_enable {

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300B_L/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300B_L/fw_table.txt
@@ -14,6 +14,7 @@ chip_limits {
   therm_trip_l1_limit: 0
   bus_peak_limit: 0
   frequency_margin: 0
+  gddr_thm_limit: 85
 }
 
 feature_enable {

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300B_R/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300B_R/fw_table.txt
@@ -14,6 +14,7 @@ chip_limits {
   therm_trip_l1_limit: 0
   bus_peak_limit: 0
   frequency_margin: 0
+  gddr_thm_limit: 85
 }
 
 feature_enable {

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300C_L/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300C_L/fw_table.txt
@@ -14,6 +14,7 @@ chip_limits {
   therm_trip_l1_limit: 0
   bus_peak_limit: 0
   frequency_margin: 0
+  gddr_thm_limit: 85
 }
 
 feature_enable {

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300C_R/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300C_R/fw_table.txt
@@ -14,6 +14,7 @@ chip_limits {
   therm_trip_l1_limit: 0
   bus_peak_limit: 0
   frequency_margin: 0
+  gddr_thm_limit: 85
 }
 
 feature_enable {

--- a/lib/tenstorrent/bh_arc/aiclk_ppm.h
+++ b/lib/tenstorrent/bh_arc/aiclk_ppm.h
@@ -16,6 +16,7 @@ typedef enum {
 	kAiclkArbMaxThm,
 	kAiclkArbMaxBoardPwr,
 	kAiclkArbMaxVoltage,
+	kAiclkArbMaxGDDRThm,
 	kAiclkArbMaxCount,
 } AiclkArbMax;
 

--- a/lib/tenstorrent/bh_arc/spirom_protobufs/fw_table.proto
+++ b/lib/tenstorrent/bh_arc/spirom_protobufs/fw_table.proto
@@ -32,6 +32,7 @@ message FwTable {
     uint32 bus_peak_limit = 10;
     int32 frequency_margin = 11;
     uint32 asic_fmin = 12;
+    uint32 gddr_thm_limit = 13;
   }
 
   message FeatureEnable {

--- a/lib/tenstorrent/bh_arc/telemetry.h
+++ b/lib/tenstorrent/bh_arc/telemetry.h
@@ -65,6 +65,7 @@
 #define TAG_GDDR_4_5_CORR_ERRS   48
 #define TAG_GDDR_6_7_CORR_ERRS   49
 #define TAG_GDDR_UNCORR_ERRS     50
+#define TAG_MAX_GDDR_TEMP        51
 
 /* Enums are subject to updates */
 typedef enum {
@@ -132,6 +133,7 @@ typedef enum {
 	GDDR_2_3_TEMP,
 	GDDR_4_5_TEMP,
 	GDDR_6_7_TEMP,
+	MAX_GDDR_TEMP,
 
 	/* DDR Errors */
 	GDDR_0_1_CORR_ERRS,
@@ -146,6 +148,7 @@ typedef enum {
 void init_telemetry(uint32_t app_version);
 uint32_t ConvertFloatToTelemetry(float value);
 float ConvertTelemetryToFloat(int32_t value);
+int GetMaxGDDRTemp(void);
 void StartTelemetryTimer(void);
 void UpdateBmFwVersion(uint32_t bl_version, uint32_t app_version);
 void UpdateTelemetryNocTranslation(bool translation_enabled);

--- a/lib/tenstorrent/bh_arc/throttler.c
+++ b/lib/tenstorrent/bh_arc/throttler.c
@@ -21,6 +21,7 @@ typedef enum {
 	kThrottlerTDC,
 	kThrottlerThm,
 	kThrottlerBoardPwr,
+	kThrottlerGDDRThm,
 	kThrottlerCount,
 } ThrottlerId;
 
@@ -57,6 +58,10 @@ static const ThrottlerLimitRange throttler_limit_ranges[kThrottlerCount] = {
 			.min = 50,
 			.max = 600,
 		},
+	[kThrottlerGDDRThm] = {
+			.min = 50,
+			.max = 100,
+	}
 };
 
 typedef struct {
@@ -125,6 +130,15 @@ static Throttler throttler[kThrottlerCount] = {
 					.p_gain = 0.2,
 					.d_gain = 0,
 			}
+	},
+	[kThrottlerGDDRThm] = {
+			.arb_max = kAiclkArbMaxGDDRThm,
+			.params = {
+
+					.alpha_filter = 1.0,
+					.p_gain = 0.2,
+					.d_gain = 0,
+				},
 	}
 };
 
@@ -141,6 +155,7 @@ void InitThrottlers(void)
 	SetThrottlerLimit(kThrottlerTDC, get_fw_table()->chip_limits.tdc_limit);
 	SetThrottlerLimit(kThrottlerThm, get_fw_table()->chip_limits.thm_limit);
 	SetThrottlerLimit(kThrottlerBoardPwr, DEFAULT_BOARD_PWR_LIMIT);
+	SetThrottlerLimit(kThrottlerGDDRThm, get_fw_table()->chip_limits.gddr_thm_limit);
 }
 
 static void UpdateThrottler(ThrottlerId id, float value)
@@ -175,6 +190,7 @@ void CalculateThrottlers(void)
 	UpdateThrottler(kThrottlerTDC, telemetry_internal_data.vcore_current);
 	UpdateThrottler(kThrottlerThm, telemetry_internal_data.asic_temperature);
 	UpdateThrottler(kThrottlerBoardPwr, 12 * ConvertTelemetryToFloat(GetInputCurrent()));
+	UpdateThrottler(kThrottlerGDDRThm, GetMaxGDDRTemp());
 
 	for (ThrottlerId i = 0; i < kThrottlerCount; i++) {
 		UpdateThrottlerArb(i);


### PR DESCRIPTION
Add current maximum GDDR temperature to the telemetry table. Add a throttler based on GDDR temperature. Add GDDR thermal throttler limit to FW table.