### PR TITLE
bh_arc: add board power limit to telemetry table

### DIFF
--- a/lib/tenstorrent/bh_arc/telemetry.c
+++ b/lib/tenstorrent/bh_arc/telemetry.c
@@ -322,7 +322,8 @@ static void update_tag_table(void)
 	tag_table[48] = (struct telemetry_entry){TAG_GDDR_UNCORR_ERRS, GDDR_UNCORR_ERRS};
 	tag_table[49] = (struct telemetry_entry){TAG_MAX_GDDR_TEMP, MAX_GDDR_TEMP};
 	tag_table[50] = (struct telemetry_entry){TAG_ASIC_LOCATION, ASIC_LOCATION};
-	tag_table[51] = (struct telemetry_entry){TAG_TELEM_ENUM_COUNT, TELEM_ENUM_COUNT};
+	tag_table[51] = (struct telemetry_entry){TAG_BOARD_PWR_LIMIT, BOARD_PWR_LIMIT};
+	tag_table[52] = (struct telemetry_entry){TAG_TELEM_ENUM_COUNT, TELEM_ENUM_COUNT};
 }
 
 /* Handler functions for zephyr timer and worker objects */
@@ -378,4 +379,9 @@ void UpdateTelemetryNocTranslation(bool translation_enabled)
 {
 	/* Note that this may be called before init_telemetry. */
 	telemetry[NOC_TRANSLATION] = translation_enabled;
+}
+
+void UpdateTelemetryBoardPwrLimit(uint32_t pwr_limit)
+{
+	telemetry[BOARD_PWR_LIMIT] = pwr_limit;
 }

--- a/lib/tenstorrent/bh_arc/telemetry.h
+++ b/lib/tenstorrent/bh_arc/telemetry.h
@@ -67,6 +67,7 @@
 #define TAG_GDDR_UNCORR_ERRS     50
 #define TAG_MAX_GDDR_TEMP        51
 #define TAG_ASIC_LOCATION        52
+#define TAG_BOARD_PWR_LIMIT      53
 
 /* Enums are subject to updates */
 typedef enum {
@@ -120,6 +121,7 @@ typedef enum {
 	FAN_RPM,
 	TIMER_HEARTBEAT, /* Incremented every time the timer is called */
 	INPUT_CURRENT,
+	BOARD_PWR_LIMIT,
 
 	/* Tile enablement/harvesting information */
 	ENABLED_TENSIX_COL,
@@ -155,5 +157,6 @@ int GetMaxGDDRTemp(void);
 void StartTelemetryTimer(void);
 void UpdateBmFwVersion(uint32_t bl_version, uint32_t app_version);
 void UpdateTelemetryNocTranslation(bool translation_enabled);
+void UpdateTelemetryBoardPwrLimit(uint32_t pwr_limit);
 
 #endif

--- a/lib/tenstorrent/bh_arc/throttler.c
+++ b/lib/tenstorrent/bh_arc/throttler.c
@@ -206,6 +206,7 @@ int32_t Bm2CmSetBoardPwrLimit(const uint8_t *data, uint8_t size)
 	uint16_t pwr_limit = *(uint16_t *)data;
 
 	SetThrottlerLimit(kThrottlerBoardPwr, pwr_limit);
+	UpdateTelemetryBoardPwrLimit(pwr_limit);
 
 	return 0;
 }


### PR DESCRIPTION
Add BOARD_PWR_LIMIT telemetry field.

Whenever board power limit is received from BMC FW, update it in the telemetry table.