### PR TITLE
scripts: bmc-reset: add support for waiting for SMC boot, autodetect paths

### DIFF
--- a/scripts/bmc-reset.py
+++ b/scripts/bmc-reset.py
@@ -22,6 +22,10 @@ from pathlib import Path
 
 logger = logging.getLogger(Path(__file__).stem)
 
+DEFAULT_BMC_CFG = (
+    Path(__file__).parents[1]
+    / "boards/tenstorrent/tt_blackhole/support/tt_blackhole_bmc.cfg"
+)
 OPT_DIR = Path("/opt/tenstorrent")
 SDK_SYSROOT = Path("/opt/zephyr/zephyr-sdk-0.17.0/sysroots/x86_64-pokysdk-linux")
 
@@ -73,11 +77,7 @@ def parse_args():
     parser.add_argument(
         "-c",
         "--config",
-        default=OPT_DIR
-        / "fw"
-        / "stable"
-        / "tt_blackhole_tt_blackhole_bmc"
-        / "tt_blackhole_bmc.cfg",
+        default=DEFAULT_BMC_CFG,
         help="OpenOCD config file",
         metavar="FILE",
         type=Path,

--- a/scripts/bmc-reset.py
+++ b/scripts/bmc-reset.py
@@ -177,6 +177,7 @@ def reset_bmc(args):
         openocd_cmd.extend(["-c", f"adapter serial {args.jtag_id}"])
 
     if args.hexfile:
+        print(f"Programming file {args.hexfile} to the BMC")
         # program the hex file and reset the BMC
         openocd_cmd.extend(
             [

--- a/scripts/bmc-reset.py
+++ b/scripts/bmc-reset.py
@@ -73,6 +73,19 @@ def rescan_pcie():
 
 
 def parse_args():
+    # Execute CMake to locate SDK sysroot
+    proc = subprocess.run(
+        ["cmake", "-P", str(Path(__file__).parent / "find_zephyr_sdk.cmake")],
+        capture_output=True,
+    )
+    if "SDK_INSTALL_DIR" in str(proc.stderr):
+        DEFAULT_SDK_INSTALL_DIR = (
+            Path(str(proc.stderr).split(":")[1][:-3])
+            / "sysroots"
+            / "x86_64-pokysdk-linux"
+        )
+    else:
+        DEFAULT_SDK_INSTALL_DIR = SDK_SYSROOT
     parser = argparse.ArgumentParser(description="Reset BMC", allow_abbrev=False)
     parser.add_argument(
         "-c",
@@ -107,7 +120,7 @@ def parse_args():
     parser.add_argument(
         "-o",
         "--openocd",
-        default=SDK_SYSROOT / "usr" / "bin" / "openocd",
+        default=DEFAULT_SDK_INSTALL_DIR / "usr" / "bin" / "openocd",
         help="Use a specific hw-map.yml file",
         metavar="FILE",
         type=Path,
@@ -115,7 +128,7 @@ def parse_args():
     parser.add_argument(
         "-s",
         "--scripts",
-        default=SDK_SYSROOT / "usr" / "share" / "openocd" / "scripts",
+        default=DEFAULT_SDK_INSTALL_DIR / "usr" / "share" / "openocd" / "scripts",
         help="Path to OpenOCD scripts directory",
         metavar="DIR",
         type=Path,

--- a/scripts/find_zephyr_sdk.cmake
+++ b/scripts/find_zephyr_sdk.cmake
@@ -1,0 +1,4 @@
+find_package(Zephyr-sdk)
+if(Zephyr-sdk_FOUND)
+  message("SDK_INSTALL_DIR:${ZEPHYR_SDK_INSTALL_DIR}")
+endif()


### PR DESCRIPTION
Add support in the bmc-reset script for waiting for the SMC boot, and autodetect paths like the Zephyr SDK where possible.

~Use this script within CI, so that we can have more reliable BMC flashing~