### PR TITLE
ci: use generic tags for blackhole, enable P150

### DIFF
--- a/.github/workflows/hardware-long.yml
+++ b/.github/workflows/hardware-long.yml
@@ -18,10 +18,13 @@ jobs:
         config:
           - board: p100
             runs-on:
-              - yyz-zephyr-lab-p100
+              - p100-jtag
           - board: p100a
             runs-on:
-              - yyz-zephyr-lab-p100a
+              - p100a-jtag
+          - board: p150a
+            runs-on:
+              - p150a-jtag
     runs-on: ${{ matrix.config.runs-on }}
     container:
       image: ghcr.io/tenstorrent/tt-metal/tt-metalium/ubuntu-22.04-dev-amd64:bd47135f35f7b26851eb09066076fb3e6074c54f # Change this to a tag when metal has release versions for this image.

--- a/.github/workflows/hardware-smoke.yml
+++ b/.github/workflows/hardware-smoke.yml
@@ -26,10 +26,13 @@ jobs:
         config:
           - board: p100
             runs-on:
-              - yyz-zephyr-lab-p100
+              - p100-jtag
           - board: p100a
             runs-on:
-              - yyz-zephyr-lab-p100a
+              - p100a-jtag
+          - board: p150a
+            runs-on:
+              - p150a-jtag
     runs-on: ${{ matrix.config.runs-on }}
     container:
       image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.27.4.20241026
@@ -138,7 +141,13 @@ jobs:
         config:
           - board: p100
             runs-on:
-              - yyz-zephyr-lab-p100
+              - p100-jtag
+          - board: p100a
+            runs-on:
+              - p100a-jtag
+          - board: p150a
+            runs-on:
+              - p150a-jtag
     runs-on: ${{ matrix.config.runs-on }}
     env:
       "ZEPHYR_SDK_INSTALL_DIR": /opt/toolchains

--- a/.github/workflows/hardware-smoke.yml
+++ b/.github/workflows/hardware-smoke.yml
@@ -63,7 +63,7 @@ jobs:
           case "${{ matrix.config.board }}" in
             p100) BMC_BOARD=tt_blackhole@p100/tt_blackhole/bmc;;
             p100a) BMC_BOARD=tt_blackhole@p100a/tt_blackhole/bmc;;
-            p150) BMC_BOARD=tt_blackhole@p150/tt_blackhole/bmc;;
+            p150a) BMC_BOARD=tt_blackhole@p150a/tt_blackhole/bmc;;
             p300) BMC_BOARD=p300/tt_blackhole/bmc;;
             *) echo "Unknown board: ${{ matrix.config.board }}"; exit 1;;
           esac
@@ -181,7 +181,7 @@ jobs:
           case "${{ matrix.config.board }}" in
             p100) BMC_BOARD=tt_blackhole@p100/tt_blackhole/bmc;;
             p100a) BMC_BOARD=tt_blackhole@p100a/tt_blackhole/bmc;;
-            p150) BMC_BOARD=tt_blackhole@p150/tt_blackhole/bmc;;
+            p150a) BMC_BOARD=tt_blackhole@p150a/tt_blackhole/bmc;;
             p300) BMC_BOARD=p300/tt_blackhole/bmc;;
             *) echo "Unknown board: ${{ matrix.config.board }}"; exit 1;;
           esac

--- a/.github/workflows/prepare-zephyr/action.yml
+++ b/.github/workflows/prepare-zephyr/action.yml
@@ -64,6 +64,11 @@ runs:
         app-path: ${{ inputs.app-path }}
         toolchains: arm-zephyr-eabi:riscv64-zephyr-elf:x86_64-zephyr-elf:arc-zephyr-elf
 
+    - name: Install app python dependencies
+      shell: bash
+      run: |
+        pip install -r ${{ inputs.app-path }}/scripts/requirements.txt
+
     - name: Verify binary blobs
       shell: bash
       run: |

--- a/app/bmc/sample.yaml
+++ b/app/bmc/sample.yaml
@@ -8,7 +8,7 @@ tests:
     platform_allow:
       - tt_blackhole@p100/tt_blackhole/bmc
       - tt_blackhole@p100a/tt_blackhole/bmc
-      - tt_blackhole@p150/tt_blackhole/bmc
+      - tt_blackhole@p150a/tt_blackhole/bmc
       - p300/tt_blackhole/bmc
     tags: e2e
     harness: console

--- a/app/smc/Kconfig.sysbuild
+++ b/app/smc/Kconfig.sysbuild
@@ -6,7 +6,7 @@ source "share/sysbuild/Kconfig"
 
 config BMC_BOARD
 	string "BMC Board"
-	default "tt_blackhole@p150/tt_blackhole/bmc" if $(BOARD_REVISION) = "p150a" || $(BOARD_REVISION) = "p150b" || $(BOARD_REVISION) = "p150c"
+	default "tt_blackhole@p150a/tt_blackhole/bmc" if $(BOARD_REVISION) = "p150a" || $(BOARD_REVISION) = "p150b" || $(BOARD_REVISION) = "p150c"
 	default "tt_blackhole@p100a/tt_blackhole/bmc" if $(BOARD_REVISION) = "p100a"
 	default "tt_blackhole@p100/tt_blackhole/bmc" if $(BOARD_REVISION) = "p100"
 	default "p300/tt_blackhole/bmc" if $(BOARD_REVISION) = "p300a" || $(BOARD_REVISION) = "p300b" || $(BOARD_REVISION) = "p300c"

--- a/boards/tenstorrent/tt_blackhole/board.yml
+++ b/boards/tenstorrent/tt_blackhole/board.yml
@@ -7,7 +7,6 @@ boards:
     revisions:
     - name: "p100"
     - name: "p100a"
-    - name: "p150"
     - name: "p150a"
     - name: "p150b"
     - name: "p150c"

--- a/boards/tenstorrent/tt_blackhole/revision.cmake
+++ b/boards/tenstorrent/tt_blackhole/revision.cmake
@@ -1,5 +1,5 @@
 set(BOARD_REVISIONS
-    "p100" "p100a" "p150" "p150a" "p150b" "p150c" "p300a" "p300b" "p300c")
+    "p100" "p100a" "p150a" "p150b" "p150c" "p300a" "p300b" "p300c")
 if(NOT BOARD_REVISION IN_LIST BOARD_REVISIONS)
 message(FATAL_ERROR "${BOARD_REVISION} is not a valid revision for tt_blackhole. Accepted revisions: ${BOARD_REVISIONS}")
 endif()

--- a/boards/tenstorrent/tt_blackhole/tt_blackhole_tt_blackhole_bmc_p150a.yaml
+++ b/boards/tenstorrent/tt_blackhole/tt_blackhole_tt_blackhole_bmc_p150a.yaml
@@ -1,5 +1,5 @@
-identifier: tt_blackhole@p150/tt_blackhole/bmc
-name: Tenstorrent Blackhole P150 board (BMC)
+identifier: tt_blackhole@p150a/tt_blackhole/bmc
+name: Tenstorrent Blackhole P150A board (BMC)
 type: mcu
 arch: arm
 toolchain:


### PR DESCRIPTION
Use generic tags for blackhole runners, as we now have two P100a runners online. Enable P150 runner in CI.