### PR TITLE
ci: build-fw: enable virtual uart by default for published binaries

### DIFF
--- a/.github/workflows/build-fw.yml
+++ b/.github/workflows/build-fw.yml
@@ -89,6 +89,8 @@ jobs:
             -b $BOARD \
             tt-zephyr-platforms/app/smc \
             -- \
+              -DEXTRA_CONF_FILE=vuart.conf \
+              -DDTC_OVERLAY_FILE=vuart.overlay \
               -DCONFIG_COMPILER_WARNINGS_AS_ERRORS=y \
               -DCONFIG_MCUBOOT_SIGNATURE_KEY_FILE=\"\$SIGNATURE_KEY_FILE\"
 


### PR DESCRIPTION
This enables the PCIe Virtual UART by default in the build-fw workflow only so that users can use `tt-console`.

This is a temporary solution until #72 is able to pass tests in CI.