### PR TITLE
app: bmc + smc: print the tenstorrent git revision along with the boot banner

### DIFF
--- a/app/bmc/prj.conf
+++ b/app/bmc/prj.conf
@@ -32,3 +32,9 @@ CONFIG_REBOOT=y
 # We always expect MCUBoot to be the primary bootloader
 CONFIG_BOOTLOADER_MCUBOOT=y
 CONFIG_MCUBOOT_SIGNATURE_KEY_FILE="bootloader/mcuboot/root-rsa-2048.pem"
+
+# Disable printing the default Zephyr boot banner
+CONFIG_BOOT_BANNER=n
+# Print the Tenstorrent boot banner + git version on startup
+CONFIG_TT_BOOT_BANNER=y
+CONFIG_TT_BOOT_BANNER_GIT_VERSION=y

--- a/app/smc/prj.conf
+++ b/app/smc/prj.conf
@@ -31,3 +31,9 @@ CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2048
 
 # perform driver-library fw and hw init prior to the application
 CONFIG_TT_BH_ARC_SYSINIT=y
+
+# Disable printing the default Zephyr boot banner
+CONFIG_BOOT_BANNER=n
+# Print the Tenstorrent boot banner + git version on startup
+CONFIG_TT_BOOT_BANNER=y
+CONFIG_TT_BOOT_BANNER_GIT_VERSION=y

--- a/app/smc/vuart.conf
+++ b/app/smc/vuart.conf
@@ -7,7 +7,3 @@ CONFIG_RAM_CONSOLE=n
 # disable RTT console so that we can use vuart
 CONFIG_USE_SEGGER_RTT=n
 CONFIG_RTT_CONSOLE=n
-
-# print a nice welcome message
-CONFIG_BOOT_BANNER=n
-CONFIG_TT_BOOT_BANNER=y

--- a/lib/tenstorrent/banner/CMakeLists.txt
+++ b/lib/tenstorrent/banner/CMakeLists.txt
@@ -2,3 +2,11 @@
 
 zephyr_library()
 zephyr_library_sources(tt_banner.c)
+
+if(CONFIG_TT_BOOT_BANNER_GIT_VERSION)
+
+include(${ZEPHYR_BASE}/cmake/modules/git.cmake)
+git_describe(. TT_GIT_VERSION)
+zephyr_library_compile_definitions(TT_GIT_VERSION="${TT_GIT_VERSION}")
+
+endif()

--- a/lib/tenstorrent/banner/Kconfig
+++ b/lib/tenstorrent/banner/Kconfig
@@ -8,3 +8,14 @@ config TT_BOOT_BANNER
 	select EARLY_CONSOLE
 	help
 	  Print Tenstorrent's boot banner instead of Zephyr's boot banner.
+
+if TT_BOOT_BANNER
+
+config TT_BOOT_BANNER_GIT_VERSION
+	bool "Print the git revision when displaying the boot banner"
+	help
+	  Print the git revision when displaying the boot banner.
+
+	  See ZEPHYR_BASE/cmake/modules/git.cmake for more information.
+
+endif

--- a/lib/tenstorrent/banner/tt_banner.c
+++ b/lib/tenstorrent/banner/tt_banner.c
@@ -8,6 +8,11 @@
 #include <zephyr/kernel.h>
 #include <version.h>
 
+#ifndef CONFIG_TT_BOOT_BANNER_GIT_VERSION
+/* prevent compiler warning */
+#define TT_GIT_VERSION ""
+#endif
+
 static int tt_boot_banner(void)
 {
 	/* clang-format off */
@@ -43,6 +48,10 @@ static int tt_boot_banner(void)
 
 	printk(logo);
 	printk("*** Booting " CONFIG_BOARD " with Zephyr OS " STRINGIFY(BUILD_VERSION) " ***\n");
+
+	if (IS_ENABLED(CONFIG_TT_BOOT_BANNER_GIT_VERSION)) {
+		printk("*** TT_GIT_VERSION " TT_GIT_VERSION " ***\n");
+	}
 
 	return 0;
 }


### PR DESCRIPTION
Print the git revision in the format

```
*** TT_GIT_VERSION b7d6567 ***
```

when `CONFIG_TT_BOOT_BANNER_GIT_VERSION` is enabled.
