### PR TITLE
Send board input power to chip instead of board input current

### DIFF
--- a/app/bmc/src/main.c
+++ b/app/bmc/src/main.c
@@ -118,18 +118,17 @@ void process_cm2bm_message(struct bh_chip *chip)
 	}
 }
 
-void ina228_current_update(void)
+void ina228_pwr_update(void)
 {
-	struct sensor_value current_sensor_val;
+	struct sensor_value sensor_val;
 
-	sensor_sample_fetch_chan(ina228, SENSOR_CHAN_CURRENT);
-	sensor_channel_get(ina228, SENSOR_CHAN_CURRENT, &current_sensor_val);
+	sensor_sample_fetch_chan(ina228, SENSOR_CHAN_POWER);
+	sensor_channel_get(ina228, SENSOR_CHAN_POWER, &sensor_val);
 
-	int32_t current =
-		(current_sensor_val.val1 << 16) + (current_sensor_val.val2 * 65536ULL) / 1000000ULL;
+	int32_t power = (sensor_val.val1 << 16) + (sensor_val.val2 * 65536ULL) / 1000000ULL;
 
 	ARRAY_FOR_EACH_PTR(BH_CHIPS, chip) {
-		bh_chip_set_input_current(chip, &current);
+		bh_chip_set_input_pwr(chip, &power);
 	}
 }
 
@@ -313,12 +312,12 @@ int main(void)
 				/* TODO: we don't have to read this per chip */
 				uint16_t max_pwr = detect_max_pwr();
 
-				bh_chip_set_board_pwr_lim(chip, max_pwr);
+				bh_chip_set_input_pwr_lim(chip, max_pwr);
 			}
 		}
 
 		if (IS_ENABLED(CONFIG_INA228)) {
-			ina228_current_update();
+			ina228_pwr_update();
 		}
 
 		if (IS_ENABLED(CONFIG_TT_FAN_CTRL)) {

--- a/include/tenstorrent/bh_chip.h
+++ b/include/tenstorrent/bh_chip.h
@@ -118,8 +118,9 @@ void bh_chip_cancel_bus_transfer_clear(struct bh_chip *chip);
 cm2bmMessageRet bh_chip_get_cm2bm_message(struct bh_chip *chip);
 int bh_chip_set_static_info(struct bh_chip *chip, bmStaticInfo *info);
 int bh_chip_set_input_current(struct bh_chip *chip, int32_t *current);
+int bh_chip_set_input_pwr(struct bh_chip *chip, uint32_t *power);
+int bh_chip_set_input_pwr_lim(struct bh_chip *chip, uint16_t max_pwr);
 int bh_chip_set_fan_rpm(struct bh_chip *chip, uint16_t rpm);
-int bh_chip_set_board_pwr_lim(struct bh_chip *chip, uint16_t max_pwr);
 
 void bh_chip_assert_asic_reset(const struct bh_chip *chip);
 void bh_chip_deassert_asic_reset(const struct bh_chip *chip);

--- a/lib/tenstorrent/bh_arc/cm2bm_msg.c
+++ b/lib/tenstorrent/bh_arc/cm2bm_msg.c
@@ -29,6 +29,7 @@ typedef struct {
 static Cm2BmMsgState cm2bm_msg_state;
 static bool bmfw_ping_valid;
 static int32_t current;
+static uint32_t power;
 K_MSGQ_DEFINE(cm2bm_msg_q, sizeof(Cm2BmMsg), 4, _Alignof(Cm2BmMsg));
 
 int32_t EnqueueCm2BmMsg(const Cm2BmMsg *msg)
@@ -233,10 +234,27 @@ int32_t Bm2CmSendCurrentHandler(const uint8_t *data, uint8_t size)
 	return 0;
 }
 
+int32_t Bm2CmSendPwrHandler(const uint8_t *data, uint8_t size)
+{
+	if (size != 4) {
+		return -1;
+	}
+
+	power = *(uint32_t *)data;
+
+	return 0;
+}
+
+
 /* TODO: Put these somewhere else? */
 int32_t GetInputCurrent(void)
 {
 	return current;
+}
+
+uint32_t GetInputPower(void)
+{
+	return power;
 }
 
 int32_t Bm2CmSendFanRPMHandler(const uint8_t *data, uint8_t size)

--- a/lib/tenstorrent/bh_arc/cm2bm_msg.h
+++ b/lib/tenstorrent/bh_arc/cm2bm_msg.h
@@ -51,7 +51,9 @@ typedef struct bmStaticInfo {
 int32_t Bm2CmSendDataHandler(const uint8_t *data, uint8_t size);
 int32_t Bm2CmPingHandler(const uint8_t *data, uint8_t size);
 int32_t Bm2CmSendCurrentHandler(const uint8_t *data, uint8_t size);
+int32_t Bm2CmSendPwrHandler(const uint8_t *data, uint8_t size);
 int32_t GetInputCurrent(void);
+uint32_t GetInputPower(void);
 int32_t Bm2CmSendFanRPMHandler(const uint8_t *data, uint8_t size);
 
 #endif

--- a/lib/tenstorrent/bh_arc/smbus_target.c
+++ b/lib/tenstorrent/bh_arc/smbus_target.c
@@ -198,6 +198,13 @@ static SmbusConfig smbus_config = {
 			  .handler = {
 					  .rcv_handler = &Bm2CmSetBoardPwrLimit
 			  }},
+		[0x25] = {
+			.valid = 1,
+			.trans_type = kSmbusTransBlockWrite,
+			.expected_blocksize = 4,
+			.handler = {
+					.rcv_handler = &Bm2CmSendPwrHandler
+			}},
 #endif
 		[0xD8] = {
 

--- a/lib/tenstorrent/bh_arc/telemetry.c
+++ b/lib/tenstorrent/bh_arc/telemetry.c
@@ -110,7 +110,7 @@ static void UpdateGddrTelemetry(void)
 			 * [15] - Error GDDR 7
 			 */
 			telemetry[GDDR_STATUS] |= (gddr_telemetry.training_complete << (i * 2)) |
-				(gddr_telemetry.gddr_error << (i * 2 + 1));
+						  (gddr_telemetry.gddr_error << (i * 2 + 1));
 
 			/* DDR_x_y_TEMP:
 			 * [31:24] GDDR y top
@@ -146,17 +146,15 @@ static void UpdateGddrTelemetry(void)
 				(gddr_telemetry.uncorr_edc_wr_error << (i * 2 + 1));
 			/* GDDR speed - in Mbps */
 			telemetry[GDDR_SPEED] = gddr_telemetry.dram_speed;
-
 		}
 	}
 }
 
 static void write_static_telemetry(uint32_t app_version)
 {
-	telemetry_table.version =
-		TELEMETRY_VERSION; /* v0.1.0 - Only update when redefining the
-				    * meaning of an existing tag
-				    */
+	telemetry_table.version = TELEMETRY_VERSION;    /* v0.1.0 - Only update when redefining the
+							 * meaning of an existing tag
+							 */
 	telemetry_table.entry_count = TELEM_ENUM_COUNT; /* Runtime count of telemetry entries */
 
 	/* Get the static values */
@@ -237,7 +235,9 @@ static void update_telemetry(void)
 	telemetry[FAN_RPM] = GetFanRPM();     /* Actual fan RPM */
 	UpdateGddrTelemetry();
 	telemetry[INPUT_CURRENT] =
-		GetInputCurrent();    /* Input current - reported in A in signed int 16.16 format */
+		GetInputCurrent(); /* Input current - reported in A in signed int 16.16 format */
+	telemetry[INPUT_POWER] =
+		GetInputPower();      /* Input power - reported in W in unsigned int 16.16 format */
 	telemetry[TIMER_HEARTBEAT]++; /* Incremented every time the timer is called */
 	SetPostCode(POST_CODE_SRC_CMFW, POST_CODE_TELEMETRY_END);
 }
@@ -293,7 +293,8 @@ static void update_tag_table(void)
 	tag_table[46] = (struct telemetry_entry){TAG_GDDR_4_5_CORR_ERRS, GDDR_4_5_CORR_ERRS};
 	tag_table[47] = (struct telemetry_entry){TAG_GDDR_6_7_CORR_ERRS, GDDR_6_7_CORR_ERRS};
 	tag_table[48] = (struct telemetry_entry){TAG_GDDR_UNCORR_ERRS, GDDR_UNCORR_ERRS};
-	tag_table[49] = (struct telemetry_entry){TAG_TELEM_ENUM_COUNT, TELEM_ENUM_COUNT};
+	tag_table[49] = (struct telemetry_entry){TAG_INPUT_POWER, INPUT_POWER};
+	tag_table[50] = (struct telemetry_entry){TAG_TELEM_ENUM_COUNT, TELEM_ENUM_COUNT};
 }
 
 /* Handler functions for zephyr timer and worker objects */

--- a/lib/tenstorrent/bh_arc/telemetry.h
+++ b/lib/tenstorrent/bh_arc/telemetry.h
@@ -65,6 +65,7 @@
 #define TAG_GDDR_4_5_CORR_ERRS   48
 #define TAG_GDDR_6_7_CORR_ERRS   49
 #define TAG_GDDR_UNCORR_ERRS     50
+#define TAG_INPUT_POWER			 51
 
 /* Enums are subject to updates */
 typedef enum {
@@ -114,10 +115,13 @@ typedef enum {
 	L2CPU_FW_VERSION,
 
 	/* MISC */
+	TIMER_HEARTBEAT, /* Incremented every time the timer is called */
+
+	/* Board telemetry */
 	FAN_SPEED,
 	FAN_RPM,
-	TIMER_HEARTBEAT, /* Incremented every time the timer is called */
 	INPUT_CURRENT,
+	INPUT_POWER,
 
 	/* Tile enablement/harvesting information */
 	ENABLED_TENSIX_COL,

--- a/lib/tenstorrent/bh_arc/throttler.c
+++ b/lib/tenstorrent/bh_arc/throttler.c
@@ -174,7 +174,7 @@ void CalculateThrottlers(void)
 	UpdateThrottler(kThrottlerFastTDC, telemetry_internal_data.vcore_current);
 	UpdateThrottler(kThrottlerTDC, telemetry_internal_data.vcore_current);
 	UpdateThrottler(kThrottlerThm, telemetry_internal_data.asic_temperature);
-	UpdateThrottler(kThrottlerBoardPwr, 12 * ConvertTelemetryToFloat(GetInputCurrent()));
+	UpdateThrottler(kThrottlerBoardPwr, ConvertTelemetryToFloat(GetInputPower()));
 
 	for (ThrottlerId i = 0; i < kThrottlerCount; i++) {
 		UpdateThrottlerArb(i);

--- a/lib/tenstorrent/bh_chip/bh_chip.c
+++ b/lib/tenstorrent/bh_chip/bh_chip.c
@@ -73,23 +73,35 @@ int bh_chip_set_input_current(struct bh_chip *chip, int32_t *current)
 
 	return ret;
 }
+
+int bh_chip_set_input_pwr(struct bh_chip *chip, uint32_t *power)
+{
+	int ret;
+
+	k_mutex_lock(&chip->data.reset_lock, K_FOREVER);
+	ret = bharc_smbus_block_write(&chip->config.arc, 0x25, 4, (uint8_t *)power);
+	k_mutex_unlock(&chip->data.reset_lock);
+
+	return ret;
+}
+
+int bh_chip_set_input_pwr_lim(struct bh_chip *chip, uint16_t max_pwr)
+{
+	int ret;
+
+	k_mutex_lock(&chip->data.reset_lock, K_FOREVER);
+	ret = bharc_smbus_word_data_write(&chip->config.arc, 0x24, max_pwr);
+	k_mutex_unlock(&chip->data.reset_lock);
+
+	return ret;
+}
+
 int bh_chip_set_fan_rpm(struct bh_chip *chip, uint16_t rpm)
 {
 	int ret;
 
 	k_mutex_lock(&chip->data.reset_lock, K_FOREVER);
 	ret = bharc_smbus_word_data_write(&chip->config.arc, 0x23, rpm);
-	k_mutex_unlock(&chip->data.reset_lock);
-
-	return ret;
-}
-
-int bh_chip_set_board_pwr_lim(struct bh_chip *chip, uint16_t max_pwr)
-{
-	int ret;
-
-	k_mutex_lock(&chip->data.reset_lock, K_FOREVER);
-	ret = bharc_smbus_word_data_write(&chip->config.arc, 0x24, max_pwr);
 	k_mutex_unlock(&chip->data.reset_lock);
 
 	return ret;


### PR DESCRIPTION
Enable input power reading in BMC FW using the INA228. Send input power to chip instead of input current. Add input power to the telemetry table.

Since SMC FW only uses current to calculate board input power for throttling, we can just send power directly instead. If needed, we could continue to send current. Nothing else uses it, but there is a telemetry field for it.