### PR TITLE
doc: release: v18.3.0: correct version in migration guide

### DIFF
--- a/doc/release/migration-guide-18.3.0.md
+++ b/doc/release/migration-guide-18.3.0.md
@@ -1,4 +1,4 @@
-# Migration Guide: TT-Zephyr-Platforms v18.2.0
+# Migration Guide: TT-Zephyr-Platforms v18.3.0
 
 ---
 


### PR DESCRIPTION
Correct the version number in the migration guide from v18.2.0 to v18.3.0