### PR TITLE
boards: tt_blackhole: dmc: select rtt backend and deferred log mode

### DIFF
--- a/boards/tenstorrent/tt_blackhole/Kconfig.defconfig
+++ b/boards/tenstorrent/tt_blackhole/Kconfig.defconfig
@@ -3,3 +3,21 @@
 
 config FLASH_EX_OP_ENABLED
 	default y if FLASH_SPI_DW
+
+if BOARD_TT_BLACKHOLE_TT_BLACKHOLE_DMC
+
+# Use deferred logging for DMC, since it allows us to capture the entirety of ZTest output
+# https://github.com/zephyrproject-rtos/zephyr/blob/main/subsys/testsuite/ztest/src/ztest.c#L723
+choice LOG_MODE
+	# Required for CONFIG_TEST_LOGGING_FLUSH_AFTER_TEST
+	default LOG_MODE_DEFERRED
+endchoice
+choice LOG_BACKEND_RTT_MODE
+	# Do not block the logging thread in case of a full buffer
+	default LOG_BACKEND_RTT_MODE_DROP
+endchoice
+# RTT is the primary log backend for devices connected via JTAG or SWD without UARTs
+config LOG_BACKEND_RTT
+	default y if LOG
+
+endif


### PR DESCRIPTION
Automatically select LOG_BACKEND_RTT and LOG_MODE_DEFERRED for the DMC.

Also select `LOG_BACKEND_RTT_MODE_DROP` since otherwise, the system could lock up if the logging thread becomes blocked on available buffer space (which is an eventuality if there are no processes actively reading from it).

Due to a quirk in ZTest, there is a possibility that the core may halt before all log messages are retrieved via RTT console.

However, since ZTest waits until the log buffer is flushed (by default), then if we enable the RTT log backend, we can ensure that logging is not stopped prematurely and that twister is able to capture all of the log output.

https://github.com/zephyrproject-rtos/zephyr/blob/e1f4181c29960e5924779d64ad6ac7c8d6ad0259/subsys/testsuite/ztest/src/ztest.c#L723

Fixes #219

Additional p100 smoke testing showing success due to this change in https://github.com/tenstorrent/tt-zephyr-platforms/actions/runs/14981311604/job/42085862618?pr=172