### PR TITLE
smbus messaging: notify BMC FW when SMC FW is ready to receive msg

### DIFF
--- a/app/dmc/src/main.c
+++ b/app/dmc/src/main.c
@@ -352,10 +352,10 @@ int main(void)
 		 */
 		ARRAY_FOR_EACH_PTR(BH_CHIPS, chip) {
 			if (chip->data.arc_needs_init_msg) {
-				if (bh_chip_set_static_info(chip, &static_info) == 0) {
+				if (bh_chip_set_static_info(chip, &static_info) == 0 &&
+				    bh_chip_set_board_pwr_lim(chip, max_pwr) == 0) {
 					chip->data.arc_needs_init_msg = false;
 				}
-				bh_chip_set_board_pwr_lim(chip, max_pwr);
 			}
 		}
 

--- a/app/dmc/src/main.c
+++ b/app/dmc/src/main.c
@@ -120,6 +120,9 @@ void process_cm2dm_message(struct bh_chip *chip)
 				set_fan_speed((uint8_t)message.data & 0xFF);
 			}
 			break;
+		case 0x4:
+			chip->data.cm_ready_for_msgs = true;
+			break;
 		}
 	}
 }
@@ -348,7 +351,7 @@ int main(void)
 		/* TODO(drosen): Turn this into a task which will re-arm until static data is sent
 		 */
 		ARRAY_FOR_EACH_PTR(BH_CHIPS, chip) {
-			if (chip->data.arc_just_reset) {
+			if (chip->data.arc_just_reset && chip->data.cm_ready_for_msgs) {
 				if (bh_chip_set_static_info(chip, &static_info) == 0) {
 					chip->data.arc_just_reset = false;
 				}

--- a/app/dmc/src/main.c
+++ b/app/dmc/src/main.c
@@ -121,7 +121,7 @@ void process_cm2dm_message(struct bh_chip *chip)
 			}
 			break;
 		case 0x4:
-			chip->data.cm_ready_for_msgs = true;
+			chip->data.arc_needs_init_msg = true;
 			break;
 		}
 	}
@@ -351,9 +351,9 @@ int main(void)
 		/* TODO(drosen): Turn this into a task which will re-arm until static data is sent
 		 */
 		ARRAY_FOR_EACH_PTR(BH_CHIPS, chip) {
-			if (chip->data.arc_just_reset && chip->data.cm_ready_for_msgs) {
+			if (chip->data.arc_needs_init_msg) {
 				if (bh_chip_set_static_info(chip, &static_info) == 0) {
-					chip->data.arc_just_reset = false;
+					chip->data.arc_needs_init_msg = false;
 				}
 				bh_chip_set_board_pwr_lim(chip, max_pwr);
 			}

--- a/app/smc/src/main.c
+++ b/app/smc/src/main.c
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include "cm2dm_msg.h"
 #include "dvfs.h"
 #include "fan_ctrl.h"
 #include "fw_table.h"
@@ -65,6 +66,8 @@ int main(void)
 			StartDVFSTimer();
 		}
 	}
+
+	Dm2CmReadyRequest();
 
 	while (1) {
 		k_msleep(1000);

--- a/include/tenstorrent/bh_chip.h
+++ b/include/tenstorrent/bh_chip.h
@@ -43,10 +43,11 @@ struct bh_chip_data {
 	bool workaround_applied;
 
 	/*
-	 * Flag set when need to send or receive 1 time info to chip.
+	 * Flags set when need to send or receive 1 time info to chip.
 	 * Could be used for static data or config of peripherals.
 	 */
 	bool arc_just_reset;
+	bool cm_ready_for_msgs;
 
 	unsigned int bus_cancel_flag;
 

--- a/include/tenstorrent/bh_chip.h
+++ b/include/tenstorrent/bh_chip.h
@@ -43,11 +43,10 @@ struct bh_chip_data {
 	bool workaround_applied;
 
 	/*
-	 * Flags set when need to send or receive 1 time info to chip.
+	 * Flag set when need to send or receive 1 time info to chip.
 	 * Could be used for static data or config of peripherals.
 	 */
-	bool arc_just_reset;
-	bool cm_ready_for_msgs;
+	bool arc_needs_init_msg;
 
 	unsigned int bus_cancel_flag;
 

--- a/lib/tenstorrent/bh_arc/cm2dm_msg.c
+++ b/lib/tenstorrent/bh_arc/cm2dm_msg.c
@@ -115,6 +115,15 @@ void UpdateFanSpeedRequest(uint32_t fan_speed)
 	EnqueueCm2DmMsg(&msg);
 }
 
+void Dm2CmReadyRequest(void)
+{
+	/* Send a message to dmfw to indicate ready to receive messages */
+	Cm2DmMsg msg = {
+		.msg_id = kCm2DmMsgIdReady,
+	};
+	EnqueueCm2DmMsg(&msg);
+}
+
 /* Report the current message and automatically acknowledge it. */
 int32_t ResetBoardByte(uint8_t *data, uint8_t size)
 {

--- a/lib/tenstorrent/bh_arc/cm2dm_msg.h
+++ b/lib/tenstorrent/bh_arc/cm2dm_msg.h
@@ -14,6 +14,7 @@ typedef enum {
 	kCm2DmMsgIdResetReq = 1,
 	kCm2DmMsgIdPing = 2,
 	kCm2DmMsgIdFanSpeedUpdate = 3,
+	kCm2DmMsgIdReady = 4,
 } Cm2DmMsgId;
 
 typedef struct {
@@ -39,6 +40,7 @@ int32_t ResetBoardByte(uint8_t *data, uint8_t size);
 
 void ChipResetRequest(void *arg);
 void UpdateFanSpeedRequest(uint32_t fan_speed);
+void Dm2CmReadyRequest(void);
 
 typedef struct dmStaticInfo {
 	/* Non-zero for valid data */

--- a/lib/tenstorrent/jtag_bootrom/jtag_bootrom.c
+++ b/lib/tenstorrent/jtag_bootrom/jtag_bootrom.c
@@ -276,6 +276,7 @@ void jtag_bootrom_soft_reset_arc(struct bh_chip *chip)
 	jtag_axi_write32(dev, BH_RESET_BASE + 0x100, 0);
 
 	chip->data.needs_reset = false;
+	chip->data.cm_ready_for_msgs = false;
 	chip->data.arc_just_reset = true;
 #endif
 }

--- a/lib/tenstorrent/jtag_bootrom/jtag_bootrom.c
+++ b/lib/tenstorrent/jtag_bootrom/jtag_bootrom.c
@@ -276,8 +276,6 @@ void jtag_bootrom_soft_reset_arc(struct bh_chip *chip)
 	jtag_axi_write32(dev, BH_RESET_BASE + 0x100, 0);
 
 	chip->data.needs_reset = false;
-	chip->data.cm_ready_for_msgs = false;
-	chip->data.arc_just_reset = true;
 #endif
 }
 


### PR DESCRIPTION
BMC FW attempts to send board power limit before SMC FW is guaranteed to be initialized. This results in unintentional throttling down to the default board power limit of 150W.

Add a cm2bm message to notify BMC FW when it's okay to start sending data.