### PR TITLE
scripts: requirements: add tt-smi to required python packages

### DIFF
--- a/.github/workflows/prepare-zephyr/action.yml
+++ b/.github/workflows/prepare-zephyr/action.yml
@@ -64,11 +64,6 @@ runs:
         app-path: ${{ inputs.app-path }}
         toolchains: arm-zephyr-eabi:riscv64-zephyr-elf:x86_64-zephyr-elf:arc-zephyr-elf
 
-    - name: Install additional python dependencies
-      shell: bash
-      run: |
-        pip install -r ${{ inputs.app-path }}/scripts/requirements.txt
-
     - name: Verify binary blobs
       shell: bash
       run: |

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -4,3 +4,4 @@ grpcio-tools
 
 # tenstorrent utilities (note: pyluwen is a dependency)
 tt-flash @ git+https://github.com/tenstorrent/tt-flash
+tt-smi @ git+https://github.com/tenstorrent/tt-smi


### PR DESCRIPTION
Ensure that `tt-smi` is installed (this is typically done via `west packages pip --install`).

Python packages are installed as part of `zephyrproject-rtos/action-zephyr-setup`, so remove the additional manual `pip` invocation.

https://github.com/zephyrproject-rtos/action-zephyr-setup/blob/db1412e2ab8e2c07b1f866541e66aec41b20d244/action.yml#L141