### PR TITLE
Use Metal Container for running Hardware Long tests & Add required Metal tests

### DIFF
--- a/.github/workflows/hardware-long.yml
+++ b/.github/workflows/hardware-long.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  hardware-metal-test:
+  hardware-zephyr-test:
     strategy:
       fail-fast: false
       matrix:
@@ -137,25 +137,31 @@ jobs:
             --hardware-map /opt/tenstorrent/twister/hw-map.yml --west-flash \
             -T ../tt-zephyr-platforms/app -ll DEBUG
 
-
-      - name: Fix APT URLs
-        run: |
-          # Patch APT URLs to use https
-          sed -i -e 's/http/https/g' /etc/apt/sources.list
-          apt update
-
-      - name: Install clang 17
-        run: |
-          wget https://apt.llvm.org/llvm.sh
-          sed -i "s/http:\/\/apt.llvm.org/https:\/\/apt.llvm.org/" -i llvm.sh
-          chmod +x llvm.sh
-          ./llvm.sh 17 all
-          rm -f llvm.sh
-
+  hardware-metal-test:
+    needs:
+      - hardware-zephyr-test
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - board: p100
+            runs-on:
+              - yyz-zephyr-lab-p100
+          - board: p100a
+            runs-on:
+              - yyz-zephyr-lab-p100a
+    runs-on: ${{ matrix.config.runs-on }}
+    container:
+      image: ghcr.io/tenstorrent/tt-metal/tt-metalium/ubuntu-22.04-dev-amd64
+      volumes:
+        - /dev/hugepages-1G:/dev/hugepages-1G
+        - /dev/hugepages:/dev/hugepages
+      options: '--device /dev/tenstorrent --device /dev/bus/usb --privileged'
+    steps:
       - name: Install Git LFS
         run: |
+          apt update
           apt install -y git-lfs
-
       - name: Checkout Metal
         uses: actions/checkout@v4
         with:
@@ -163,19 +169,7 @@ jobs:
           path: tt-metal
           lfs: true
           submodules: true
-          ref: v0.55.0
-
-      - name: Install Metal Dependencies
-        working-directory: tt-metal
-        continue-on-error: true
-        shell: bash
-        run: |
-          sed -i 's/apt-get install/apt-get install -y/' install_dependencies.sh
-          sed -i 's/python3.8-venv/python3.10-venv/' install_dependencies.sh
-          apt install -y python3.10-dev python3.10-venv libpython3.10-dev python3.10
-          # This script will fail to install the tt-hugepages service, just ignore it
-          ./install_dependencies.sh
-
+          ref: v0.56.0
       - name: Run Metal Tests
         working-directory: tt-metal
         shell: bash
@@ -192,13 +186,9 @@ jobs:
           # Run metal tests
           tests/scripts/run_cpp_unit_tests.sh
           TT_METAL_SLOW_DISPATCH_MODE=1 tests/scripts/run_cpp_unit_tests.sh
+
       - name: cleanup
         if: ${{ always() }}
         run: |
-          # Clean up patched Zephyr repo
-          west patch clean
           # Clean out metal
           rm -rf tt-metal
-          # Cleanup the checked out repo, we can leave everything else
-          rm -rf tt-zephyr-platforms
-          rm -rf .west

--- a/.github/workflows/hardware-long.yml
+++ b/.github/workflows/hardware-long.yml
@@ -187,7 +187,7 @@ jobs:
           path: tt-metal
           lfs: true
           submodules: true
-          ref: abhullar/bh-virtual
+          ref: main
           fetch-depth: 500
           fetch-tags: true
       - name: Build Metal UMD Tests

--- a/.github/workflows/hardware-long.yml
+++ b/.github/workflows/hardware-long.yml
@@ -159,7 +159,7 @@ jobs:
               - yyz-zephyr-lab-p100a
     runs-on: ${{ matrix.config.runs-on }}
     container:
-      image: ghcr.io/tenstorrent/tt-metal/tt-metalium/ubuntu-22.04-dev-amd64:latest
+      image: ghcr.io/tenstorrent/tt-metal/tt-metalium/ubuntu-22.04-dev-amd64:bd47135f35f7b26851eb09066076fb3e6074c54f # Change this to a tag when metal has release versions for this image.
       volumes:
         - /dev/hugepages-1G:/dev/hugepages-1G
         - /dev/hugepages:/dev/hugepages
@@ -188,7 +188,7 @@ jobs:
           path: tt-metal
           lfs: true
           submodules: true
-          ref: main
+          ref: 12652be514e62224b5ccb160e5248fc83dfd96c1 # Change this when metal revision is available.
           fetch-depth: 500
           fetch-tags: true
       - name: Build Metal UMD Tests

--- a/.github/workflows/hardware-long.yml
+++ b/.github/workflows/hardware-long.yml
@@ -173,14 +173,10 @@ jobs:
         run: |
           apt update
           apt install -y git-lfs
-      - name: Checkout Zephyr Platforms (only for rescan-pcie.sh)
-        uses: actions/checkout@v4
-        with:
-          path: tt-zephyr-platforms
-          ref: ${{ github.ref }}
       - name: Run the rescan-pcie.sh script
         run: |
-          ./tt-zephyr-platforms/scripts/rescan-pcie.sh
+          curl -o /tmp/rescan-pcie.sh https://raw.githubusercontent.com/tenstorrent/tt-zephyr-platforms/${{ github.ref }}/scripts/rescan-pcie.sh
+          . /tmp/rescan-pcie.sh
       - name: Checkout Metal
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/hardware-long.yml
+++ b/.github/workflows/hardware-long.yml
@@ -136,7 +136,6 @@ jobs:
             --tag e2e \
             --hardware-map /opt/tenstorrent/twister/hw-map.yml --west-flash \
             -T ../tt-zephyr-platforms/app -ll DEBUG
-          ../tt-zephyr-platforms/scripts/rescan-pcie.sh
       - name: Install TT-SMI and reset the device
         run: |
           sed -i -e 's/http/https/g' /etc/apt/sources.list
@@ -191,7 +190,7 @@ jobs:
           ref: abhullar/bh-virtual
           fetch-depth: 500
           fetch-tags: true
-      - name: Build UMD Tests
+      - name: Build Metal UMD Tests
         working-directory: tt-metal
         shell: bash
         env:
@@ -201,7 +200,7 @@ jobs:
         run: |
           # Build metal
           ./build_metal.sh --build-umd-tests
-      - name: Run UMD Tests
+      - name: Run Metal UMD Tests
         working-directory: tt-metal
         shell: bash
         env:

--- a/.github/workflows/hardware-long.yml
+++ b/.github/workflows/hardware-long.yml
@@ -43,14 +43,14 @@ jobs:
         run: |
           curl -L -o combined-fwbundle.zip https://nightly.link/tenstorrent/tt-zephyr-platforms/workflows/build-fw/main/combined-fwbundle.zip
           unzip combined-fwbundle.zip
-      - name: Flash the firmware
-        run: |
-          pip install git+https://github.com/tenstorrent/tt-flash.git
-          tt-flash --fw-tar fw_pack*.fwbundle --force
       - name: Run the rescan-pcie.sh script
         run: |
           curl -o /tmp/rescan-pcie.sh https://raw.githubusercontent.com/tenstorrent/tt-zephyr-platforms/${{ github.ref }}/scripts/rescan-pcie.sh
           . /tmp/rescan-pcie.sh
+      - name: Flash the firmware
+        run: |
+          pip install git+https://github.com/tenstorrent/tt-flash.git
+          tt-flash --fw-tar fw_pack*.fwbundle --force
       - name: Checkout Metal
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/hardware-long.yml
+++ b/.github/workflows/hardware-long.yml
@@ -19,9 +19,9 @@ jobs:
           - board: p100
             runs-on:
               - yyz-zephyr-lab-p100
-          # - board: p100a
-          #   runs-on:
-          #     - yyz-zephyr-lab-p100a
+          - board: p100a
+            runs-on:
+              - yyz-zephyr-lab-p100a
     runs-on: ${{ matrix.config.runs-on }}
     env:
       "ZEPHYR_SDK_INSTALL_DIR": /opt/toolchains
@@ -123,6 +123,7 @@ jobs:
           # flash BMC and SMC firmware, but since each chip uses a separate
           # debug adapter this doesn't work. For now, just flash BMC
           # then run twister with SMC firmware
+          ../tt-zephyr-platforms/scripts/rescan-pcie.sh
           ./scripts/twister -i --retry-failed 3 \
             --retry-interval 5 \
             --tag e2e \

--- a/.github/workflows/hardware-long.yml
+++ b/.github/workflows/hardware-long.yml
@@ -42,7 +42,7 @@ jobs:
         # Replace this with the reliance on the previous workflow that builds the firmware bundle.
         run: |
           curl -L -o combined-fwbundle.zip https://nightly.link/tenstorrent/tt-zephyr-platforms/workflows/build-fw/main/combined-fwbundle.zip
-          unzip combined-fwbundle.zip
+          unzip -o combined-fwbundle.zip
       - name: Run the rescan-pcie.sh script
         run: |
           curl -o /tmp/rescan-pcie.sh https://raw.githubusercontent.com/tenstorrent/tt-zephyr-platforms/${{ github.ref }}/scripts/rescan-pcie.sh
@@ -87,6 +87,13 @@ jobs:
           TT_METAL_HOME: ${{ github.workspace }}/tt-metal
         run: |
           ./build_metal.sh --build-tests --build-programming-examples
+      - name: Run Metal Tests
+        shell: bash
+        working-directory: tt-metal
+        env:
+          ARCH_NAME: blackhole
+          TT_METAL_HOME: ${{ github.workspace }}/tt-metal
+        run: |
           PYTHON_CMD=python3.10 source ./create_venv.sh
           TT_METAL_SKIP_ETH_CORES_WITH_RETRAIN=1 ./build/test/tt_metal/unit_tests_dispatch --gtest_filter="CommandQueueSingleCardFixture.*"
           #Tests Metal command queue basic apis
@@ -101,3 +108,4 @@ jobs:
         run: |
           # Clean out metal
           rm -rf tt-metal
+          rm -rf combined-fwbundle.zip fw_pack*.fwbundle

--- a/.github/workflows/hardware-long.yml
+++ b/.github/workflows/hardware-long.yml
@@ -19,9 +19,9 @@ jobs:
           - board: p100
             runs-on:
               - yyz-zephyr-lab-p100
-          - board: p100a
-            runs-on:
-              - yyz-zephyr-lab-p100a
+          # - board: p100a
+          #   runs-on:
+          #     - yyz-zephyr-lab-p100a
     runs-on: ${{ matrix.config.runs-on }}
     env:
       "ZEPHYR_SDK_INSTALL_DIR": /opt/toolchains

--- a/.github/workflows/hardware-long.yml
+++ b/.github/workflows/hardware-long.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install Git LFS and Cargo (for tt-flash)
         run: |
           apt update
-          apt install -y git-lfs cargo
+          apt install -y git-lfs cargo unzip
       - name: Download the latest firmware bundle
         # Replace this with the reliance on the previous workflow that builds the firmware bundle.
         run: |

--- a/.github/workflows/hardware-long.yml
+++ b/.github/workflows/hardware-long.yml
@@ -11,142 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  hardware-zephyr-test:
-    strategy:
-      fail-fast: false
-      matrix:
-        config:
-          - board: p100
-            runs-on:
-              - yyz-zephyr-lab-p100
-          - board: p100a
-            runs-on:
-              - yyz-zephyr-lab-p100a
-    runs-on: ${{ matrix.config.runs-on }}
-    env:
-      "ZEPHYR_SDK_INSTALL_DIR": /opt/toolchains
-    container:
-      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.27.4.20241026
-      volumes:
-        - /dev/hugepages-1G:/dev/hugepages-1G
-        - /dev/hugepages:/dev/hugepages
-        - /opt/SEGGER:/opt/SEGGER
-        - /opt/tenstorrent/fw/stable:/opt/tenstorrent/fw/stable
-        - /opt/tenstorrent/twister:/opt/tenstorrent/twister
-        - /opt/tenstorrent/bin/openocd-rtt:/opt/tenstorrent/bin/openocd-rtt
-      options: '--device /dev/tenstorrent --device /dev/bus/usb --privileged'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          path: tt-zephyr-platforms
-          ref: ${{ github.ref }}
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.10'
-
-      - name: Log Test SHA
-        working-directory: tt-zephyr-platforms
-        run: |
-          # debug
-          git log  --pretty=oneline | head -n 10
-
-      - name: Install west
-        run: |
-          pip install west
-
-      - name: west setup
-        # FIXME: would be ideal to use a built-in github environment variable
-        # instead of tt-zephyr-platforms
-        run: |
-          rm -Rf .west
-          west init -l tt-zephyr-platforms
-
-      - name: Setup Zephyr modules
-        run: |
-          west config manifest.group-filter -- +optional
-          west update
-
-          # need to install protoc manually here, for some reason
-          pip install -r zephyr/scripts/requirements.txt
-          pip install protobuf grpcio-tools
-
-      - name: Apply patches
-        run: |
-          west patch clean
-          west -v patch apply -r
-
-      - name: Checkout pyluwen
-        uses: actions/checkout@v4
-        with:
-          repository: tenstorrent/luwen
-          path: luwen
-
-      - name: Build pyluwen
-        run: |
-          # Setup cargo, since we run with a different $HOME
-          HOME=/root . /root/.cargo/env
-          # Install maturin for build (we already have cargo)
-          pip install maturin
-          cd luwen/crates/pyluwen
-          maturin build --release
-          pip install ../../target/wheels/*
-
-      - name: Generate board names
-        shell: bash
-        run: |
-          case "${{ matrix.config.board }}" in
-            p100) SMC_BOARD=tt_blackhole@p100/tt_blackhole/smc;;
-            p100a) SMC_BOARD=tt_blackhole@p100a/tt_blackhole/smc;;
-            p150a) SMC_BOARD=tt_blackhole@p150a/tt_blackhole/smc;;
-            *) echo "Unknown board: ${{ matrix.config.board }}"; exit 1;;
-          esac
-          case "${{ matrix.config.board }}" in
-            p100) BMC_BOARD=tt_blackhole@p100/tt_blackhole/bmc;;
-            p100a) BMC_BOARD=tt_blackhole@p100a/tt_blackhole/bmc;;
-            p150) BMC_BOARD=tt_blackhole@p150/tt_blackhole/bmc;;
-            p300) BMC_BOARD=p300/tt_blackhole/bmc;;
-            *) echo "Unknown board: ${{ matrix.config.board }}"; exit 1;;
-          esac
-          echo "SMC_BOARD=$SMC_BOARD" >> "$GITHUB_ENV"
-          echo "BMC_BOARD=$BMC_BOARD" >> "$GITHUB_ENV"
-
-      - name: Flash Firmware
-        working-directory: zephyr
-        run: |
-          # This needs to be added to the github runner
-          export PATH=$PATH:/opt/SEGGER/JLink/
-
-          # TODO: ideally we would use one twister command to build and
-          # flash BMC and SMC firmware, but since each chip uses a separate
-          # debug adapter this doesn't work. For now, just flash BMC
-          # then run twister with SMC firmware
-          ../tt-zephyr-platforms/scripts/rescan-pcie.sh
-          ./scripts/twister -i --retry-failed 3 \
-            --retry-interval 5 \
-            --tag e2e \
-            -p $BMC_BOARD --device-testing \
-            --hardware-map /opt/tenstorrent/twister/hw-map.yml --west-flash \
-            -T ../tt-zephyr-platforms/app -ll DEBUG
-          # Run E2E test to verify BMC and SMC firmware boot, and that
-          # the SMC firmware sets up PCIe and ARC messages
-          ./scripts/twister -i --retry-failed 3 \
-            -p $SMC_BOARD --device-testing \
-            --tag e2e \
-            --hardware-map /opt/tenstorrent/twister/hw-map.yml --west-flash \
-            -T ../tt-zephyr-platforms/app -ll DEBUG
-      - name: Install TT-SMI and reset the device
-        run: |
-          sed -i -e 's/http/https/g' /etc/apt/sources.list
-          apt update
-          apt install -y cargo
-          pip install git+https://github.com/tenstorrent/tt-smi@v3.0.5
-          tt-smi -r 0
   hardware-metal-test:
-    needs:
-      - hardware-zephyr-test
     strategy:
       fail-fast: false
       matrix:
@@ -169,10 +34,19 @@ jobs:
       TT_METAL_HOME: ${{ github.workspace }}/tt-metal
       PYTHONPATH: ${{ github.workspace }}/tt-metal
     steps:
-      - name: Install Git LFS
+      - name: Install Git LFS and Cargo (for tt-flash)
         run: |
           apt update
-          apt install -y git-lfs
+          apt install -y git-lfs cargo
+      - name: Download the latest firmware bundle
+        # Replace this with the reliance on the previous workflow that builds the firmware bundle.
+        run: |
+          curl -L -o combined-fwbundle.zip https://nightly.link/tenstorrent/tt-zephyr-platforms/workflows/build-fw/main/combined-fwbundle.zip
+          unzip combined-fwbundle.zip
+      - name: Flash the firmware
+        run: |
+          pip install git+https://github.com/tenstorrent/tt-flash.git
+          tt-flash --fw-tar fw_pack*.fwbundle --force
       - name: Run the rescan-pcie.sh script
         run: |
           curl -o /tmp/rescan-pcie.sh https://raw.githubusercontent.com/tenstorrent/tt-zephyr-platforms/${{ github.ref }}/scripts/rescan-pcie.sh

--- a/.github/workflows/hardware-long.yml
+++ b/.github/workflows/hardware-long.yml
@@ -136,7 +136,14 @@ jobs:
             --tag e2e \
             --hardware-map /opt/tenstorrent/twister/hw-map.yml --west-flash \
             -T ../tt-zephyr-platforms/app -ll DEBUG
-
+          ../tt-zephyr-platforms/scripts/rescan-pcie.sh
+      - name: Install TT-SMI and reset the device
+        run: |
+          sed -i -e 's/http/https/g' /etc/apt/sources.list
+          apt update
+          apt install -y cargo
+          pip install git+https://github.com/tenstorrent/tt-smi@v3.0.5
+          tt-smi -r 0
   hardware-metal-test:
     needs:
       - hardware-zephyr-test
@@ -152,16 +159,28 @@ jobs:
               - yyz-zephyr-lab-p100a
     runs-on: ${{ matrix.config.runs-on }}
     container:
-      image: ghcr.io/tenstorrent/tt-metal/tt-metalium/ubuntu-22.04-dev-amd64
+      image: ghcr.io/tenstorrent/tt-metal/tt-metalium/ubuntu-22.04-dev-amd64:latest
       volumes:
         - /dev/hugepages-1G:/dev/hugepages-1G
         - /dev/hugepages:/dev/hugepages
       options: '--device /dev/tenstorrent --device /dev/bus/usb --privileged'
+    env:
+      ARCH_NAME: blackhole
+      TT_METAL_HOME: ${{ github.workspace }}/tt-metal
+      PYTHONPATH: ${{ github.workspace }}/tt-metal
     steps:
       - name: Install Git LFS
         run: |
           apt update
           apt install -y git-lfs
+      - name: Checkout Zephyr Platforms (only for rescan-pcie.sh)
+        uses: actions/checkout@v4
+        with:
+          path: tt-zephyr-platforms
+          ref: ${{ github.ref }}
+      - name: Run the rescan-pcie.sh script
+        run: |
+          ./tt-zephyr-platforms/scripts/rescan-pcie.sh
       - name: Checkout Metal
         uses: actions/checkout@v4
         with:
@@ -169,8 +188,10 @@ jobs:
           path: tt-metal
           lfs: true
           submodules: true
-          ref: v0.56.0
-      - name: Run Metal Tests
+          ref: abhullar/bh-virtual
+          fetch-depth: 500
+          fetch-tags: true
+      - name: Build UMD Tests
         working-directory: tt-metal
         shell: bash
         env:
@@ -178,15 +199,33 @@ jobs:
           TT_METAL_HOME: ${{ github.workspace }}/tt-metal
           PYTHONPATH: ${{ github.workspace }}/tt-metal
         run: |
-          # Debug
-          python3 -V
           # Build metal
+          ./build_metal.sh --build-umd-tests
+      - name: Run UMD Tests
+        working-directory: tt-metal
+        shell: bash
+        env:
+          ARCH_NAME: blackhole
+          TT_METAL_HOME: ${{ github.workspace }}/tt-metal
+        run: |
+          ./build/test/umd/blackhole/unit_tests
+      - name: Build Other Metal Tests
+        shell: bash
+        working-directory: tt-metal
+        env:
+          ARCH_NAME: blackhole
+          TT_METAL_HOME: ${{ github.workspace }}/tt-metal
+        run: |
           ./build_metal.sh --build-tests --build-programming-examples
           PYTHON_CMD=python3.10 source ./create_venv.sh
-          # Run metal tests
-          tests/scripts/run_cpp_unit_tests.sh
-          TT_METAL_SLOW_DISPATCH_MODE=1 tests/scripts/run_cpp_unit_tests.sh
-
+          TT_METAL_SKIP_ETH_CORES_WITH_RETRAIN=1 ./build/test/tt_metal/unit_tests_dispatch --gtest_filter="CommandQueueSingleCardFixture.*"
+          #Tests Metal command queue basic apis
+          TT_METAL_SKIP_ETH_CORES_WITH_RETRAIN=1 ./build/test/tt_metal/unit_tests_dispatch --gtest_filter="CommandQueueSingleCardProgramFixture.*"
+          #Tests Metal program apis
+          TT_METAL_SKIP_ETH_CORES_WITH_RETRAIN=1 ./build/test/tt_metal/unit_tests_dispatch --gtest_filter="CommandQueueSingleCardBufferFixture.ShardedBufferLarge*ReadWrites"
+          ./build/test/tt_metal/unit_tests_dispatch --gtest_filter=RandomProgramFixture.*
+          ./build/test/tt_metal/unit_tests_api_blackhole --gtest_filter=*SimpleDram*:*SimpleL1*
+          ./build/test/tt_metal/unit_tests_dispatch --gtest_filter=CommandQueueSingleCardBufferFixture.*
       - name: cleanup
         if: ${{ always() }}
         run: |


### PR DESCRIPTION
To update the metal version to the latest version, we need to change how we install dependencies in the workflows.

- Broke down the workflow into two jobs
- Got rid of manual installation of metal and started using a metal container 
- Upgraded metal to ~v0.56.0~ ~almeet's branch `abhullar/bh-virtual` ~ now on Metal main.

TODO:
- [x] Figure out the unit-tests errors
- [x] Reset of P100a does not seem to be working