### PR TITLE
ci: p100a: temporarily disable p100a tests due to jtag reset issues

### DIFF
--- a/.github/workflows/hardware-long.yml
+++ b/.github/workflows/hardware-long.yml
@@ -11,13 +11,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Temporarily disable P100A tests due to reset issue #101
+        # Note: YAMLLint complains about 'comment not indented like content', so removed instead
         config:
           - board: p100
             runs-on:
               - yyz-zephyr-lab-p100
-          - board: p100a
-            runs-on:
-              - yyz-zephyr-lab-p100a
     runs-on: ${{ matrix.config.runs-on }}
     env:
       "ZEPHYR_SDK_INSTALL_DIR": /opt/toolchains

--- a/.github/workflows/hardware-smoke.yml
+++ b/.github/workflows/hardware-smoke.yml
@@ -132,13 +132,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Temporarily disable P100A tests due to reset issue #101
+        # Note: YAMLLint complains about 'comment not indented like content', so removed instead
         config:
           - board: p100
             runs-on:
               - yyz-zephyr-lab-p100
-          - board: p100a
-            runs-on:
-              - yyz-zephyr-lab-p100a
     runs-on: ${{ matrix.config.runs-on }}
     env:
       "ZEPHYR_SDK_INSTALL_DIR": /opt/toolchains


### PR DESCRIPTION
Temporarily disable P100A tests due to lack of JTAG SRST signal.

This affects P150A and other platforms as well. P100 is the only platform not affected.

The tests will be re-enabled when issue https://github.com/tenstorrent/tt-zephyr-platforms/issues/101 is fixed. For any bugfixes targeting P100A+, a "Testing Done" section will need to be included with the PR description, as we are in feature freeze / stabilization.