### PR TITLE
scripts: pcie_utils.py: rescan even if no card is on bus

### DIFF
--- a/scripts/pcie_utils.py
+++ b/scripts/pcie_utils.py
@@ -27,18 +27,23 @@ def rescan_pcie():
     """
     # First, we must find the PCIe card to power it off
     dev = find_tt_bus()
-    if dev is None:
-        raise RuntimeError("No tenstorrent card found to power off")
-    print(f"Powering off device at {dev}")
+    if dev is not None:
+        print(f"Powering off device at {dev}")
+        try:
+            with open(os.path.join(dev, "remove"), "w") as f:
+                f.write("1")
+        except PermissionError as e:
+            print(
+                "Error, this script must be run with elevated permissions to rescan PCIe bus"
+            )
+            raise e
+    # Now, rescan the bus
     try:
-        with open(os.path.join(dev, "remove"), "w") as f:
+        with open("/sys/bus/pci/rescan", "w") as f:
             f.write("1")
+            time.sleep(1)
     except PermissionError as e:
         print(
             "Error, this script must be run with elevated permissions to rescan PCIe bus"
         )
         raise e
-    # Now, rescan the bus
-    with open("/sys/bus/pci/rescan", "w") as f:
-        f.write("1")
-        time.sleep(1)


### PR DESCRIPTION
Commit d33106d (app: pytest: e2e_smoke: support rescan if no card is on bus) added this behavior to the e2e smoke test, but commit d1ea6e1 (boards: tt_blackhole: rename bmc to dmc to avoid confusion) did not port the behavior into the new pcie_utils.py script. Reintroduce it.