### PR TITLE
doc: release: v18.3.0: add release notes template and migration guide

### DIFF
--- a/doc/release/migration-guide-18.3.0.md
+++ b/doc/release/migration-guide-18.3.0.md
@@ -1,0 +1,7 @@
+# Migration Guide: TT-Zephyr-Platforms v18.2.0
+
+---
+
+This document lists recommended and required changes for those migrating from the previous v18.2.0 firmware release to the new v18.3.0 firmware release.
+
+[comment]: <> (UL by area, indented as necessary)

--- a/doc/release/release-notes-18.3.0.md
+++ b/doc/release/release-notes-18.3.0.md
@@ -1,0 +1,40 @@
+# TT-Zephyr-Platforms v18.3.0
+
+---
+
+We are pleased to announce the release of TT Zephyr Platforms firmware version 18.3.0 🥳🎉.
+
+Major enhancements with this release include:
+
+[comment]: <> (H3 Performance Improvements, if applicable)
+[comment]: <> (H3 New and Experimental Features, if applicable)
+[comment]: <> (H3 External Project Collaboration Efforts, if applicable)
+[comment]: <> (H3 Stability Improvements, if applicable)
+[comment]: <> (H1 Security vulnerabilities fixed?)
+
+## Migration guide
+
+An overview of required and recommended changes to make when migrating from the previous v18.2.0 release can be found in [v18.3.0 Migration Guide](https://github.com/tenstorrent/tt-zephyr-platforms/tree/main/doc/release/migration-guide-v18.3.0.md).
+
+## API Changes
+
+[comment]: <> (H3 Removed APIs, if applicable)
+
+[comment]: <> (same order for Subsequent H2 sections)
+[comment]: <> (UL PCIe)
+[comment]: <> (UL DDR)
+[comment]: <> (UL Ethernet)
+[comment]: <> (UL Telemetry)
+[comment]: <> (UL Debug / Developer Features)
+[comment]: <> (UL Drivers)
+[comment]: <> (UL Libraries)
+
+[comment]: <> (H3 Deprecated APIs, if applicable)
+
+[comment]: <> (H3 New APIs, if applicable)
+
+[comment]: <> (H2 New Boards, if applicable)
+
+[comment]: <> (H2 New Samples, if applicable)
+
+[comment]: <> (H2 Other Notable Changes, if applicable)


### PR DESCRIPTION
Add a blank template for v18.3.0 release notes and migration guide.