### PR TITLE
ci: increase stable firmware revision

### DIFF
--- a/.github/workflows/hardware-smoke.yml
+++ b/.github/workflows/hardware-smoke.yml
@@ -47,7 +47,7 @@ jobs:
       - uses: ./tt-zephyr-platforms/.github/workflows/prepare-hardware
         with:
           board: ${{ matrix.config.board }}
-          version: '80.15.0.0'
+          version: '80.17.0.0'
 
       - name: Generate board names
         shell: bash
@@ -166,7 +166,7 @@ jobs:
       - uses: ./tt-zephyr-platforms/.github/workflows/prepare-hardware
         with:
           board: ${{ matrix.config.board }}
-          version: '80.15.0.0'
+          version: '80.17.0.0'
 
       - name: Generate board names
         shell: bash


### PR DESCRIPTION
Increase stable firmware revision flashed in CI. Based on RTT logs, it appears the CI instability may be due to flashing a stable CMFW that still has the I2C hang issue- if so, upgrading to fw bundle 80.17.0.0 should resolve this