### PR TITLE
Ensure that the bmfw is padded to 0xb000 for all boards

### DIFF
--- a/boards/tenstorrent/tt_blackhole/bootfs/p150b-bootfs.yaml
+++ b/boards/tenstorrent/tt_blackhole/bootfs/p150b-bootfs.yaml
@@ -41,6 +41,7 @@ images:
 
   # Board Mgmt FW
   - name: bmfw
+    padto: 0xb000
     binary: $BUILD_DIR/bmc/zephyr/zephyr.signed.bin
 
   # Meta data about the flashing process

--- a/boards/tenstorrent/tt_blackhole/bootfs/p150c-bootfs.yaml
+++ b/boards/tenstorrent/tt_blackhole/bootfs/p150c-bootfs.yaml
@@ -41,6 +41,7 @@ images:
 
   # Board Mgmt FW
   - name: bmfw
+    padto: 0xb000
     binary: $BUILD_DIR/bmc/zephyr/zephyr.signed.bin
 
   # Meta data about the flashing process

--- a/boards/tenstorrent/tt_blackhole/bootfs/p300a-left-bootfs.yaml
+++ b/boards/tenstorrent/tt_blackhole/bootfs/p300a-left-bootfs.yaml
@@ -37,6 +37,7 @@ images:
 
   # Board Mgmt FW
   - name: bmfw
+    padto: 0xc000
     binary: $BUILD_DIR/bmc/zephyr/zephyr.signed.bin
 
   # Meta data about the flashing process

--- a/boards/tenstorrent/tt_blackhole/bootfs/p300b-left-bootfs.yaml
+++ b/boards/tenstorrent/tt_blackhole/bootfs/p300b-left-bootfs.yaml
@@ -37,6 +37,7 @@ images:
 
   # Board Mgmt FW
   - name: bmfw
+    padto: 0xc000
     binary: $BUILD_DIR/bmc/zephyr/zephyr.signed.bin
 
   # Meta data about the flashing process

--- a/boards/tenstorrent/tt_blackhole/bootfs/p300c-left-bootfs.yaml
+++ b/boards/tenstorrent/tt_blackhole/bootfs/p300c-left-bootfs.yaml
@@ -37,6 +37,7 @@ images:
 
   # Board Mgmt FW
   - name: bmfw
+    padto: 0xc000
     binary: $BUILD_DIR/bmc/zephyr/zephyr.signed.bin
 
   # Meta data about the flashing process


### PR DESCRIPTION
Added bmfw padding to all board types; required to make sure the SPI driver will be able to read the binaries in order to self-update.