### PR TITLE
doc: release: v18.2.0: note that virtual uart is enabled by default

### DIFF
--- a/doc/release/release-notes-18.2.0.md
+++ b/doc/release/release-notes-18.2.0.md
@@ -15,6 +15,9 @@ Major enhancements with this release include:
   * Added ETH mailbox with 2 messages
   * ETH msg LINK_STATUS_CHECK: checks for link status
   * ETH msg RELEASE_CORE: Releases control of RISC0 to run function at specified L1 addr
+* Virtual UART now enabled by default for Blackhole firmware bundles
+  * Creates an in-memory virtual uart for firmware observability and debugging
+  * Use `tt-console` to view `printk()` and `LOG_*()` messages from the host
 
 [comment]: <> (H3 External Project Collaboration Efforts, if applicable)
 [comment]: <> (H3 Stability Improvements, if applicable)


### PR DESCRIPTION
Add a release note stating that the PCIe Virtual UART is enabled by default for Blackhole firmware bundles.

Use the provided `tt-console` app to view `printk()` and `LOG_*()` messages from firmware on Linux hosts.

```
cd tt-zephyr-platforms
gcc -Iinclude -O0 -g -Wall -Wextra -Werror -std=gnu11 -o tt-console \
            scripts/tt-console/console.c
```