### PR TITLE
maintainers: add release notes maintainer to the maintainers file

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1,0 +1,62 @@
+# Structure in this doc is intentionally borrowed from the Zephyr Project
+# See https://github.com/zephyrproject-rtos/zephyr/tree/main/MAINTAINERS.yml
+
+Release Notes:
+  status: maintained
+  maintainers:
+    - cfriedt
+  files:
+    - doc/release/release-notes-*
+    - doc/release/release-notes-*
+  labels:
+    - "release ✅"
+
+"West project: cmsis":
+  status: odd fixes
+  files: []
+  labels: []
+  description: |
+    Maintained upstream.
+
+"West project: hal_stm32":
+  status: odd fixes
+  files: []
+  labels: []
+  description: |
+    Maintained upstream.
+
+"West project: mbedtls":
+  status: odd fixes
+  files: []
+  labels: []
+  description: |
+    Maintained upstream.
+
+"West project: mcuboot":
+  status: odd fixes
+  files: []
+  labels: []
+  description: |
+    Maintained upstream.
+
+"West project: nanopb":
+  status: odd fixes
+  files: []
+  labels: []
+  description: |
+    Maintained upstream.
+
+"West project: segger":
+  status: odd fixes
+  files: []
+  labels: []
+  description: |
+    Maintained upstream.
+
+"West project: zephyr":
+  status: odd fixes
+  files: []
+  labels:
+    - "zephyr 🪁"
+  description: |
+    Maintained upstream.


### PR DESCRIPTION
Add a release notes maintainer to the maintainers file.

This file intentionally uses the same structure as that from the Zephyr Project. It is intended to be used programmatically to associate areas of code (C, devicetree, documentation, etc) to various individuals within Tenstorrent's firmware organization.

Additional areas and maintainers should be added soon.

Please see the upstream maintainers file for more info:

https://github.com/zephyrproject-rtos/zephyr/tree/main/MAINTAINERS.yml

* also added required entries for entries in `west.yml`, otherwise there were compliance errors