### PR TITLE
ci: allow forks to run their own CI

### DIFF
--- a/.github/workflows/hardware-long.yml
+++ b/.github/workflows/hardware-long.yml
@@ -7,7 +7,6 @@ on:
 
 jobs:
   hardware-metal-test:
-    if: github.repository_owner == 'tenstorrent'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/hardware-smoke.yml
+++ b/.github/workflows/hardware-smoke.yml
@@ -16,7 +16,6 @@ on:
 
 jobs:
   hardware-smoke-test:
-    if: github.repository_owner == 'tenstorrent'
     strategy:
       fail-fast: false
       matrix:
@@ -128,7 +127,6 @@ jobs:
             zephyr/twister-smc-smoke/twister.json
 
   smoke-e2e-test:
-    if: github.repository_owner == 'tenstorrent'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
If a customer buys a Tenstorrent card, they should be able to set up their own CI infrastructure.

Approval for workflow runs is already restricted via settings.

```
Settings -> Actions -> General ->
Approval for running fork pull requests... from contributors
-> Require approval for all external contributors
```

Secrets are per-organization / repo