### PR TITLE
lib: tenstorrent: continued elimination of I2C gremlins

### DIFF
--- a/.github/workflows/hardware-long.yml
+++ b/.github/workflows/hardware-long.yml
@@ -112,3 +112,70 @@ jobs:
           # Clean out metal
           rm -rf tt-metal
           rm -rf combined-fwbundle.zip fw_pack*.fwbundle
+
+  reset-hammer-test:
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - board: p100
+            runs-on:
+              - p100-jtag
+          - board: p100a
+            runs-on:
+              - p100a-jtag
+          - board: p150a
+            runs-on:
+              - p150a-jtag
+    runs-on: ${{ matrix.config.runs-on }}
+    env:
+      "ZEPHYR_SDK_INSTALL_DIR": /opt/toolchains
+    container:
+      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.27.4.20241026
+      volumes:
+        - /dev/hugepages-1G:/dev/hugepages-1G
+        - /opt/tenstorrent/:/opt/tenstorrent/
+      options: '--device /dev/tenstorrent --device /dev/bus/usb --privileged'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: tt-zephyr-platforms
+          ref: ${{ github.ref }}
+      - uses: ./tt-zephyr-platforms/.github/workflows/prepare-zephyr
+        with:
+          app-path: tt-zephyr-platforms
+
+      - name: Generate board names
+        shell: bash
+        run: |
+          case "${{ matrix.config.board }}" in
+            p100) SMC_BOARD=tt_blackhole@p100/tt_blackhole/smc;;
+            p100a) SMC_BOARD=tt_blackhole@p100a/tt_blackhole/smc;;
+            p150a) SMC_BOARD=tt_blackhole@p150a/tt_blackhole/smc;;
+            *) echo "Unknown board: ${{ matrix.config.board }}"; exit 1;;
+          esac
+          case "${{ matrix.config.board }}" in
+            p100) BMC_BOARD=tt_blackhole@p100/tt_blackhole/bmc;;
+            p100a) BMC_BOARD=tt_blackhole@p100a/tt_blackhole/bmc;;
+            p150a) BMC_BOARD=tt_blackhole@p150a/tt_blackhole/bmc;;
+            p300) BMC_BOARD=p300/tt_blackhole/bmc;;
+            *) echo "Unknown board: ${{ matrix.config.board }}"; exit 1;;
+          esac
+          echo "SMC_BOARD=$SMC_BOARD" >> "$GITHUB_ENV"
+          echo "BMC_BOARD=$BMC_BOARD" >> "$GITHUB_ENV"
+
+      - name: Run reset test
+        working-directory: tt-zephyr-platforms
+        timeout-minutes: 90
+        shell: bash
+        run: |
+          ./scripts/run-reset-hammer.sh $SMC_BOARD 1000
+
+      - name: Print RTT logs
+        if: ${{ failure() }}
+        working-directory: tt-zephyr-platforms
+        run: |
+          echo "BMC RTT logs:"
+          python3 ./scripts/bmc_rtt.py -n --openocd /opt/tenstorrent/bin/openocd-rtt
+          echo "SMC RTT logs:"
+          python3 ./scripts/smc_rtt.py -n --openocd /opt/tenstorrent/bin/openocd-rtt

--- a/lib/tenstorrent/bh_arc/dw_apb_i2c.c
+++ b/lib/tenstorrent/bh_arc/dw_apb_i2c.c
@@ -210,7 +210,7 @@ static inline uint32_t GetI2CPadDataAddr(uint32_t id)
 }
 
 /* Bitbang recovery sequence on I2C bus */
-static void I2CRecoverBus(uint32_t id)
+void I2CRecoverBus(uint32_t id)
 {
 	uint32_t drive_strength = 0x7F; /* 50% of max 0xFF */
 	uint32_t i2c_cntl = (drive_strength << RESET_UNIT_I2C_PAD_CNTL_DRV_SHIFT) |

--- a/lib/tenstorrent/bh_arc/dw_apb_i2c.h
+++ b/lib/tenstorrent/bh_arc/dw_apb_i2c.h
@@ -37,4 +37,5 @@ uint32_t I2CRMWV(uint32_t id, uint16_t command, uint32_t command_byte_size, cons
 			const uint8_t *p_mask, uint32_t data_byte_size);
 void SetI2CSlaveCallbacks(uint32_t id, const struct i2c_target_callbacks *cb);
 void PollI2CSlave(uint32_t id);
+void I2CRecoverBus(uint32_t id);
 #endif

--- a/lib/tenstorrent/bh_arc/regulator.c
+++ b/lib/tenstorrent/bh_arc/regulator.c
@@ -311,6 +311,8 @@ uint32_t RegulatorInit(PcbType board_type)
 			if (i2c_error) {
 				LOG_WRN("Vcore regulator init retried on cmd %#x with error %#x",
 					regulator_data->cmd, i2c_error);
+				/* First, try a bus recovery */
+				I2CRecoverBus(PMBUS_MST_ID);
 				/* Retry once */
 				i2c_error = I2CRMWV(PMBUS_MST_ID, regulator_data->cmd,
 					PMBUS_CMD_BYTE_SIZE, regulator_data->data,

--- a/scripts/run-reset-hammer.sh
+++ b/scripts/run-reset-hammer.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+# Copyright (c) 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+BOARD=$1
+COUNT=$2
+
+if [ $# -ne 2 ]; then
+	echo "Incorrect number of arguments, expected board name and test count"
+	exit 1
+fi
+
+# Repeatedly resets the SMC. Intended to be run within CI.
+# Accepts two arguments:
+# 1. board name to use
+# 2. the number of times to run the reset test
+
+TT_Z_P="$(dirname $(realpath $0))/.."
+echo $TT_Z_P
+
+fail_cnt=0
+pass_cnt=0
+
+function report_results()
+{
+	echo "Reset test ended: $pass_cnt passed, $fail_cnt failed"
+
+	if [ $fail_cnt -ne 0 ]; then
+		echo "Reset test failed with $fail_cnt errors"
+		exit 1
+	else
+		echo "Reset test passed successfully"
+		exit 0
+	fi
+}
+
+trap report_results SIGINT
+
+# Build the test
+west build -p always -b $BOARD -d build-reset-test $TT_Z_P/app/smc
+
+for i in $(seq 1 $COUNT); do
+	# Flash twice, this gives us the best chance of resetting the SMC while
+	# I2C init is ongoing
+	echo "Flashing SMC twice"
+	west flash -d build-reset-test > /dev/null 2>&1
+	west flash -d build-reset-test > /dev/null 2>&1
+	# Rescan PCI
+	sudo $TT_Z_P/scripts/rescan-pcie.sh
+	# Test with tt-smi
+	tt-smi -s > /dev/null
+	if [ $? -ne 0 ]; then
+		echo "Reset test failed on iteration $i"
+		((fail_cnt++))
+	else
+		echo "Reset test passed on iteration $i"
+		((pass_cnt++))
+	fi
+done
+
+# Call exit function on script completion
+report_results


### PR DESCRIPTION
Add a reset hammer test, intended to be run nightly. This test will reset the SMC repeatedly, and verify that I2C hangs do not occur when the SMC crashes (or is reset) during early init.

This PR also includes additional I2C recovery fixes, and should not be merged until the reset hammer test is passing at 1000 iterations on P100/P100a/P150a