### PR TITLE
ci: prepare-zephyr: resolve tt-smi tt-flash version conflict

### DIFF
--- a/.github/workflows/prepare-zephyr/action.yml
+++ b/.github/workflows/prepare-zephyr/action.yml
@@ -17,11 +17,6 @@ runs:
       with:
         python-version: '3.10'
 
-    - name: Install west
-      shell: bash
-      run: |
-        pip install west
-
     - name: Install curl
       shell: bash
       run: |

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -3,5 +3,5 @@ protobuf
 grpcio-tools
 
 # tenstorrent utilities (note: pyluwen is a dependency)
-tt-flash @ git+https://github.com/tenstorrent/tt-flash
-tt-smi @ git+https://github.com/tenstorrent/tt-smi
+tt-flash @ git+https://github.com/tenstorrent/tt-flash@v3.3.1
+tt-smi @ git+https://github.com/tenstorrent/tt-smi@v3.0.14


### PR DESCRIPTION
`tt-smi` and `tt-flash` both depend on different (fixed) versions of `pyluwen` (they should probably use `>=`). In any case, the pip `scripts/requirements.txt` file was failing to get installed and as a result, `protoc` was failing.

Resolve the dependencies for now.

This was causing multiple PRs to fail.