### PR TITLE
lib: tenstorrent: banner: add print of Zephyr SDK revision

### DIFF
--- a/app/bmc/prj.conf
+++ b/app/bmc/prj.conf
@@ -38,3 +38,4 @@ CONFIG_BOOT_BANNER=n
 # Print the Tenstorrent boot banner + git version on startup
 CONFIG_TT_BOOT_BANNER=y
 CONFIG_TT_BOOT_BANNER_GIT_VERSION=y
+CONFIG_TT_BOOT_BANNER_SDK_VERSION=y

--- a/app/smc/prj.conf
+++ b/app/smc/prj.conf
@@ -37,3 +37,4 @@ CONFIG_BOOT_BANNER=n
 # Print the Tenstorrent boot banner + git version on startup
 CONFIG_TT_BOOT_BANNER=y
 CONFIG_TT_BOOT_BANNER_GIT_VERSION=y
+CONFIG_TT_BOOT_BANNER_SDK_VERSION=y

--- a/lib/tenstorrent/banner/CMakeLists.txt
+++ b/lib/tenstorrent/banner/CMakeLists.txt
@@ -10,3 +10,7 @@ git_describe(${APPLICATION_SOURCE_DIR} TT_GIT_VERSION)
 zephyr_library_compile_definitions(TT_GIT_VERSION="${TT_GIT_VERSION}")
 
 endif()
+
+if(CONFIG_TT_BOOT_BANNER_SDK_VERSION)
+	zephyr_library_compile_definitions(ZEPHYR_SDK_VERSION="zephyr sdk ${SDK_VERSION}")
+endif()

--- a/lib/tenstorrent/banner/Kconfig
+++ b/lib/tenstorrent/banner/Kconfig
@@ -18,4 +18,9 @@ config TT_BOOT_BANNER_GIT_VERSION
 
 	  See ZEPHYR_BASE/cmake/modules/git.cmake for more information.
 
+config TT_BOOT_BANNER_SDK_VERSION
+	bool "Print the sdk revision when displaying the boot banner"
+	help
+	  Print the SDK revision used when displaying the boot banner
+
 endif

--- a/lib/tenstorrent/banner/tt_banner.c
+++ b/lib/tenstorrent/banner/tt_banner.c
@@ -52,6 +52,9 @@ static int tt_boot_banner(void)
 	if (IS_ENABLED(CONFIG_TT_BOOT_BANNER_GIT_VERSION)) {
 		printk("*** TT_GIT_VERSION " TT_GIT_VERSION " ***\n");
 	}
+	if (IS_ENABLED(CONFIG_TT_BOOT_BANNER_SDK_VERSION)) {
+		printk("*** SDK_VERSION " ZEPHYR_SDK_VERSION " ***\n");
+	}
 
 	return 0;
 }


### PR DESCRIPTION
Add print of Zephyr SDK revision during boot. This will enable truly reproducible builds, since we will be able to use the same toolchain and SHA.