### PR TITLE
ci: switch back to hw-map.yml after dmc rename

### DIFF
--- a/.github/workflows/hardware-smoke.yml
+++ b/.github/workflows/hardware-smoke.yml
@@ -77,7 +77,7 @@ jobs:
           ./scripts/twister -i --retry-failed 3 \
             --retry-interval 5 \
             -p $DMC_BOARD --device-testing \
-            --hardware-map /opt/tenstorrent/twister/hw-map-dmc.yml --west-flash \
+            --hardware-map /opt/tenstorrent/twister/hw-map.yml --west-flash \
             --tag smoke \
             --alt-config-root ../tt-zephyr-platforms/test-conf/samples \
             --alt-config-root ../tt-zephyr-platforms/test-conf/tests \
@@ -111,7 +111,7 @@ jobs:
             --retry-interval 5 \
             --tag e2e \
             -p $DMC_BOARD --device-testing \
-            --hardware-map /opt/tenstorrent/twister/hw-map-dmc.yml --west-flash \
+            --hardware-map /opt/tenstorrent/twister/hw-map.yml --west-flash \
             -T ../tt-zephyr-platforms/app \
             --outdir twister-dmc-e2e
 
@@ -119,7 +119,7 @@ jobs:
           ./scripts/twister -i --retry-failed 3 \
             --retry-interval 5 \
             -p $SMC_BOARD --device-testing \
-            --hardware-map /opt/tenstorrent/twister/hw-map-dmc.yml --west-flash \
+            --hardware-map /opt/tenstorrent/twister/hw-map.yml --west-flash \
             --tag smoke \
             --alt-config-root ../tt-zephyr-platforms/test-conf/samples \
             --alt-config-root ../tt-zephyr-platforms/test-conf/tests \
@@ -218,7 +218,7 @@ jobs:
             --retry-interval 5 \
             --tag e2e \
             -p $DMC_BOARD --device-testing \
-            --hardware-map /opt/tenstorrent/twister/hw-map-dmc.yml --west-flash \
+            --hardware-map /opt/tenstorrent/twister/hw-map.yml --west-flash \
             -T ../tt-zephyr-platforms/app \
             --outdir twister-dmc-e2e
           # Run E2E test to verify DMC and SMC firmware boot, and that
@@ -226,7 +226,7 @@ jobs:
           ./scripts/twister -i --retry-failed 3 \
             -p $SMC_BOARD --device-testing \
             --tag e2e \
-            --hardware-map /opt/tenstorrent/twister/hw-map-dmc.yml --west-flash \
+            --hardware-map /opt/tenstorrent/twister/hw-map.yml --west-flash \
             -T ../tt-zephyr-platforms/app \
             --outdir twister-smc-e2e
 

--- a/.github/workflows/hardware-smoke.yml
+++ b/.github/workflows/hardware-smoke.yml
@@ -38,9 +38,7 @@ jobs:
       image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.27.4.20241026
       volumes:
         - /dev/hugepages-1G:/dev/hugepages-1G
-        - /opt/tenstorrent/fw/stable:/opt/tenstorrent/fw/stable
-        - /opt/tenstorrent/twister:/opt/tenstorrent/twister
-        - /opt/tenstorrent/bin/openocd-rtt:/opt/tenstorrent/bin/openocd-rtt
+        - /opt/tenstorrent:/opt/tenstorrent
       options: '--device /dev/tenstorrent --device /dev/bus/usb --privileged'
     steps:
       - uses: actions/checkout@v4
@@ -174,9 +172,7 @@ jobs:
       image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.27.4.20241026
       volumes:
         - /dev/hugepages-1G:/dev/hugepages-1G
-        - /opt/tenstorrent/fw/stable:/opt/tenstorrent/fw/stable
-        - /opt/tenstorrent/twister:/opt/tenstorrent/twister
-        - /opt/tenstorrent/bin/openocd-rtt:/opt/tenstorrent/bin/openocd-rtt
+        - /opt/tenstorrent:/opt/tenstorrent
       options: '--device /dev/tenstorrent --device /dev/bus/usb --privileged'
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/hardware-smoke.yml
+++ b/.github/workflows/hardware-smoke.yml
@@ -147,7 +147,7 @@ jobs:
         working-directory: tt-zephyr-platforms
         run: |
           echo "DMC RTT logs:"
-          python3 ./scripts/dmc_rtt.py -n --openocd /opt/tenstorrent/bin/openocd-rtt
+          python3 ./scripts/dmc_rtt.py -n
           echo "SMC RTT logs:"
           python3 ./scripts/smc_rtt.py -n --openocd /opt/tenstorrent/bin/openocd-rtt
 
@@ -261,6 +261,6 @@ jobs:
         working-directory: tt-zephyr-platforms
         run: |
           echo "DMC RTT logs:"
-          python3 ./scripts/dmc_rtt.py -n --openocd /opt/tenstorrent/bin/openocd-rtt
+          python3 ./scripts/dmc_rtt.py -n
           echo "SMC RTT logs:"
           python3 ./scripts/smc_rtt.py -n --openocd /opt/tenstorrent/bin/openocd-rtt


### PR DESCRIPTION
Change workflows to use hw-map.yml instead of hw-map-dmc.yml after renaming bmc to dmc.

Additionally:
* ci: hardware-smoke: mount /opt/tenstorrent volume once
* ci: hardware-smoke: only use openocd-rtt for arc