### PR TITLE
ci: make sure docker container uses HTTPs for HTTP

### DIFF
--- a/.github/workflows/prepare-zephyr/action.yml
+++ b/.github/workflows/prepare-zephyr/action.yml
@@ -26,6 +26,8 @@ runs:
       shell: bash
       run: |
         if ! command -v curl &> /dev/null ; then
+          # Patch the HTTP urls to use HTTPs, required on gitlab self hosted runners
+          sed -i 's/http:/https:/g'  /etc/apt/sources.list
           apt-get update
           apt-get install -y curl
         fi


### PR DESCRIPTION
Self hosted docker containers need https urls for http. Patch the urls when installing curl, as this step is only running on docker containers anyways