### PR TITLE
ci: release: enable release workflow even for rcs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   push:
     tags:
       - 'v*'
-      - '!v*rc*'
+      - 'v*rc*'
 
 jobs:
   build-release:


### PR DESCRIPTION
Enable the release workflow for release candidates. This will enable artifact generation for the usual artifacts with fewer manual steps.