### PR TITLE
app: pytest: e2e_smoke: support rescan if no card is on bus

### DIFF
--- a/app/smc/pytest/e2e_smoke.py
+++ b/app/smc/pytest/e2e_smoke.py
@@ -48,21 +48,26 @@ def rescan_pcie():
     """
     # First, we must find the PCIe card to power it off
     dev = find_tt_bus()
-    if dev is None:
-        raise RuntimeError("No tenstorrent card found to power off")
-    print(f"Powering off device at {dev}")
+    if dev is not None:
+        print(f"Powering off device at {dev}")
+        try:
+            with open(os.path.join(dev, "remove"), "w") as f:
+                f.write("1")
+        except PermissionError as e:
+            print(
+                "Error, this script must be run with elevated permissions to rescan PCIe bus"
+            )
+            raise e
+    # Now, rescan the bus
     try:
-        with open(os.path.join(dev, "remove"), "w") as f:
+        with open("/sys/bus/pci/rescan", "w") as f:
             f.write("1")
+            time.sleep(1)
     except PermissionError as e:
         print(
             "Error, this script must be run with elevated permissions to rescan PCIe bus"
         )
         raise e
-    # Now, rescan the bus
-    with open("/sys/bus/pci/rescan", "w") as f:
-        f.write("1")
-        time.sleep(1)
 
 
 def get_arc_chip(unlaunched_dut: DeviceAdapter):


### PR DESCRIPTION
In some cases, no card is on the PCIe bus at the start of the test. Still support rescanning this case