### PR TITLE
zephyr: module: add package-managers so that pip installs automatically

### DIFF
--- a/.github/workflows/prepare-zephyr/action.yml
+++ b/.github/workflows/prepare-zephyr/action.yml
@@ -64,11 +64,6 @@ runs:
         app-path: ${{ inputs.app-path }}
         toolchains: arm-zephyr-eabi:riscv64-zephyr-elf:x86_64-zephyr-elf:arc-zephyr-elf
 
-    - name: Install app python dependencies
-      shell: bash
-      run: |
-        pip install -r ${{ inputs.app-path }}/scripts/requirements.txt
-
     - name: Verify binary blobs
       shell: bash
       run: |

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -24,6 +24,11 @@ boards:
 runners:
   - file: scripts/tt_flash_runner.py
 
+package-managers:
+  pip:
+    requirement-files:
+      - scripts/requirements.txt
+
 blobs:
   - path: tt_blackhole_erisc.bin
     sha256: c0fa6016a0dc9a7aedb5712af9ebfa843eb9201111e6bf5356b857125a1fe1f7


### PR DESCRIPTION
Add `package-managers` and `pip` to `zephyr/module.yml`, which ensures that `west packages pip --install` picks up pypi packages for our module.

Testing Done:
```shell
% west packages pip
-r /Users/cfriedt/tt-zephyr-platforms-work/zephyr/scripts/requirements.txt
-r /Users/cfriedt/tt-zephyr-platforms-work/tt-zephyr-platforms.git/scripts/requirements.txt
-r /Users/cfriedt/tt-zephyr-platforms-work/modules/lib/nanopb/extra/requirements.txt
-r /Users/cfriedt/tt-zephyr-platforms-work/bootloader/mcuboot/zephyr/requirements.txt
```

See also
https://docs.zephyrproject.org/latest/develop/modules.html#python-pip