### PR TITLE
lib: tenstorrent: banner: use APPLICATION_SOURCE_DIR for git describe

### DIFF
--- a/lib/tenstorrent/banner/CMakeLists.txt
+++ b/lib/tenstorrent/banner/CMakeLists.txt
@@ -6,7 +6,7 @@ zephyr_library_sources(tt_banner.c)
 if(CONFIG_TT_BOOT_BANNER_GIT_VERSION)
 
 include(${ZEPHYR_BASE}/cmake/modules/git.cmake)
-git_describe(. TT_GIT_VERSION)
+git_describe(${APPLICATION_SOURCE_DIR} TT_GIT_VERSION)
 zephyr_library_compile_definitions(TT_GIT_VERSION="${TT_GIT_VERSION}")
 
 endif()


### PR DESCRIPTION
Use APPLICATION_SOURCE_DIR for the `git describe` step- otherwise, git describe will fail when building the application from outside of the tt-zephyr-platforms repo