### PR TITLE
ci: release: artifacts for p150b p150c p300a p300b and p300c

### DIFF
--- a/.github/workflows/build-fw.yml
+++ b/.github/workflows/build-fw.yml
@@ -18,6 +18,8 @@ on:
       - main
       - v*-branch
 
+# TODO: read boards / board revs from a YAML file (generate a matrix)
+# possibly using https://github.com/marketplace/actions/files-to-matrix
 jobs:
   build:
     runs-on: ubuntu-24.04

--- a/.github/workflows/build-fw.yml
+++ b/.github/workflows/build-fw.yml
@@ -141,3 +141,32 @@ jobs:
             build-recovery/**/zephyr.hex
             build-recovery/**/zephyr.map
             build-recovery/**/zephyr.stat
+
+  build-combined-fwbundle:
+    runs-on: ubuntu-24.04
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: tt-zephyr-platforms
+          ref: ${{ github.ref }}
+
+      - name: Download firmware artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: firmware-*
+          path: tt-zephyr-platforms
+
+      - name: Build Combined Firmware Bundle
+        shell: bash
+        run: |
+          pip install pykwalify
+          BUNDLE_TEMP_PREFIX="$PWD/tt-zephyr-platforms/firmware-" \
+            ./tt-zephyr-platforms/scripts/build-combined-fwbundle.sh
+
+      - name: Upload Combined Firmware Bundle Assets
+        uses: actions/upload-artifact@v4
+        with:
+          name: combined-fwbundle
+          path: |
+            fw_pack*.fwbundle

--- a/.github/workflows/build-fw.yml
+++ b/.github/workflows/build-fw.yml
@@ -18,6 +18,10 @@ on:
       - main
       - v*-branch
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 # TODO: read boards / board revs from a YAML file (generate a matrix)
 # possibly using https://github.com/marketplace/actions/files-to-matrix
 jobs:

--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -14,6 +14,10 @@ on:
       - main
       - v*-branch
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-tt-console:
     runs-on: ubuntu-22.04

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -12,6 +12,10 @@ on:
       - main
       - v*-branch
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check_compliance:
     runs-on: ubuntu-22.04

--- a/.github/workflows/copyright-check.yml
+++ b/.github/workflows/copyright-check.yml
@@ -14,6 +14,10 @@ on:
       - main
       - v*-branch
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   copyright_check_job:
     runs-on: ubuntu-22.04

--- a/.github/workflows/hardware-long.yml
+++ b/.github/workflows/hardware-long.yml
@@ -6,6 +6,10 @@ on:
     - cron: "0 0 * * *"
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   hardware-metal-test:
     strategy:

--- a/.github/workflows/hardware-smoke.yml
+++ b/.github/workflows/hardware-smoke.yml
@@ -14,6 +14,10 @@ on:
       - main
       - v*-branch
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   hardware-smoke-test:
     strategy:

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -14,6 +14,10 @@ on:
       - main
       - v*-branch
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   scancode_job:
     runs-on: ubuntu-22.04

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Package firmware artifacts
         run: |
           # TODO: read boards / board revs from a YAML file
-          BOARD_REVS="p100 p100a p150a"
+          BOARD_REVS="p100 p100a p150a p150b p150c p300a p300b p300c"
 
           for REV in $BOARD_REVS; do
             cp build-*/update.fwbundle $REV.fwbundle

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,11 @@ jobs:
         with:
           pattern: firmware-*
 
+      - name: Download combined firmware bundle
+        uses: actions/download-artifact@v4
+        with:
+          name: combined-fwbundle
+
       - name: Package firmware artifacts
         run: |
           # TODO: read boards / board revs from a YAML file

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,36 +42,21 @@ jobs:
           name: tt-zephyr-platforms-${{ steps.get_version.outputs.VERSION }}.spdx
           path: tt-zephyr-platforms-${{ steps.get_version.outputs.VERSION }}.spdx
 
-      # FIXME: need a more clever way to download and combine lots of artifacts
-      - name: Download firmware artifact (p100)
+      - name: Download firmware artifacts
         uses: actions/download-artifact@v4
         with:
-          name: firmware-p100
-          path: assets/p100
-
-      - name: Download firmware artifact (p100a)
-        uses: actions/download-artifact@v4
-        with:
-          name: firmware-p100a
-          path: assets/p100a
-
-      - name: Download firmware artifact (p150a)
-        uses: actions/download-artifact@v4
-        with:
-          name: firmware-p150a
-          path: assets/p150a
+          pattern: firmware-*
 
       - name: Package firmware artifacts
         run: |
-          cp assets/p100/update.fwbundle p100.fwbundle
-          cp assets/p100a/update.fwbundle p100a.fwbundle
-          cp assets/p150a/update.fwbundle p150a.fwbundle
+          # TODO: read boards / board revs from a YAML file
+          BOARD_REVS="p100 p100a p150a"
 
-          cd assets
-          zip -r -9 ../tt-zephyr-platforms-${{ steps.get_version.outputs.VERSION }}.zip \
-            p100 \
-            p100a \
-            p150a
+          for REV in $BOARD_REVS; do
+            cp build-*/update.fwbundle $REV.fwbundle
+          done
+
+          zip -r -9 tt-zephyr-platforms-${{ steps.get_version.outputs.VERSION }}.zip $BOARD_REVS
 
       - name: Create empty release notes body
         run: |
@@ -85,8 +70,6 @@ jobs:
           draft: true
           prerelease: true
           files: |
-            p100.fwbundle
-            p100a.fwbundle
-            p150a.fwbundle
+            *.fwbundle
             tt-zephyr-platforms-${{ steps.get_version.outputs.VERSION }}.zip
             tt-zephyr-platforms-${{ steps.get_version.outputs.VERSION }}.spdx

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ jobs:
       SIGNATURE_KEY: ${{ secrets.SIGNATURE_KEY }}
 
   publish-release:
+    needs: build-release
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -14,6 +14,10 @@ on:
       - main
       - v*-branch
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   unit-test:
     env:

--- a/scripts/build-combined-fwbundle.sh
+++ b/scripts/build-combined-fwbundle.sh
@@ -5,12 +5,16 @@
 
 set -e
 
-TEMP_DIR="$(mktemp -d)"
-
-echo "Created TEMP_DIR"
+if [ -z "$BUNDLE_TEMP_PREFIX" ]; then
+  TEMP_DIR="$(mktemp -d)/"
+  echo "Created TEMP_DIR"
+else
+  echo "Using existing BUNDLE_TEMP_PREFIX: $BUNDLE_TEMP_PREFIX"
+  TEMP_DIR="$BUNDLE_TEMP_PREFIX"
+fi
 
 cleanup() {
-    if [ -d "$TEMP_DIR" ]; then
+    if [ -z "$BUNDLE_TEMP_PREFIX" ] && [ -d "$TEMP_DIR" ]; then
         rm -Rf "$TEMP_DIR"
         echo "Removed TEMP_DIR"
     fi
@@ -18,15 +22,17 @@ cleanup() {
 trap cleanup EXIT
 
 mPATH="$(dirname "$0")"
+TTZP_BASE="$(dirname "$mPATH")"
 # put tt_boot_fs.py in the path (use it to combine .fwbundle files)
 PATH="$mPATH:$PATH"
 
+# TODO: read boards / board revs from a YAML file
 BOARD_REVS="p100 p100a p150a p150b p150c p300a p300b p300c"
 
-MAJOR="$(grep "^VERSION_MAJOR" VERSION | awk '{print $3}')"
-MINOR="$(grep "^VERSION_MINOR" VERSION | awk '{print $3}')"
-PATCH="$(grep "^PATCHLEVEL" VERSION | awk '{print $3}')"
-EXTRAVERSION="$(grep "^EXTRAVERSION" VERSION | awk '{print $3}')"
+MAJOR="$(grep "^VERSION_MAJOR" "$TTZP_BASE/VERSION" | awk '{print $3}')"
+MINOR="$(grep "^VERSION_MINOR" "$TTZP_BASE/VERSION" | awk '{print $3}')"
+PATCH="$(grep "^PATCHLEVEL" "$TTZP_BASE/VERSION" | awk '{print $3}')"
+EXTRAVERSION="$(grep "^EXTRAVERSION" "$TTZP_BASE/VERSION" | awk '{print $3}')"
 
 if [ -z "$MAJOR" ] || [ -z "$MINOR" ] || [ -z "$PATCH" ]; then
   echo "required version info missing: MAJOR=$MAJOR MINOR=$MINOR PATCH=$PATCH"
@@ -48,15 +54,23 @@ echo "Building release $RELEASE / pack $PRELEASE"
 for REV in $BOARD_REVS; do
   BOARD="tt_blackhole@$REV/tt_blackhole/smc"
 
+  if [ -n "$BUNDLE_TEMP_PREFIX" ]; then
+    if [ -f "${TEMP_DIR}${REV}/update.fwbundle" ]; then
+      echo "Using pre-built ${TEMP_DIR}${REV}/update.fwbundle"
+      continue
+    fi
+    echo "Warning: pre-built ${TEMP_DIR}${REV}/update.fwbundle not found"
+  fi
+
   echo "Building $BOARD"
-  west build -d "$TEMP_DIR/$REV" --sysbuild -p -b "$BOARD" app/smc >/dev/null 2>&1
+  west build -d "${TEMP_DIR}${REV}" --sysbuild -p -b "$BOARD" app/smc >/dev/null 2>&1
 done
 
 echo "Creating fw_pack-$PRELEASE.fwbundle"
 # construct arguments..
 ARGS=""
 for REV in $BOARD_REVS; do
-  ARGS="$ARGS -c $TEMP_DIR/$REV/update.fwbundle"
+  ARGS="$ARGS -c ${TEMP_DIR}${REV}/update.fwbundle"
 done
 
 # shellcheck disable=SC2086


### PR DESCRIPTION
* scripts: build-combined-fwbundle: use pre-built per-board fwbundles
* ci: release: ensure publish-release depends on build-release
* ci: release: simplify firmware bundle logic
* ci: build-fw: run build-combined-firmware in CI
* ci: release: add combined firmware bundle to release artifacts
* ci: release: artifacts for p150b p150c p300a p300b and p300c
* ci: cancel previous workflow runs on force push

Testing Done (for `./scripts/build-combined-fwbundle.sh`):
```shell
BUNDLE_TEMP_PREFIX="$PWD/build-" ./scripts/build-combined-fwbundle.sh 
Using existing BUNDLE_TEMP_PREFIX: /Users/cfriedt/tt-zephyr-platforms-work/tt-zephyr-platforms.git/build-
Building release 18.1.99 / pack 18.1.99.0
Using pre-built build-p100/update.fwbundle
Using pre-built build-p100a/update.fwbundle
Using pre-built build-p150a/update.fwbundle
Using pre-built build-p150b/update.fwbundle
Using pre-built build-p150c/update.fwbundle
Using pre-built build-p300a/update.fwbundle
Using pre-built build-p300b/update.fwbundle
Using pre-built build-p300c/update.fwbundle
Creating fw_pack-18.1.99.0.fwbundle
Wrote fwbundle to fw_pack-18.1.99.0.fwbundle

# of course, still works without the environment variable specified
./scripts/build-combined-fwbundle.sh
Created TEMP_DIR
Building release 18.1.99 / pack 18.1.99.0
Building tt_blackhole@p100/tt_blackhole/smc
...
```