### PR TITLE
Get board power limit from SPI FW Table

### DIFF
--- a/app/dmc/src/main.c
+++ b/app/dmc/src/main.c
@@ -148,25 +148,14 @@ uint16_t detect_max_pwr(void)
 		GPIO_DT_SPEC_GET_OR(DT_PATH(psu_sense0), gpios, {0});
 	static const struct gpio_dt_spec psu_sense1 =
 		GPIO_DT_SPEC_GET_OR(DT_PATH(psu_sense1), gpios, {0});
-	static const struct gpio_dt_spec board_id0 =
-		GPIO_DT_SPEC_GET_OR(DT_PATH(board_id0), gpios, {0});
 
 	gpio_pin_configure_dt(&psu_sense0, GPIO_INPUT);
 	gpio_pin_configure_dt(&psu_sense1, GPIO_INPUT);
-	gpio_pin_configure_dt(&board_id0, GPIO_INPUT);
 
 	int sense0_val = gpio_pin_get_dt(&psu_sense0);
 	int sense1_val = gpio_pin_get_dt(&psu_sense1);
-	int board_id0_val = gpio_pin_get_dt(&board_id0);
 
-	uint16_t board_pwr;
 	uint16_t psu_pwr;
-
-	if (board_id0_val) {
-		board_pwr = 450;
-	} else {
-		board_pwr = 300;
-	}
 
 	if (!sense0_val && !sense1_val) {
 		psu_pwr = 600;
@@ -187,7 +176,7 @@ uint16_t detect_max_pwr(void)
 		gpio_pin_configure_dt(&psu_sense0, GPIO_INPUT);
 	}
 
-	return MIN(board_pwr, psu_pwr);
+	return psu_pwr;
 }
 
 int main(void)

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P100A/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P100A/fw_table.txt
@@ -15,6 +15,7 @@ chip_limits {
   bus_peak_limit: 0
   frequency_margin: 0
   gddr_thm_limit: 85
+  board_power_limit: 300
 }
 
 feature_enable {

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P150A/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P150A/fw_table.txt
@@ -15,6 +15,7 @@ chip_limits {
   bus_peak_limit: 0
   frequency_margin: 0
   gddr_thm_limit: 85
+  board_power_limit: 300
 }
 
 feature_enable {

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P150B/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P150B/fw_table.txt
@@ -15,6 +15,7 @@ chip_limits {
   bus_peak_limit: 0
   frequency_margin: 0
   gddr_thm_limit: 85
+  board_power_limit: 300
 }
 
 feature_enable {

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P150C/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P150C/fw_table.txt
@@ -15,6 +15,7 @@ chip_limits {
   bus_peak_limit: 0
   frequency_margin: 0
   gddr_thm_limit: 85
+  board_power_limit: 450
 }
 
 feature_enable {

--- a/lib/tenstorrent/bh_arc/spirom_protobufs/fw_table.proto
+++ b/lib/tenstorrent/bh_arc/spirom_protobufs/fw_table.proto
@@ -33,6 +33,7 @@ message FwTable {
     int32 frequency_margin = 11;
     uint32 asic_fmin = 12;
     uint32 gddr_thm_limit = 13;
+    uint32 board_power_limit = 14;
   }
 
   message FeatureEnable {

--- a/lib/tenstorrent/bh_arc/throttler.c
+++ b/lib/tenstorrent/bh_arc/throttler.c
@@ -5,6 +5,7 @@
  */
 
 #include <zephyr/sys/util.h>
+#include <zephyr/logging/log.h>
 #include "throttler.h"
 #include "aiclk_ppm.h"
 #include "cm2dm_msg.h"
@@ -15,6 +16,7 @@
 #define kThrottlerAiclkScaleFactor 500.0F
 #define DEFAULT_BOARD_PWR_LIMIT 150
 
+LOG_MODULE_REGISTER(throttler);
 typedef enum {
 	kThrottlerTDP,
 	kThrottlerFastTDC,
@@ -144,8 +146,11 @@ static Throttler throttler[kThrottlerCount] = {
 
 static void SetThrottlerLimit(ThrottlerId id, float limit)
 {
-	throttler[id].limit =
+	float clamped_limit =
 		CLAMP(limit, throttler_limit_ranges[id].min, throttler_limit_ranges[id].max);
+
+	LOG_INF("Throttler %d limit set to %d\n", id, (uint32_t)clamped_limit);
+	throttler[id].limit = clamped_limit;
 }
 
 void InitThrottlers(void)

--- a/lib/tenstorrent/bh_arc/throttler.c
+++ b/lib/tenstorrent/bh_arc/throttler.c
@@ -6,6 +6,7 @@
 
 #include <zephyr/sys/util.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/sys/byteorder.h>
 #include "throttler.h"
 #include "aiclk_ppm.h"
 #include "cm2dm_msg.h"
@@ -208,7 +209,10 @@ int32_t Dm2CmSetBoardPwrLimit(const uint8_t *data, uint8_t size)
 		return -1;
 	}
 
-	uint16_t pwr_limit = *(uint16_t *)data;
+	uint32_t pwr_limit = sys_get_le16(data);
+
+	LOG_INF("Cable Power Limit: %u\n", pwr_limit);
+	pwr_limit = MIN(pwr_limit, get_fw_table()->chip_limits.board_power_limit);
 
 	SetThrottlerLimit(kThrottlerBoardPwr, pwr_limit);
 	UpdateTelemetryBoardPwrLimit(pwr_limit);


### PR DESCRIPTION
We have been getting the board power limit from a strapping GPIO connected to the DMC on p100a and p150a/b/c. However on the boards that we've checked, this strap does not follow our product definition.

Use a SPI FW table parameter to get this limit instead of the strapping GPIO. Update the limits to the product definition values.

Internal ticket: https://tenstorrent.atlassian.net/browse/SYS-1511