### PR TITLE
lib: tenstorrent: improve I2C recovery function

### DIFF
--- a/lib/tenstorrent/bh_arc/dw_apb_i2c.c
+++ b/lib/tenstorrent/bh_arc/dw_apb_i2c.c
@@ -226,6 +226,14 @@ static void I2CRecoverBus(uint32_t id)
 	/* Set both pads to output low */
 	WriteReg(GetI2CPadDataAddr(id), 0x0);
 	/*
+	 * First, manually hold SCL low for 150 ms. Per the SMBUS spec,
+	 * we should only need to hold the line low for 25 ms, but that does
+	 * not work reliably and this does...
+	 */
+	i2c_cntl ^= RESET_UNIT_I2C_PAD_CTRL_TRIEN_SCL_MASK;
+	WriteReg(GetI2CPadCntlAddr(id), i2c_cntl);
+	Wait(150 * WAIT_1MS);
+	/*
 	 * Bitbang I2C reset to unstick bus. Hold SDA low, toggle SCL 32 times to create 16
 	 * clock cycles. Note we toggle the TRIEN bit, as when TRIEN is
 	 * set the bus will be released and external pullups will


### PR DESCRIPTION
Add the following improvements to the I2C recovery function used when the I2C bus sticks:
- forcibly hold SCL low for 100ms, to induce a reset for PMBUS/SMBUS devices

This PR also adds a `reset-hammer` test, which runs as part of the long hardware testsuite. This test takes roughly 75 minutes to complete, and resets the SMC 1000 times, each time verifying there is no I2C hang. Each reset is performed twice in quick succession, because in my testing this had the best chance of reproducing I2C issues (presumably because regulator init occurs during early boot)

A link to a run of this test within the PR can be seen here, before I moved it to the nightly tests: [tenstorrent/tt-zephyr-platforms/actions/runs/14767700634/job/41462250566?pr=168](https://github.com/tenstorrent/tt-zephyr-platforms/actions/runs/14767700634/job/41462250566?pr=168)