### PR TITLE
ci: fixes for build artifact uploads

### DIFF
--- a/.github/workflows/hardware-smoke.yml
+++ b/.github/workflows/hardware-smoke.yml
@@ -90,6 +90,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: DMC Smoke test results (${{ matrix.config.board }})
+          include-hidden-files: true
           path: |
             zephyr/twister-dmc-smoke/**/handler.log
             zephyr/twister-dmc-smoke/**/zephyr.dts
@@ -130,6 +131,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: SMC Smoke test results (${{ matrix.config.board }})
+          include-hidden-files: true
           path: |
             zephyr/twister-smc-smoke/**/handler.log
             zephyr/twister-smc-smoke/**/zephyr.dts
@@ -231,6 +233,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: E2E test results (${{ matrix.config.board }})
+	  include-hidden-files: true
           path: |
             zephyr/twister-*-e2e/**/handler.log
             zephyr/twister-*-e2e/**/zephyr.dts
@@ -258,6 +261,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: E2E Flash results (${{ matrix.config.board }})
+          include-hidden-files: true
           path: |
             zephyr/twister-e2e-flash/**/update.fwbundle
 

--- a/.github/workflows/hardware-smoke.yml
+++ b/.github/workflows/hardware-smoke.yml
@@ -93,6 +93,7 @@ jobs:
           include-hidden-files: true
           path: |
             zephyr/twister-dmc-smoke/**/handler.log
+            zephyr/twister-dmc-smoke/**/twister_harness.log
             zephyr/twister-dmc-smoke/**/zephyr.dts
             zephyr/twister-dmc-smoke/**/.config
             zephyr/twister-dmc-smoke/**/*.map
@@ -134,6 +135,7 @@ jobs:
           include-hidden-files: true
           path: |
             zephyr/twister-smc-smoke/**/handler.log
+            zephyr/twister-smc-smoke/**/twister_harness.log
             zephyr/twister-smc-smoke/**/zephyr.dts
             zephyr/twister-smc-smoke/**/.config
             zephyr/twister-smc-smoke/**/*.map
@@ -236,6 +238,7 @@ jobs:
 	  include-hidden-files: true
           path: |
             zephyr/twister-*-e2e/**/handler.log
+            zephyr/twister-*-e2e/**/twister_harness.log
             zephyr/twister-*-e2e/**/zephyr.dts
             zephyr/twister-*-e2e/**/.config
             zephyr/twister-*-e2e/**/*.map

--- a/.github/workflows/hardware-smoke.yml
+++ b/.github/workflows/hardware-smoke.yml
@@ -230,23 +230,6 @@ jobs:
             -T ../tt-zephyr-platforms/app \
             --outdir twister-smc-e2e
 
-      - name: Upload E2E Test results
-        if: ${{ always() }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: E2E test results (${{ matrix.config.board }})
-	  include-hidden-files: true
-          path: |
-            zephyr/twister-*-e2e/**/handler.log
-            zephyr/twister-*-e2e/**/twister_harness.log
-            zephyr/twister-*-e2e/**/zephyr.dts
-            zephyr/twister-*-e2e/**/.config
-            zephyr/twister-*-e2e/**/*.map
-            zephyr/twister-*-e2e/**/zephyr.elf
-            zephyr/twister-*-e2e/**/*.lst
-            zephyr/twister-*-e2e/twister.log
-            zephyr/twister-*-e2e/twister.json
-
       - name: run-e2e-flash-test
         working-directory: zephyr
         run: |
@@ -259,14 +242,23 @@ jobs:
             --device-serial-pty rtt \
             --outdir twister-e2e-flash
 
-      - name: Upload E2E Flash Results
+      - name: Upload E2E Test results
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: E2E Flash results (${{ matrix.config.board }})
+          name: E2E test results (${{ matrix.config.board }})
           include-hidden-files: true
           path: |
-            zephyr/twister-e2e-flash/**/update.fwbundle
+            zephyr/twister-*e2e*/**/handler.log
+            zephyr/twister-*e2e*/**/twister_harness.log
+            zephyr/twister-*e2e*/**/zephyr.dts
+            zephyr/twister-*e2e*/**/.config
+            zephyr/twister-*e2e*/**/*.map
+            zephyr/twister-*e2e*/**/zephyr.elf
+            zephyr/twister-*e2e*/**/*.lst
+            zephyr/twister-*e2e*/twister.log
+            zephyr/twister-*e2e*/twister.json
+            zephyr/twister-*e2e*/**/update.fwbundle
 
       - name: Print RTT logs
         if: ${{ failure() }}


### PR DESCRIPTION
While looking at test results for #164, I realized we aren't uploading the `twister_harness.log` file where pytest results are stored.

This PR fixes that issue, as well as a few other improvements:
- enable uploading hidden files so that the `.config` file gets uploaded
- combine the e2e-flash and e2e-smoke uploads, since we are going to run some tests exclusively within the `e2e-flash` run