### PR TITLE
ci: workflows: checkout github.ref instead of default SHA

### DIFF
--- a/.github/workflows/build-fw.yml
+++ b/.github/workflows/build-fw.yml
@@ -37,6 +37,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           path: tt-zephyr-platforms
+          ref: ${{ github.ref }}
       - uses: ./tt-zephyr-platforms/.github/workflows/prepare-zephyr
         with:
           app-path: tt-zephyr-platforms
@@ -108,6 +109,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           path: tt-zephyr-platforms
+          ref: ${{ github.ref }}
       - uses: ./tt-zephyr-platforms/.github/workflows/prepare-zephyr
         with:
           app-path: tt-zephyr-platforms

--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.ref }}
       - name: Run the script
         run: |
           gcc -Iinclude -O0 -g -Wall -Wextra -Werror -std=gnu11 -o tt-console \

--- a/.github/workflows/copyright-check.yml
+++ b/.github/workflows/copyright-check.yml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.ref }}
       - name: Run the script
         run: |
           ./scripts/check-copyright.py

--- a/.github/workflows/hardware-long.yml
+++ b/.github/workflows/hardware-long.yml
@@ -35,6 +35,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: tt-zephyr-platforms
+          ref: ${{ github.ref }}
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/hardware-smoke.yml
+++ b/.github/workflows/hardware-smoke.yml
@@ -39,6 +39,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           path: tt-zephyr-platforms
+          ref: ${{ github.ref }}
       - uses: ./tt-zephyr-platforms/.github/workflows/prepare-zephyr
         with:
           app-path: tt-zephyr-platforms
@@ -152,6 +153,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           path: tt-zephyr-platforms
+          ref: ${{ github.ref }}
       - uses: ./tt-zephyr-platforms/.github/workflows/prepare-zephyr
         with:
           app-path: tt-zephyr-platforms

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.ref }}
       - name: Scan the code
         id: scancode
         uses: zephyrproject-rtos/action_scancode@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           path: tt-zephyr-platforms
+          ref: ${{ github.ref }}
       - uses: ./tt-zephyr-platforms/.github/workflows/prepare-zephyr
         with:
           app-path: tt-zephyr-platforms

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -26,6 +26,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           path: tt-zephyr-platforms
+          ref: ${{ github.ref }}
       - uses: ./tt-zephyr-platforms/.github/workflows/prepare-zephyr
         with:
           app-path: tt-zephyr-platforms
@@ -70,6 +71,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           path: tt-zephyr-platforms
+          ref: ${{ github.ref }}
       - uses: ./tt-zephyr-platforms/.github/workflows/prepare-zephyr
         with:
           app-path: tt-zephyr-platforms


### PR DESCRIPTION
Checkout ${{ github.ref }} instead of the default SHA for the github checkout event. This resolves an issue where restarting CI on a failed job would not merge the PR branch with the latest main, so CI fixes from external PRs would not be picked up.