### PR TITLE
boards: tt_blackhole: dmc: delete bias-pull-up property of i2c1

### DIFF
--- a/boards/tenstorrent/tt_blackhole/p300_tt_blackhole_dmc.dts
+++ b/boards/tenstorrent/tt_blackhole/p300_tt_blackhole_dmc.dts
@@ -10,6 +10,14 @@
 
 #include "tt_blackhole_base.dtsi"
 
+/* These two I/O have external pull-ups to 1.8V */
+&i2c1_scl_pa9 {
+	/delete-property/ bias-pull-up;
+};
+&i2c1_sda_pa10 {
+	/delete-property/ bias-pull-up;
+};
+
 /*
  * Left chip is local (comes up in non bifercation mode) this is referred to as chip1
  * in the schematics


### PR DESCRIPTION
Blackhole boards all have external resisters pulling-up SCL, SDA, and interrupt lines up to 1.8V.

Delete the devicetree property so that only one resister is pulling- up, and to minimize potential electrical issues.