### PR TITLE
maintainers: add danieldegrasse and cfriedt as ci maintainers

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1,6 +1,16 @@
 # Structure in this doc is intentionally borrowed from the Zephyr Project
 # See https://github.com/zephyrproject-rtos/zephyr/tree/main/MAINTAINERS.yml
 
+Continuous Integration:
+  status: maintained
+  maintainers:
+    - cfriedt
+    - danieldegrasse
+  files:
+    - .github/workflows/
+  labels:
+    - "ci ♾️"
+
 Release Notes:
   status: maintained
   maintainers:


### PR DESCRIPTION
Add Daniel DeGrasse and Chris Friedt as CI maintainers.

Not sure if I care enough to add a [maintainers file maintainer](https://github.com/zephyrproject-rtos/zephyr/blob/64fe434297c6c7e6cfb8fcc5c49c9b1f78114569/MAINTAINERS.yml#L2700)