### PR TITLE
ci: use shortened Zephyr setup when SDK is already present

### DIFF
--- a/.github/workflows/prepare-zephyr/action.yml
+++ b/.github/workflows/prepare-zephyr/action.yml
@@ -56,13 +56,40 @@ runs:
           rm -rf zephyr-sdk
         fi
 
-    # TODO: potentially improve caching strategy
-    # Note: this step performs "west init", "west update", and installs zephyr python dependencies
-    - name: Set up Zephyr project
+    - name: Check if Zephyr SDK is installed
+      shell: bash
+      id: check-sdk
+      run: |
+        if [ -d "/opt/toolchains" ]; then
+          echo "SDK installation found"
+          export SDK_SETUP=$(find /opt/toolchains/ -name setup.sh)
+          echo "setup-script=$SDK_SETUP" >> "$GITHUB_OUTPUT"
+          echo "exists=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "No SDK installation found"
+          echo "exists=false" >> "$GITHUB_OUTPUT"
+        fi
+
+    # If zephyr SDK isn't installed, perform the full Zephyr setup step
+    - name: Set up Zephyr project (full)
+      if: steps.check-sdk.outputs.exists == 'false'
       uses: zephyrproject-rtos/action-zephyr-setup@v1
       with:
         app-path: ${{ inputs.app-path }}
         toolchains: arm-zephyr-eabi:riscv64-zephyr-elf:x86_64-zephyr-elf:arc-zephyr-elf
+
+    # Otherwise, all we actually need is to run west init and pip install
+    - name: Set up Zephyr project (basic)
+      if: steps.check-sdk.outputs.exists == 'true'
+      shell: bash
+      run: |
+        # Register SDK cmake package
+        ${{ steps.check-sdk.outputs.setup-script }} -c
+        pip3 install -U pip wheel
+        pip3 install west
+        west init -l ${{ inputs.app-path }}
+        west update -o=--depth=1 -n
+        west packages pip --install --ignore-venv-check || pip3 install -r zephyr/scripts/requirements.txt
 
     - name: Install app python dependencies
       shell: bash


### PR DESCRIPTION
When running within a Zephyr SDK docker image, we don't need to manually setup the Zephyr SDK every time. Add a basic setup step that runs when we already have an SDK installed. This should speed up CI execution time