### PR TITLE
scripts: tt_boot_fs.py: add ls subcommand to list boot fs contents

### DIFF
--- a/scripts/tt_boot_fs.py
+++ b/scripts/tt_boot_fs.py
@@ -205,7 +205,7 @@ class FsEntry:
     load_addr: int
     executable: bool
 
-    def descriptor(self) -> bytes:
+    def get_descriptor(self) -> tt_boot_fs_fd:
         image_tag = [0] * MAX_TAG_LEN
         for index, c in enumerate(self.tag):
             image_tag[index] = ord(c)
@@ -230,8 +230,10 @@ class FsEntry:
             ),
         )
         fd.fd_crc = cksum(bytes(fd))
+        return fd
 
-        return bytes(fd)
+    def descriptor(self) -> bytes:
+        return bytes(self.get_descriptor())
 
 
 @dataclass

--- a/scripts/tt_boot_fs.py
+++ b/scripts/tt_boot_fs.py
@@ -408,6 +408,9 @@ class BootFs:
 
         self._check_overlap()
 
+        # Add failover to self.entries for each retrieval later
+        self.entries["failover"] = failover
+
     def _check_overlap(self):
         tracker = RangeTracker(1)
         for write in self.writes:

--- a/scripts/tt_boot_fs.py
+++ b/scripts/tt_boot_fs.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import base64
 import ctypes
 from dataclasses import dataclass
 import logging
@@ -729,6 +730,65 @@ def fsck(path: Path, alignment: int = 0x1000) -> bool:
     return fs is not None
 
 
+def ls(
+    bootfs: Path, verbose: int = 0, output_json: bool = False, input_base64=False
+) -> bool:
+    fds = []
+
+    try:
+        data = (
+            base64.b16decode(open(bootfs, "r").read())
+            if input_base64
+            else open(bootfs, "rb").read()
+        )
+        fs = BootFs.from_binary(data)
+
+        if verbose >= 0 and not output_json:
+            hdr = "spi_addr\timage_tag\tsize   \tcopy_dest\tdata_crc\tflags   \tfd_crc"
+            print(hdr)
+            bar = "-" * (len(hdr.replace("\t", "")) + 8 * hdr.count("\t"))
+            print(bar)
+
+        order: list[(int, str)] = []
+        for tag, entry in fs.entries.items():
+            order.append((entry.spi_addr, tag))
+        order.sort(key=lambda x: x[0])
+        order = list(map(lambda x: x[1], order))
+
+        for tag in order:
+            entry = fs.entries[tag]
+            fd = entry.get_descriptor()
+
+            obj = {
+                "spi_addr": fd.spi_addr,
+                "image_tag": tag,
+                "size": len(entry.data),
+                "copy_dest": fd.copy_dest,
+                "data_crc": fd.data_crc,
+                "flags": fd.flags.val,
+                "fd_crc": fd.fd_crc,
+            }
+            fds.append(obj)
+
+            # if very quiet, then don't even print out data
+            if verbose <= -2:
+                continue
+
+            if not output_json:
+                print(
+                    f"{fd.spi_addr:08x}\t{tag:<8}\t{len(entry.data)}\t{fd.copy_dest:08x}\t"
+                    f"{fd.data_crc:08x}\t{fd.flags.val:08x}\t{fd.fd_crc:08x}"
+                )
+
+    except Exception as e:
+        _logger.error(f"Exception: {e}")
+
+    if fds and output_json and verbose >= 0:
+        print(json.dumps(fds))
+
+    return fds
+
+
 def mkbundle(
     output: Path, version: list[int], combine: list[Path], boot_fs: dict[str, Path]
 ):
@@ -834,6 +894,11 @@ def invoke_fwbundle(args):
     return os.EX_OK
 
 
+def invoke_ls(args):
+    ls(args.bootfs, args.verbose - args.quiet, args.json, args.base64)
+    return os.EX_OK
+
+
 def parse_args():
     parser = argparse.ArgumentParser(
         description="Utility to manage tt_boot_fs binaries", allow_abbrev=False
@@ -897,6 +962,26 @@ def parse_args():
         default=[],
     )
     bundle_parser.set_defaults(func=invoke_fwbundle)
+
+    ls_parser = subparsers.add_parser("ls", help="list tt_boot_fs contents")
+    ls_parser.add_argument("bootfs", metavar="FS", help="filesystem to list", type=Path)
+    ls_parser.add_argument(
+        "-b",
+        "--base64",
+        help="input is base64-encoded",
+        default=False,
+        action="store_true",
+    )
+    ls_parser.add_argument(
+        "-j", "--json", help="output JSON", default=False, action="store_true"
+    )
+    ls_parser.add_argument(
+        "-q", "--quiet", help="decrease verbosity", default=0, action="count"
+    )
+    ls_parser.add_argument(
+        "-v", "--verbose", help="increase verbosity", default=0, action="count"
+    )
+    ls_parser.set_defaults(func=invoke_ls)
 
     # Parse arguments
     args = parser.parse_args()

--- a/tests/lib/tenstorrent/tt_boot_fs/pytest/test-tt-boot-fs.py
+++ b/tests/lib/tenstorrent/tt_boot_fs/pytest/test-tt-boot-fs.py
@@ -148,8 +148,8 @@ def gen_released_image(tmp_path: Path):
         # Test on a recent experimental release (note: stable release does not have a recovery image)
         URL = (
             "https://github.com/tenstorrent/tt-firmware/raw/"
-            "9f2173161f11599411619cec25e6425cf56a7d59"
-            "/experiments/fw_pack-80.14.2.0.fwbundle"
+            "7bc0a90226e684962fb039cf26580356d7646574"
+            "/fw_pack-80.15.0.0.fwbundle"
         )
         targz = tmp_path / "fw_pack.tar.gz"
         urlretrieve(URL, targz)

--- a/tests/lib/tenstorrent/tt_boot_fs/pytest/test-tt-boot-fs.py
+++ b/tests/lib/tenstorrent/tt_boot_fs/pytest/test-tt-boot-fs.py
@@ -171,7 +171,7 @@ def gen_released_image(tmp_path: Path):
 
 
 def get_released_image_path(tmp_path: Path):
-    _, pth = gen_test_image(tmp_path)
+    _, pth = gen_released_image(tmp_path)
     return pth
 
 

--- a/tests/lib/tenstorrent/tt_boot_fs/pytest/test-tt-boot-fs.py
+++ b/tests/lib/tenstorrent/tt_boot_fs/pytest/test-tt-boot-fs.py
@@ -252,3 +252,132 @@ def test_tt_boot_fs_cksum():
 
     for it in items:
         assert tt_boot_fs.cksum(it[1]) == it[0]
+
+
+def test_tt_boot_fs_ls(tmp_path: Path):
+    """
+    Test the ability to list a tt_boot_fs.
+    """
+
+    # Note: values are specific to fw_pack-80.15.0.0.fwbundle due to get_released_image_path()
+    expected_fds = [
+        {
+            "spi_addr": 81920,
+            "image_tag": "cmfwcfg",
+            "size": 56,
+            "copy_dest": 0,
+            "data_crc": 2158370831,
+            "flags": 56,
+            "fd_crc": 4168430605,
+        },
+        {
+            "spi_addr": 86016,
+            "image_tag": "cmfw",
+            "size": 86600,
+            "copy_dest": 268435456,
+            "data_crc": 1374720981,
+            "flags": 33641032,
+            "fd_crc": 3680084864,
+        },
+        {
+            "spi_addr": 176128,
+            "image_tag": "ethfwcfg",
+            "size": 512,
+            "copy_dest": 0,
+            "data_crc": 2352493,
+            "flags": 512,
+            "fd_crc": 3455414089,
+        },
+        {
+            "spi_addr": 180224,
+            "image_tag": "ethfw",
+            "size": 34304,
+            "copy_dest": 0,
+            "data_crc": 433295191,
+            "flags": 34304,
+            "fd_crc": 2151631411,
+        },
+        {
+            "spi_addr": 217088,
+            "image_tag": "memfwcfg",
+            "size": 256,
+            "copy_dest": 0,
+            "data_crc": 15943,
+            "flags": 256,
+            "fd_crc": 3453442091,
+        },
+        {
+            "spi_addr": 221184,
+            "image_tag": "memfw",
+            "size": 10032,
+            "copy_dest": 0,
+            "data_crc": 3642299916,
+            "flags": 10032,
+            "fd_crc": 1066009376,
+        },
+        {
+            "spi_addr": 233472,
+            "image_tag": "ethsdreg",
+            "size": 1152,
+            "copy_dest": 0,
+            "data_crc": 897437643,
+            "flags": 1152,
+            "fd_crc": 273632020,
+        },
+        {
+            "spi_addr": 237568,
+            "image_tag": "ethsdfw",
+            "size": 19508,
+            "copy_dest": 0,
+            "data_crc": 3168980852,
+            "flags": 19508,
+            "fd_crc": 818321009,
+        },
+        {
+            "spi_addr": 258048,
+            "image_tag": "bmfw",
+            "size": 35744,
+            "copy_dest": 0,
+            "data_crc": 2928587200,
+            "flags": 35744,
+            "fd_crc": 637115074,
+        },
+        {
+            "spi_addr": 294912,
+            "image_tag": "flshinfo",
+            "size": 4,
+            "copy_dest": 0,
+            "data_crc": 50462976,
+            "flags": 4,
+            "fd_crc": 3672136659,
+        },
+        {
+            "spi_addr": 299008,
+            "image_tag": "failover",
+            "size": 65828,
+            "copy_dest": 268435456,
+            "data_crc": 2239637331,
+            "flags": 33620260,
+            "fd_crc": 1985122380,
+        },
+        {
+            "spi_addr": 16773120,
+            "image_tag": "boardcfg",
+            "size": 0,
+            "copy_dest": 0,
+            "data_crc": 0,
+            "flags": 0,
+            "fd_crc": 3670524614,
+        },
+    ]
+    actual_fds = tt_boot_fs.ls(
+        get_released_image_path(tmp_path),
+        verbose=-2,
+        output_json=True,
+        input_base64=False,
+    )
+    assert actual_fds == expected_fds, "tt_boot_fs.ls() failed with valid image"
+
+    assert not tt_boot_fs.ls(
+        get_corrupted_test_image_path(tmp_path)
+    ), "tt_boot_fs.ls() succeeded with invalid image"


### PR DESCRIPTION
* scripts: tt_boot_fs.py: add `FsEntry.get_descriptor()`
* scripts: tt_boot_fs.py: add `BootFs.check_entry()`
* scripts: tt_boot_fs.py: add failover to `BootFs.entries`
* tests: tt_boot_fs: choose non-corrupt `fw_pack-80.15.0.0.fwbundle`
* tests: tt_boot_fs: correct copy-paste error
* scripts: tt_boot_fs.py: add `ls` subcommand to list fs contents
* tests: tt_boot_fs: add test for `ls` subcommand

Testing Done (aside from added pytest):
```shell
URL="https://github.com/tenstorrent/tt-firmware/raw/7bc0a90226e684962fb039cf26580356d7646574/fw_pack-80.15.0.0.fwbundle"
wget -O /tmp/fw_pack.tar.gz "$URL"
mkdir -p /tmp/fw_pack
tar xpvzf /tmp/fw_pack.tar.gz -C /tmp/fw_pack
```

Copy-paste this into `python3 -i`
```python
import base64

data = None
with open('/tmp/fw_pack/P100-1/image.bin', 'r') as f:
    data = base64.b16decode(f.read())

with open('/tmp/image.bin', 'wb') as f:
    f.write(data)
```

Human-readable (sort of?) output:
```shell
./scripts/tt_boot_fs.py ls /tmp/image.bin 
spi_addr        image_tag       size    copy_dest       data_crc        flags           fd_crc
-------------------------------------------------------------------------------------------------------
00014000        cmfwcfg         56      00000000        80a6200f        00000038        f875340d
00015000        cmfw            86600   10000000        51f093d5        02015248        db59a380
0002b000        ethfwcfg        512     00000000        0023e56d        00000200        cdf56f49
0002c000        ethfw           34304   00000000        19d38f57        00008600        803f4a33
00035000        memfwcfg        256     00000000        00003e47        00000100        cdd7582b
00036000        memfw           10032   00000000        d919160c        00002730        3f8a0320
00039000        ethsdreg        1152    00000000        357dcfcb        00000480        104f4b14
0003a000        ethsdfw         19508   00000000        bce2cf74        00004c34        30c69671
0003f000        bmfw            35744   00000000        ae8eb1c0        00008ba0        25f99ac2
00048000        flshinfo        4       00000000        03020100        00000004        dae05bd3
00049000        failover        65828   10000000        857e2753        02010124        7652904c
00fff000        boardcfg        0       00000000        00000000        00000000        dac7c2c6
```

Or with JSON output and base64 encoded input:
```shell
./scripts/tt_boot_fs.py ls -j -b /tmp/fw_pack/P100-1/image.bin | jq .
[
  {
    "spi_addr": 81920,
    "image_tag": "cmfwcfg",
    "size": 56,
    "copy_dest": 0,
    "data_crc": 2158370831,
    "flags": 56,
    "fd_crc": 4168430605
  },
  {
    "spi_addr": 86016,
    "image_tag": "cmfw",
    "size": 86600,
    "copy_dest": 268435456,
    "data_crc": 1374720981,
    "flags": 33641032,
    "fd_crc": 3680084864
  },
  {
    "spi_addr": 176128,
    "image_tag": "ethfwcfg",
    "size": 512,
    "copy_dest": 0,
    "data_crc": 2352493,
    "flags": 512,
    "fd_crc": 3455414089
  },
  {
    "spi_addr": 180224,
    "image_tag": "ethfw",
    "size": 34304,
    "copy_dest": 0,
    "data_crc": 433295191,
    "flags": 34304,
    "fd_crc": 2151631411
  },
  {
    "spi_addr": 217088,
    "image_tag": "memfwcfg",
    "size": 256,
    "copy_dest": 0,
    "data_crc": 15943,
    "flags": 256,
    "fd_crc": 3453442091
  },
  {
    "spi_addr": 221184,
    "image_tag": "memfw",
    "size": 10032,
    "copy_dest": 0,
    "data_crc": 3642299916,
    "flags": 10032,
    "fd_crc": 1066009376
  },
  {
    "spi_addr": 233472,
    "image_tag": "ethsdreg",
    "size": 1152,
    "copy_dest": 0,
    "data_crc": 897437643,
    "flags": 1152,
    "fd_crc": 273632020
  },
  {
    "spi_addr": 237568,
    "image_tag": "ethsdfw",
    "size": 19508,
    "copy_dest": 0,
    "data_crc": 3168980852,
    "flags": 19508,
    "fd_crc": 818321009
  },
  {
    "spi_addr": 258048,
    "image_tag": "bmfw",
    "size": 35744,
    "copy_dest": 0,
    "data_crc": 2928587200,
    "flags": 35744,
    "fd_crc": 637115074
  },
  {
    "spi_addr": 294912,
    "image_tag": "flshinfo",
    "size": 4,
    "copy_dest": 0,
    "data_crc": 50462976,
    "flags": 4,
    "fd_crc": 3672136659
  },
  {
    "spi_addr": 299008,
    "image_tag": "failover",
    "size": 65828,
    "copy_dest": 268435456,
    "data_crc": 2239637331,
    "flags": 33620260,
    "fd_crc": 1985122380
  },
  {
    "spi_addr": 16773120,
    "image_tag": "boardcfg",
    "size": 0,
    "copy_dest": 0,
    "data_crc": 0,
    "flags": 0,
    "fd_crc": 3670524614
  }
]
```

Fixes #94 
Closes #89