### PR TITLE
ci: temporarily disable p100a hw tests until it runs reliably

### DIFF
--- a/.github/workflows/hardware-smoke.yml
+++ b/.github/workflows/hardware-smoke.yml
@@ -139,9 +139,6 @@ jobs:
           - board: p100
             runs-on:
               - yyz-zephyr-lab-p100
-          - board: p100a
-            runs-on:
-              - yyz-zephyr-lab-p100a
     runs-on: ${{ matrix.config.runs-on }}
     env:
       "ZEPHYR_SDK_INSTALL_DIR": /opt/toolchains


### PR DESCRIPTION
p100a machines need manual recovery almost constantly. p100 seems fine. 

It's a massive waste of developer time and is blocking CI, so just disable p100a until we can reliably run tests on that platform as part of the regular test sequence (which I hope is ASAP).

Case in point:
* https://github.com/tenstorrent/tt-zephyr-platforms/pull/160
* the PR above simply adds `tt-smi` to `scripts/requirements.txt`
* there should be zero reason for CI failing on p100a hardware tests

Likely the same problem will plague p150a, p150b, p150c, p300a, p300b, and p300c systems, so it needs to be done right.

Temporary workaround for #162, but that will need a fix ASAP.