### PR TITLE
scripts: tt-console: support accessing console via JTAG

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -27,8 +27,19 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          path: tt-zephyr-platforms
           ref: ${{ github.ref }}
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Fetch dependencies
+        run: |
+          pip install west
+          west init -l tt-zephyr-platforms
+          west update libjaylink
+
       - name: Run the script
         run: |
-          gcc -Iinclude -O0 -g -Wall -Wextra -Werror -std=gnu11 -o tt-console \
-            scripts/tt-console/console.c
+          cd tt-zephyr-platforms/scripts/tt-console
+          ./build.sh

--- a/.github/workflows/prepare-zephyr/action.yml
+++ b/.github/workflows/prepare-zephyr/action.yml
@@ -17,12 +17,19 @@ runs:
       with:
         python-version: '3.10'
 
-    - name: Install curl
+    - name: Install dependencies
       shell: bash
       run: |
         if ! command -v curl &> /dev/null ; then
-          apt-get update
-          apt-get install -y curl
+          sudo apt-get update
+          sudo apt-get install -y curl
+        fi
+        if pkg-config --exists libusb-1.0; then
+          echo "Found libusb"
+        else
+          echo "Installing libusb"
+          sudo apt-get update
+          sudo apt-get install -y libusb-1.0-0-dev
         fi
 
     - name: Install Rust

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -63,6 +63,13 @@ Release Notes:
   description: |
     Maintained upstream.
 
+"West project: libjaylink":
+  status: odd fixes
+  files: []
+  labels: []
+  description: |
+    Maintained upstream.
+
 "West project: zephyr":
   status: odd fixes
   files: []

--- a/app/smc/pytest/vuart.py
+++ b/app/smc/pytest/vuart.py
@@ -55,8 +55,8 @@ def test_boot_banner_pcie(tt_console: Path, arc_chip):
 def test_boot_banner_jtag(tt_console: Path, arc_chip):
     arc_chip.axi_read32(ARC_STATUS)
 
-    # run 'tt-console' in quiet mode, and timeout after 10 seconds
-    cmd = f"{tt_console} -q -j -w 10000"
+    # run 'tt-console' in quiet mode, and timeout after 2 seconds
+    cmd = f"{tt_console} -q -j -w 2000"
     proc = subprocess.run(cmd.split(), capture_output=True, check=True)
 
     out = proc.stdout.decode("utf-8")

--- a/app/smc/pytest/vuart.py
+++ b/app/smc/pytest/vuart.py
@@ -17,9 +17,14 @@ CONSOLE_C = MODULE_ROOT / "scripts" / "tt-console" / "console.c"
 
 @pytest.fixture(scope="session")
 def tt_console(tmp_path_factory: Path):
-    tt_console_exe = tmp_path_factory.getbasetemp() / "tt-console"
-    cmd = f"gcc -O0 -g -Wall -Wextra -Werror -std=gnu11 -I {MODULE_ROOT}/include -o {tt_console_exe} {CONSOLE_C}"
-    subprocess.run(cmd.split(), capture_output=True, check=True)
+    tt_console_inst_dir = tmp_path_factory.getbasetemp() / "tt-console-install"
+    tt_console_exe = tt_console_inst_dir / "usr" / "local" / "bin" / "tt-console"
+    cmd = f"./autogen.sh; DESTDIR={tt_console_inst_dir} ./configure;"
+    cmd += f"DESTDIR={tt_console_inst_dir} make -j $(nproc);"
+    cmd += f"DESTDIR={tt_console_inst_dir} make install"
+    subprocess.run(
+        cmd, capture_output=True, shell=True, check=True, cwd=CONSOLE_C.parents[0]
+    )
     return tt_console_exe
 
 

--- a/app/smc/pytest/vuart.py
+++ b/app/smc/pytest/vuart.py
@@ -28,7 +28,7 @@ def tt_console(tmp_path_factory: Path):
     return tt_console_exe
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="function")
 def arc_chip(unlaunched_dut: DeviceAdapter):
     return get_arc_chip(unlaunched_dut)
 
@@ -37,11 +37,26 @@ def test_compile_tt_console(tt_console: Path):
     assert os.access(tt_console, os.X_OK)
 
 
-def test_boot_banner(tt_console: Path, arc_chip):
+def test_boot_banner_pcie(tt_console: Path, arc_chip):
     arc_chip.axi_read32(ARC_STATUS)
 
     # run 'tt-console' in quiet mode, and timeout after 500ms
     cmd = f"{tt_console} -q -w 500"
+    proc = subprocess.run(cmd.split(), capture_output=True, check=True)
+
+    out = proc.stdout.decode("utf-8")
+
+    # check that the boot banner is seen on the console
+    assert "Booting tt_blackhole with Zephyr OS" in out
+
+    print(f"\nconsole output successfully captured:\n{out}")
+
+
+def test_boot_banner_jtag(tt_console: Path, arc_chip):
+    arc_chip.axi_read32(ARC_STATUS)
+
+    # run 'tt-console' in quiet mode, and timeout after 10 seconds
+    cmd = f"{tt_console} -q -j -w 10000"
     proc = subprocess.run(cmd.split(), capture_output=True, check=True)
 
     out = proc.stdout.decode("utf-8")

--- a/app/smc/sample.yaml
+++ b/app/smc/sample.yaml
@@ -45,8 +45,6 @@ tests:
     harness_config:
       pytest_root:
         - pytest/vuart.py
-      pytest_args:
-        - "--dut-scope=session"
     extra_dtc_overlay_files:
       - vuart.overlay
     extra_overlay_confs:

--- a/scripts/tt-console/.gitignore
+++ b/scripts/tt-console/.gitignore
@@ -1,0 +1,14 @@
+.deps/*
+Makefile
+Makefile.in
+aclocal.m4
+autom4te.cache/*
+compile
+config.h
+config.h.in
+config.status
+configure
+depcomp
+install-sh
+missing
+stamp-h1

--- a/scripts/tt-console/.gitignore
+++ b/scripts/tt-console/.gitignore
@@ -1,4 +1,6 @@
+.libs/*
 .deps/*
+ar-lib
 Makefile
 Makefile.in
 aclocal.m4
@@ -7,8 +9,14 @@ compile
 config.h
 config.h.in
 config.status
+config.guess
+config.sub
 configure
 depcomp
 install-sh
 missing
+libmemdriver*
+libtool
+ltmain.sh
 stamp-h1
+tt-console

--- a/scripts/tt-console/.gitignore
+++ b/scripts/tt-console/.gitignore
@@ -20,3 +20,4 @@ libtool
 ltmain.sh
 stamp-h1
 tt-console
+tt-console-memtest

--- a/scripts/tt-console/Makefile.am
+++ b/scripts/tt-console/Makefile.am
@@ -1,0 +1,3 @@
+bin_PROGRAMS = tt-console
+tt_console_SOURCES = console.c
+tt_console_CPPFLAGS = -g -O0 -std=gnu11 -I ../../include

--- a/scripts/tt-console/Makefile.am
+++ b/scripts/tt-console/Makefile.am
@@ -6,6 +6,6 @@ tt_console_CPPFLAGS = -g -O0 -std=gnu11 -I ../../include -Wall -Werror
 noinst_LTLIBRARIES = libmemdriver.la
 libmemdriver_la_LIBADD = ../../../modules/libjaylink/libjaylink/libjaylink.la
 libmemdriver_la_CPPFLAGS = -I ../../../modules/libjaylink/ -g -O0 -std=gnu11 -I ../../include -Wall -Werror
-libmemdriver_la_SOURCES = arc_jtag.c
+libmemdriver_la_SOURCES = arc_jtag.c arc_tlb.c
 
 tt_console_LDADD = libmemdriver.la

--- a/scripts/tt-console/Makefile.am
+++ b/scripts/tt-console/Makefile.am
@@ -1,11 +1,15 @@
 AUTOMAKE_OPTIONS = subdir-objects
 SUBDIRS=../../../modules/libjaylink
 bin_PROGRAMS = tt-console
+noinst_PROGRAMS = tt-console-memtest
 tt_console_SOURCES = console.c
+tt_console_memtest_SOURCES = test.c
 tt_console_CPPFLAGS = -g -O0 -std=gnu11 -I ../../include -Wall -Werror
+tt_console_memtest_CPPFLAGS = -g -O0 -std=gnu11 -I ../../include -Wall -Werror
 noinst_LTLIBRARIES = libmemdriver.la
 libmemdriver_la_LIBADD = ../../../modules/libjaylink/libjaylink/libjaylink.la
 libmemdriver_la_CPPFLAGS = -I ../../../modules/libjaylink/ -g -O0 -std=gnu11 -I ../../include -Wall -Werror
 libmemdriver_la_SOURCES = arc_jtag.c arc_tlb.c
 
 tt_console_LDADD = libmemdriver.la
+tt_console_memtest_LDADD = libmemdriver.la

--- a/scripts/tt-console/Makefile.am
+++ b/scripts/tt-console/Makefile.am
@@ -1,3 +1,11 @@
+AUTOMAKE_OPTIONS = subdir-objects
+SUBDIRS=../../../modules/libjaylink
 bin_PROGRAMS = tt-console
 tt_console_SOURCES = console.c
-tt_console_CPPFLAGS = -g -O0 -std=gnu11 -I ../../include
+tt_console_CPPFLAGS = -g -O0 -std=gnu11 -I ../../include -Wall -Werror
+noinst_LTLIBRARIES = libmemdriver.la
+libmemdriver_la_LIBADD = ../../../modules/libjaylink/libjaylink/libjaylink.la
+libmemdriver_la_CPPFLAGS = -I ../../../modules/libjaylink/ -g -O0 -std=gnu11 -I ../../include -Wall -Werror
+libmemdriver_la_SOURCES = arc_jtag.c
+
+tt_console_LDADD = libmemdriver.la

--- a/scripts/tt-console/arc_jtag.c
+++ b/scripts/tt-console/arc_jtag.c
@@ -1,0 +1,1 @@
+/* Stub file */

--- a/scripts/tt-console/arc_jtag.c
+++ b/scripts/tt-console/arc_jtag.c
@@ -1,1 +1,775 @@
-/* Stub file */
+/*
+ * Copyright (c) 2025 Tenstorrent AI ULC
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ */
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <errno.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <libjaylink/libjaylink.h>
+
+#include "arc_jtag.h"
+
+#define D(level, fmt, ...)                                                      \
+	if (verbose >= level) {                                                 \
+		printf("D: %s(): " fmt "\r\n", __func__, ##__VA_ARGS__);        \
+	}
+
+#define E(fmt, ...) fprintf(stderr, "E: %s(): " fmt "\r\n", __func__, ##__VA_ARGS__)
+
+#define I(fmt, ...)                                                             \
+	if (verbose >= 0) {                                                     \
+		printf(fmt "\r\n", ##__VA_ARGS__);                              \
+	}
+
+static struct jaylink_context *ctx;
+static struct jaylink_device_handle *devh;
+static int verbose;
+static uint8_t caps[JAYLINK_DEV_EXT_CAPS_SIZE];
+static struct jaylink_connection conn;
+
+#define DIV_ROUND_UP(val, div) ((((val) + ((div) - 1))) / (div))
+
+#define JTAG_QUEUE_SIZE 256 /* Number of JTAG states we can queue transations between */
+
+/* ARC JTAG definitions */
+#define ARC_IDCODE 0x201444B1
+
+#define ARC_JTAG_STATUS_REG 0x8
+#define ARC_TRANSACTION_CMD_REG 0x9
+#define ARC_ADDRESS_REG 0xa
+#define ARC_DATA_REG 0xb
+#define ARC_IDCODE_REG 0xc
+#define ARC_BYPASS_REG 0xf
+
+#define ARC_TRANSACTION_WRITE_MEM 0x0
+#define ARC_TRANSACTION_WRITE_REG 0x1
+#define ARC_TRANSACTION_WRITE_AUX_REG 0x2
+#define ARC_TRANSACTION_NOP 0x3
+#define ARC_TRANSACTION_READ_MEM 0x4
+#define ARC_TRANSACTION_READ_REG 0x5
+#define ARC_TRANSACTION_READ_AUX_REG 0x6
+
+struct tdo_buffer {
+	uint8_t *buf;
+	int bit_len;
+	struct tdo_buffer *next;
+};
+
+/* Tracks queued JTAG transactions */
+static struct {
+	uint8_t tms[JTAG_QUEUE_SIZE / 8];
+	uint8_t tdi[JTAG_QUEUE_SIZE / 8];
+	uint8_t tdo[JTAG_QUEUE_SIZE / 8];
+	uint8_t ir_len;
+	uint8_t bypass_dr_len;
+	uint8_t tap_count;
+	uint32_t queue_idx;
+	/* Linked list of output buffers */
+	struct tdo_buffer *tdo_buf_list;
+} jtag_queue;
+
+/*
+ * Performs a bitwise copy into `dst`. Copy is started from `src_offset` offset
+ * in `src`, to the bit offset `dst_offset` in `dst`. `bit_len` bits are copied.
+ */
+static void bitcopy(uint8_t *dst, const uint8_t *src, int dst_offset, int src_offset, int bit_len)
+{
+	for (int i = 0; i < bit_len; i++) {
+		int dst_bit_off = (dst_offset + i) % 8;
+		int dst_byte_off = (dst_offset + i) / 8;
+		int src_bit_off = (src_offset + i) % 8;
+		int src_byte_off = (src_offset + i) / 8;
+
+		if (src[src_byte_off] & (1 << src_bit_off)) {
+			dst[dst_byte_off] |= (1 << dst_bit_off);
+		} else {
+			dst[dst_byte_off] &= ~(1 << dst_bit_off);
+		}
+	}
+}
+
+/*
+ * Zeros out the bits in `dst` starting from `dst_offset` to `bit_len` bits.
+ */
+static void bitzero(uint8_t *dst, int dst_offset, int bit_len)
+{
+	for (int i = 0; i < bit_len; i++) {
+		int bit_offset = (dst_offset + i) % 8;
+		int byte_offset = (dst_offset + i) / 8;
+
+		dst[byte_offset] &= ~(1 << bit_offset);
+	}
+}
+
+static int jtag_queue_transaction(const uint8_t *tms, const uint8_t *tdi, uint8_t *tdo, int bit_len)
+{
+	struct tdo_buffer *buf;
+
+	if (jtag_queue.queue_idx + bit_len > JTAG_QUEUE_SIZE) {
+		E("JTAG queue overflow");
+		return -ENOBUFS;
+	}
+
+	/* Enqueue the TMS, TDI, and TDO data */
+	if (tms) {
+		bitcopy(jtag_queue.tms, tms, jtag_queue.queue_idx, 0, bit_len);
+	} else {
+		bitzero(jtag_queue.tms, jtag_queue.queue_idx, bit_len);
+	}
+	if (tdi) {
+		bitcopy(jtag_queue.tdi, tdi, jtag_queue.queue_idx, 0, bit_len);
+	} else {
+		bitzero(jtag_queue.tdi, jtag_queue.queue_idx, bit_len);
+	}
+	buf = malloc(sizeof(struct tdo_buffer));
+	if (!buf) {
+		E("Failed to allocate memory for TDO buffer");
+		return -ENOMEM;
+	}
+	buf->buf = tdo;
+	buf->bit_len = bit_len;
+	buf->next = NULL;
+	/* Append this buffer to the linked list */
+	if (jtag_queue.tdo_buf_list == NULL) {
+		jtag_queue.tdo_buf_list = buf;
+	} else {
+		struct tdo_buffer *cur = jtag_queue.tdo_buf_list;
+
+		while (cur->next) {
+			cur = cur->next;
+		}
+		cur->next = buf;
+	}
+
+	jtag_queue.queue_idx += bit_len;
+
+	return 0;
+}
+
+static int jtag_enqueue_write_ir(uint8_t *data, int tap_idx, int bit_len, bool return_to_idle)
+{
+	int ret;
+	uint8_t tms[DIV_ROUND_UP(bit_len, 8)];
+	uint8_t tdi;
+
+	/* Enqueue transation into SHIFT-IR state. Assume we start in run/test idle */
+	tms[0] = 0x3;
+	ret = jtag_queue_transaction(tms, NULL, NULL, 3);
+	if (ret < 0) {
+		return ret;
+	}
+	/* Now, enqueue IR writes for the TAPs in bypass before this one */
+	memset(tms, 0, sizeof(tms));
+	for (int i = 0; i < jtag_queue.tap_count; i++) {
+		if (i == tap_idx) {
+			/* Enqueue the IR write */
+			if (i == jtag_queue.tap_count - 1) {
+				/* Set high bit of TMS to exit IR write */
+				tms[DIV_ROUND_UP(bit_len, 8) - 1] = 1 << ((bit_len - 1) % 8);
+			} else {
+				tms[DIV_ROUND_UP(bit_len, 8) - 1] = 0;
+			}
+			ret = jtag_queue_transaction(tms, data, NULL, bit_len);
+			if (ret < 0) {
+				return ret;
+			}
+		} else {
+			/* Enqueue the bypass IR write */
+			if (jtag_queue.ir_len > (sizeof(tdi) * 8)) {
+				E("IR length exceeds buffer size");
+				return -EINVAL;
+			}
+			if (i == jtag_queue.tap_count - 1) {
+				/* Set high bit of TMS to exit IR write */
+				tms[0] = 1 << ((jtag_queue.ir_len - 1) % 8);
+			} else {
+				tms[0] = 0;
+			}
+			tdi = (1 << jtag_queue.ir_len) - 1;
+			ret = jtag_queue_transaction(tms, &tdi, NULL, jtag_queue.ir_len);
+			if (ret < 0) {
+				return ret;
+			}
+		}
+	}
+	tms[0] = 0x1;
+
+	return jtag_queue_transaction(tms, NULL, NULL, return_to_idle ? 2 : 1);
+}
+
+static int jtag_enqueue_write_dr(const uint8_t *data, int tap_idx, int bit_len, bool return_to_idle)
+{
+	int ret;
+	uint8_t tms[DIV_ROUND_UP(bit_len, 8)];
+	uint8_t tdi;
+
+	/* Enqueue transation into SHIFT-DR state. Assume we start in run/test idle */
+	tms[0] = 0x1;
+	ret = jtag_queue_transaction(tms, NULL, NULL, 3);
+	if (ret < 0) {
+		return ret;
+	}
+	/* Now, enqueue DR writes for the TAPs in bypass before this one */
+	memset(tms, 0, sizeof(tms));
+	for (int i = 0; i < jtag_queue.tap_count; i++) {
+		if (i == tap_idx) {
+			/* Enqueue the DR write */
+			if (i == jtag_queue.tap_count - 1) {
+				/* Set high bit of TMS to exit DR shift */
+				tms[DIV_ROUND_UP(bit_len, 8) - 1] = 1 << ((bit_len - 1) % 8);
+			} else {
+				tms[DIV_ROUND_UP(bit_len, 8) - 1] = 0;
+			}
+			ret = jtag_queue_transaction(tms, data, NULL, bit_len);
+			if (ret < 0) {
+				return ret;
+			}
+		} else {
+			/* Enqueue the bypass DR write */
+			if (jtag_queue.bypass_dr_len > (sizeof(tdi) * 8)) {
+				E("DR length exceeds buffer size");
+				return -EINVAL;
+			}
+			if (i == jtag_queue.tap_count - 1) {
+				/* Set high bit of TMS to exit DR shift */
+				tms[0] = 1 << ((jtag_queue.bypass_dr_len - 1) % 8);
+			} else {
+				tms[0] = 0;
+			}
+			tdi = (1 << jtag_queue.bypass_dr_len) - 1;
+			ret = jtag_queue_transaction(tms, &tdi, NULL, jtag_queue.bypass_dr_len);
+			if (ret < 0) {
+				return ret;
+			}
+		}
+	}
+	tms[0] = 0x1;
+
+	return jtag_queue_transaction(tms, NULL, NULL, return_to_idle ? 2 : 1);
+}
+
+static int jtag_enqueue_read_dr(uint8_t *data, int tap_idx, int bit_len, bool return_to_idle)
+{
+	int ret;
+	uint8_t tms[DIV_ROUND_UP(bit_len, 8)];
+	uint8_t tdi;
+
+	/* Enqueue transation into SHIFT-DR state. Assume we start in run/test idle */
+	tms[0] = 0x1;
+	ret = jtag_queue_transaction(tms, NULL, NULL, 3);
+	if (ret < 0) {
+		return ret;
+	}
+	memset(tms, 0, sizeof(tms));
+	/* Now, enqueue IR writes for the TAPs in bypass before this one */
+	for (int i = 0; i < jtag_queue.tap_count; i++) {
+		if (i == tap_idx) {
+			/* Enqueue the DR write */
+			if (i == jtag_queue.tap_count - 1) {
+				/* Set high bit of TMS to exit DR shift */
+				tms[DIV_ROUND_UP(bit_len, 8) - 1] = 1 << ((bit_len - 1) % 8);
+			} else {
+				tms[DIV_ROUND_UP(bit_len, 8) - 1] = 0;
+			}
+			ret = jtag_queue_transaction(tms, NULL, data, bit_len);
+			if (ret < 0) {
+				return ret;
+			}
+		} else {
+			/* Enqueue the bypass DR write */
+			if (jtag_queue.bypass_dr_len > (sizeof(tdi) * 8)) {
+				E("DR length exceeds buffer size");
+				return -EINVAL;
+			}
+			if (i == jtag_queue.tap_count - 1) {
+				/* Set high bit of TMS to exit DR shift */
+				tms[0] = 1 << ((jtag_queue.bypass_dr_len - 1) % 8);
+			} else {
+				tms[0] = 0;
+			}
+			tdi = (1 << jtag_queue.bypass_dr_len) - 1;
+			ret = jtag_queue_transaction(tms, &tdi, NULL, jtag_queue.bypass_dr_len);
+			if (ret < 0) {
+				return ret;
+			}
+		}
+	}
+	tms[0] = 0x1;
+
+	return jtag_queue_transaction(tms, NULL, NULL, return_to_idle ? 2 : 1);
+}
+
+static int jtag_execute_queue(void)
+{
+	int ret;
+	int bit_idx = 0;
+	struct tdo_buffer *tdo_buf = jtag_queue.tdo_buf_list;
+	struct tdo_buffer *next_buf;
+
+	/* Execute the queued transactions */
+	ret = jaylink_jtag_io(devh, jtag_queue.tms, jtag_queue.tdi,
+			      jtag_queue.tdo, jtag_queue.queue_idx,
+			      JAYLINK_JTAG_VERSION_3);
+	if (ret != JAYLINK_OK) {
+		E("Failed to execute JTAG queue: %s", jaylink_strerror(ret));
+		return ret;
+	}
+	/* Copy out TDO data */
+	while (tdo_buf) {
+		if (tdo_buf->buf) {
+			bitcopy(tdo_buf->buf, jtag_queue.tdo, 0, bit_idx, tdo_buf->bit_len);
+		}
+		bit_idx += tdo_buf->bit_len;
+		next_buf = tdo_buf->next;
+		free(tdo_buf);
+		tdo_buf = next_buf;
+	}
+	if (bit_idx != jtag_queue.queue_idx) {
+		E("TDO data length mismatch: expected %d, got %d", jtag_queue.queue_idx, bit_idx);
+		return -EINVAL;
+	}
+	/* Reset queue state */
+	jtag_queue.queue_idx = 0;
+	jtag_queue.tdo_buf_list = NULL;
+	return 0;
+}
+
+static int jtag_go_idle(void)
+{
+	uint8_t tms = 0x1f;
+	int ret;
+
+	/* Move to run/test idle state */
+	ret = jtag_queue_transaction(&tms, NULL, NULL, 6);
+	if (ret != 0) {
+		return ret;
+	}
+	ret = jtag_execute_queue();
+	if (ret != 0) {
+		return ret;
+	}
+
+	return 0;
+}
+
+static void arc_jtag_queue_init(void)
+{
+	/*
+	 * In the future, we could replace this with a function that
+	 * detects the TAPs in the chain and sets the bypass length
+	 * accordingly. For now, we hardcode the values for the ARC TAPs.
+	 */
+	jtag_queue.ir_len = 4;
+	jtag_queue.bypass_dr_len = 1;
+	jtag_queue.tap_count = 5;
+	jtag_queue.queue_idx = 0;
+	jtag_queue.tdo_buf_list = NULL;
+	memset(jtag_queue.tms, 0, sizeof(jtag_queue.tms));
+	memset(jtag_queue.tdi, 0, sizeof(jtag_queue.tdi));
+	memset(jtag_queue.tdo, 0, sizeof(jtag_queue.tdo));
+}
+
+/*
+ * Reads IDCODE register from TAP 0 for attached device
+ */
+static int arc_jtag_read_idcode(uint32_t *idcode)
+{
+	int ret;
+	uint8_t data;
+
+	data = 0xc;
+	/* Write IR to read IDCode */
+	ret = jtag_enqueue_write_ir(&data, 0, 4, true);
+	if (ret < 0) {
+		E("Error, failed to queue IR write for IDCODE\n");
+		return ret;
+	}
+	/* Read IDCode */
+	ret = jtag_enqueue_read_dr((uint8_t *)idcode, 0, 32, true);
+	if (ret < 0) {
+		E("Error, failed to queue DR read for IDCODE\n");
+		return ret;
+	}
+	ret = jtag_execute_queue();
+	if (ret < 0) {
+		E("Error, failed to execute JTAG queue\n");
+		return ret;
+	}
+	return ret;
+}
+
+/*
+ * Reads `len` bytes of device memory, starting at address `start_addr` into
+ * `buf`. This function is specific to the JTAG implementation on ARC HS4x.
+ */
+int arc_jtag_read_mem(uint32_t start_addr, uint8_t *buf, size_t len)
+{
+	int ret;
+	uint8_t data;
+	uint32_t aligned_addr = start_addr & ~0x3;
+	uint32_t unaligned_start_cnt = (start_addr & 0x3) ? 4 - (start_addr & 0x3) : 0;
+	uint32_t aligned_cnt = (len - unaligned_start_cnt) & ~0x3;
+	uint32_t unaligned_end_cnt = len - (aligned_cnt + unaligned_start_cnt);
+	uint8_t temp[4];
+	size_t cpy_idx = 0;
+
+	/* Write to IR to select transaction CMD on TAP 1 */
+	data = ARC_TRANSACTION_CMD_REG;
+	ret = jtag_enqueue_write_ir(&data, 1, 4, false);
+	if (ret < 0) {
+		E("Error, failed to queue IR write for transaction CMD\n");
+		return ret;
+	}
+	/* Select memory read transaction */
+	data = ARC_TRANSACTION_READ_MEM;
+	ret = jtag_enqueue_write_dr(&data, 1, 4, false);
+	if (ret < 0) {
+		E("Error, failed to queue DR write for transaction CMD\n");
+		return ret;
+	}
+	/* Write to IR to select address on TAP 1 */
+	data = ARC_ADDRESS_REG;
+	ret = jtag_enqueue_write_ir(&data, 1, 4, false);
+	if (ret < 0) {
+		E("Error, failed to queue IR write for address CMD\n");
+		return ret;
+	}
+	/* Write DR with address we want to access. Return to idle so transaction runs */
+	ret = jtag_enqueue_write_dr((uint8_t *)&aligned_addr, 1, 32, true);
+	if (ret < 0) {
+		E("Error, failed to queue DR write for address CMD\n");
+		return ret;
+	}
+	/* Write to IR to select data reg */
+	data = ARC_DATA_REG;
+	ret = jtag_enqueue_write_ir(&data, 1, 4, true);
+	if (ret < 0) {
+		E("Error, failed to queue IR write for data CMD\n");
+		return ret;
+	}
+	if (unaligned_start_cnt) {
+		/* Read the first word, but only the last `unaligned_start_cnt` bytes */
+		ret = jtag_enqueue_read_dr(temp, 1, 32, true);
+		if (ret < 0) {
+			E("Error, failed to queue DR read for data CMD\n");
+			return ret;
+		}
+		ret = jtag_execute_queue();
+		if (ret < 0) {
+			E("Error, failed to execute JTAG queue\n");
+			return ret;
+		}
+		memcpy(&buf[cpy_idx], &temp[4 - unaligned_start_cnt], unaligned_start_cnt);
+		cpy_idx += unaligned_start_cnt;
+	}
+	/* ARC supports automatic address increment, so just keep executing DR reads */
+	for (; cpy_idx < (unaligned_start_cnt + aligned_cnt); cpy_idx += 4) {
+		ret = jtag_enqueue_read_dr(&buf[cpy_idx], 1, 32, true);
+		if (ret < 0) {
+			E("Error, failed to queue DR read for data CMD\n");
+			return ret;
+		}
+		ret = jtag_execute_queue();
+		if (ret < 0) {
+			E("Error, failed to execute JTAG queue\n");
+			return ret;
+		}
+	}
+	if (unaligned_end_cnt) {
+		/* Read the last word, but only the first `unaligend_end_cnt` bytes */
+		ret = jtag_enqueue_read_dr(temp, 1, 32, true);
+		if (ret < 0) {
+			E("Error, failed to queue DR read for data CMD\n");
+			return ret;
+		}
+		ret = jtag_execute_queue();
+		if (ret < 0) {
+			E("Error, failed to execute JTAG queue\n");
+			return ret;
+		}
+		memcpy(&buf[cpy_idx], temp, unaligned_end_cnt);
+	}
+	return 0;
+}
+
+/*
+ * Writes `len` bytes of device memory, starting at address `start_addr` from
+ * `buf`. This function is specific to the JTAG implementation on ARC HS4x.
+ */
+int arc_jtag_write_mem(uint32_t start_addr, const uint8_t *buf, size_t len)
+{
+	int ret;
+	uint8_t data;
+	uint32_t aligned_addr = start_addr & ~0x3;
+	uint32_t unaligned_start_cnt = (start_addr & 0x3) ? 4 - (start_addr & 0x3) : 0;
+	uint32_t aligned_cnt = (len - unaligned_start_cnt) & ~0x3;
+	uint32_t unaligned_end_cnt = len - (aligned_cnt + unaligned_start_cnt);
+	uint8_t temp[4];
+	size_t cpy_idx = 0;
+
+	if (unaligned_start_cnt) {
+		/* Use a read-modify-write algorithm to set the first word */
+		ret = arc_jtag_read_mem(aligned_addr, temp, 4);
+		if (ret < 0) {
+			E("Error, failed to read memory for unaligned write\n");
+			return ret;
+		}
+		memcpy(&temp[4 - unaligned_start_cnt], &buf[cpy_idx], unaligned_start_cnt);
+		ret = arc_jtag_write_mem(aligned_addr, temp, 4);
+		if (ret < 0) {
+			E("Error, failed to write memory for unaligned write\n");
+			return ret;
+		}
+		aligned_addr += 4;
+		cpy_idx += unaligned_start_cnt;
+	}
+
+	if (aligned_cnt) {
+		/* Write to IR to select transaction CMD on TAP 1 */
+		data = ARC_TRANSACTION_CMD_REG;
+		ret = jtag_enqueue_write_ir(&data, 1, 4, false);
+		if (ret < 0) {
+			E("Error, failed to queue IR write for transaction CMD\n");
+			return ret;
+		}
+		/* Select memory write transaction */
+		data = ARC_TRANSACTION_WRITE_MEM;
+		ret = jtag_enqueue_write_dr(&data, 1, 4, false);
+		if (ret < 0) {
+			E("Error, failed to queue DR write for transaction CMD\n");
+			return ret;
+		}
+		/* Write to IR to select address register on TAP 1 */
+		data = ARC_ADDRESS_REG;
+		ret = jtag_enqueue_write_ir(&data, 1, 4, false);
+		if (ret < 0) {
+			E("Error, failed to queue IR write for address CMD\n");
+			return ret;
+		}
+		/* Write DR with address we want to access. */
+		ret = jtag_enqueue_write_dr((uint8_t *)&aligned_addr, 1, 32, false);
+		if (ret < 0) {
+			E("Error, failed to queue DR write for address CMD\n");
+			return ret;
+		}
+		/* Write to IR to select data reg */
+		data = ARC_DATA_REG;
+		ret = jtag_enqueue_write_ir(&data, 1, 4, false);
+		if (ret < 0) {
+			E("Error, failed to queue IR write for data CMD\n");
+			return ret;
+		}
+	}
+	/* ARC supports automatic address increment, so just keep executing DR writes */
+	for (; cpy_idx < (unaligned_start_cnt + aligned_cnt); cpy_idx += 4) {
+		/* Return to idle here so we run transaction */
+		ret = jtag_enqueue_write_dr(&buf[cpy_idx], 1, 32, true);
+		if (ret < 0) {
+			E("Error, failed to queue DR write for data CMD\n");
+			return ret;
+		}
+		ret = jtag_execute_queue();
+		if (ret < 0) {
+			E("Error, failed to execute JTAG queue\n");
+			return ret;
+		}
+	}
+	if (unaligned_end_cnt) {
+		/* Write the last `unaligned_end_cnt` bytes using read-modify-write */
+		ret = arc_jtag_read_mem(aligned_addr + aligned_cnt, temp, 4);
+		if (ret < 0) {
+			E("Error, failed to read memory for unaligned write\n");
+			return ret;
+		}
+		memcpy(temp, &buf[cpy_idx], unaligned_end_cnt);
+		ret = arc_jtag_write_mem(aligned_addr + aligned_cnt, temp, 4);
+		if (ret < 0) {
+			E("Error, failed to write memory for unaligned write\n");
+			return ret;
+		}
+	}
+	return 0;
+}
+
+int arc_jtag_init(void *data)
+{
+	size_t num_devs;
+	struct jaylink_device **devs;
+	struct jaylink_device *selected_device = NULL;
+	struct jaylink_connection conns[JAYLINK_MAX_CONNECTIONS];
+	struct jtag_init_data *init_data = (struct jtag_init_data *)data;
+	bool found_handle;
+	size_t conn_count;
+	int ret;
+	uint32_t idcode;
+
+	verbose = init_data->verbose;
+
+	ret = jaylink_init(&ctx);
+	if (ret != JAYLINK_OK) {
+		return -1;
+	}
+
+	ret = jaylink_discovery_scan(ctx, JAYLINK_HIF_USB);
+	if (ret != JAYLINK_OK) {
+		jaylink_exit(ctx);
+		ctx = NULL;
+		return -1;
+	}
+
+	ret = jaylink_get_devices(ctx, &devs, &num_devs);
+	if (ret != JAYLINK_OK) {
+		jaylink_exit(ctx);
+		ctx = NULL;
+		return -1;
+	}
+
+	if (init_data->serial_number) {
+		uint32_t serial, test_serial;
+
+		ret = jaylink_parse_serial_number(init_data->serial_number, &serial);
+		if (ret != JAYLINK_OK) {
+			E("Invalid serial number: %s", init_data->serial_number);
+			goto error;
+		}
+		for (size_t i = 0; i < num_devs; i++) {
+			ret = jaylink_device_get_serial_number(devs[i], &test_serial);
+			if (ret != JAYLINK_OK) {
+				E("Failed to get serial number for device %zu", i);
+				goto error;
+			}
+			if (test_serial == serial) {
+				selected_device = devs[i];
+				I("Found JLink device with serial number: %s",
+					init_data->serial_number);
+				break;
+			}
+		}
+		if (selected_device == NULL) {
+			E("No JLink device found with serial number: %s", init_data->serial_number);
+			goto error;
+		}
+	} else if (num_devs > 1) {
+		I("Multiple JLink devices found, using the first one.");
+		selected_device = devs[0];
+	} else if (num_devs == 1) {
+		selected_device = devs[0];
+	} else {
+		E("No JLink devices found.");
+		goto error;
+	}
+	ret = jaylink_open(selected_device, &devh);
+	if (ret != JAYLINK_OK) {
+		E("Failed to open JLink device: %s", jaylink_strerror(ret));
+		goto error;
+	}
+
+	memset(caps, 0, JAYLINK_DEV_EXT_CAPS_SIZE);
+	ret = jaylink_get_caps(devh, caps);
+	if (ret != JAYLINK_OK) {
+		E("Failed to get JLink capabilities: %s", jaylink_strerror(ret));
+		goto error;
+	}
+	if (jaylink_has_cap(caps, JAYLINK_DEV_CAP_GET_EXT_CAPS)) {
+		ret = jaylink_get_extended_caps(devh, caps);
+		if (ret != JAYLINK_OK) {
+			E("Failed to get extended capabilities: %s", jaylink_strerror(ret));
+			goto error;
+		}
+	}
+
+	if (verbose > 3) {
+		jaylink_log_set_level(ctx, JAYLINK_LOG_LEVEL_DEBUG);
+	}
+
+	if (jaylink_has_cap(caps, JAYLINK_DEV_CAP_REGISTER)) {
+		conn.handle = 0;
+		conn.pid = 0;
+		strcpy(conn.hid, "0.0.0.0");
+		conn.iid = 0;
+		conn.cid = 0;
+
+		ret = jaylink_register(devh, &conn, conns, &conn_count);
+		if (ret != JAYLINK_OK) {
+			E("jaylink_register() failed: %s", jaylink_strerror(ret));
+			goto error;
+		}
+
+		found_handle = false;
+
+		for (size_t i = 0; i < conn_count; i++) {
+			if (conns[i].handle == conn.handle) {
+				found_handle = true;
+				break;
+			}
+		}
+		if (!found_handle) {
+			E("Maximum number of JLink connections reached");
+			ret = -ENODEV;
+			goto error;
+		}
+	}
+
+	/* Select JTAG interface */
+	if (jaylink_has_cap(caps, JAYLINK_DEV_CAP_SELECT_TIF)) {
+		ret = jaylink_select_interface(devh, JAYLINK_TIF_JTAG, NULL);
+		if (ret != JAYLINK_OK) {
+			E("jaylink_select_interface() failed: %s", jaylink_strerror(ret));
+			goto error;
+		}
+	}
+
+	/* Init JTAG queue and check the IDCODE register */
+	arc_jtag_queue_init();
+	ret = jtag_go_idle();
+	if (ret < 0) {
+		E("Failed to enter run/test idle");
+		goto error;
+	}
+	ret = arc_jtag_read_idcode(&idcode);
+	if (ret < 0) {
+		E("Failed to read IDCODE");
+		goto error;
+	}
+	D(1, "IDCODE: 0x%08X", idcode);
+	if (idcode != ARC_IDCODE) {
+		E("IDCODE mismatch: expected 0x%08X, got 0x%08X", ARC_IDCODE, idcode);
+		ret = -ENODEV;
+		goto error;
+	}
+
+	jaylink_free_devices(devs, true);
+	return 0;
+error:
+	if (devh) {
+		jaylink_close(devh);
+		devh = NULL;
+	}
+	jaylink_free_devices(devs, true);
+	jaylink_exit(ctx);
+	ctx = NULL;
+	return ret;
+}
+
+void arc_jtag_exit(void)
+{
+	size_t conn_count;
+	struct jaylink_connection conns[JAYLINK_MAX_CONNECTIONS];
+
+	if (devh) {
+		if (jaylink_has_cap(caps, JAYLINK_DEV_CAP_REGISTER)) {
+			jaylink_unregister(devh, &conn, conns, &conn_count);
+		}
+		jaylink_close(devh);
+		devh = NULL;
+	}
+	if (ctx) {
+		jaylink_exit(ctx);
+		ctx = NULL;
+	}
+}

--- a/scripts/tt-console/arc_jtag.h
+++ b/scripts/tt-console/arc_jtag.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2025 Tenstorrent AI ULC
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ */
+
+#ifndef ARC_JTAG_H_
+#define ARC_JTAG_H_
+
+#include <stdint.h>
+
+struct jtag_init_data {
+	int verbose;
+	const char *serial_number;
+};
+
+int arc_jtag_init(void *data);
+void arc_jtag_exit(void);
+int arc_jtag_write_mem(uint32_t start_addr, const uint8_t *buf, size_t len);
+int arc_jtag_read_mem(uint32_t start_addr, uint8_t *buf, size_t len);
+
+#endif /* ARC_JTAG_H_ */

--- a/scripts/tt-console/arc_tlb.c
+++ b/scripts/tt-console/arc_tlb.c
@@ -1,0 +1,460 @@
+/*
+ * Copyright (c) 2025 Tenstorrent AI ULC
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ */
+
+#ifndef __ZEPHYR__
+#include "attrs.x"
+#endif
+
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <getopt.h>
+#include <inttypes.h>
+#include <libgen.h>
+#include <signal.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/mman.h>
+#include <sys/select.h>
+#include <termios.h>
+#include <sys/time.h>
+#include <unistd.h>
+
+#include "arc_tlb.h"
+
+#define ARC_X 8
+#define ARC_Y 0
+
+#define TLB_2M_REG_SIZE            (3 * sizeof(uint32_t))
+#define TLB_2M_SHIFT               21
+#define TLB_2M_WINDOW_SIZE         BIT(TLB_2M_SHIFT)
+#define TLB_2M_WINDOW_MASK         BIT_MASK(TLB_2M_SHIFT)
+#define BH_NUM_2M_TLBS             202
+#define BH_NUM_4G_TLBS             8
+#define BH_NUM_TLBS                (BH_NUM_2M_TLBS + BH_NUM_4G_TLBS)
+
+#define ARC_CSM_TLB 179
+
+#define TLB_REGS_LEN PAGE_SIZE
+
+#define ARC_CSM_BASE    0x10000000
+#define TLB_CONFIG_ADDR 0x1FC00000
+
+#define TENSTORRENT_PCI_VENDOR_ID 0x1e52
+#define TENSTORRENT_IOCTL_MAGIC           0xFA
+#define TENSTORRENT_IOCTL_GET_DEVICE_INFO _IO(TENSTORRENT_IOCTL_MAGIC, 0)
+#define TENSTORRENT_IOCTL_QUERY_MAPPINGS  _IO(TENSTORRENT_IOCTL_MAGIC, 2)
+
+#define NUM_TENSTORRENT_QUERY_MAPPINGS   8
+#define TENSTORRENT_MAPPING_RESOURCE0_UC 1
+#define TENSTORRENT_MAPPING_RESOURCE0_WC 2
+
+#define KB(n) (1024 * (n))
+#define MB(n) (1024 * 1024 * (n))
+
+#ifndef PAGE_SIZE
+#define PAGE_SIZE KB(4)
+#endif
+
+#ifndef BIT
+#define BIT(n) (1UL << (n))
+#endif
+
+#ifndef BIT_MASK
+#define BIT_MASK(n) (BIT(n) - 1)
+#endif
+
+enum tlb_order {
+	TLB_ORDER_RELAXED,        /* Unposted AXI Writes. Relaxed NOC ordering */
+	TLB_ORDER_STRICT,         /* Unposted AXI Writes. Strict NOC ordering */
+	TLB_ORDER_POSTED_RELAXED, /* Posted AXI Writes. Relaxed NOC ordering */
+	TLB_ORDER_POSTED_STRICT,  /* Posted AXI Writes. Strict NOC ordering */
+};
+
+struct tenstorrent_get_device_info_inp {
+	uint32_t output_size_bytes;
+};
+
+struct tenstorrent_get_device_info_out {
+	uint32_t output_size_bytes;
+	uint16_t vendor_id;
+	uint16_t device_id;
+	uint16_t subsystem_vendor_id;
+	uint16_t subsystem_id;
+	uint16_t bus_dev_fn;
+	uint16_t max_dma_buf_size_log2;
+	uint16_t pci_domain;
+};
+
+struct tenstorrent_get_device_info {
+	struct tenstorrent_get_device_info_inp in;
+	struct tenstorrent_get_device_info_out out;
+};
+
+struct tenstorrent_mapping {
+	uint32_t mapping_id;
+	uint32_t: 32;
+	uint64_t mapping_base;
+	uint64_t mapping_size;
+};
+
+struct tenstorrent_query_mappings_inp {
+	uint32_t output_mapping_count;
+	uint32_t: 32;
+};
+
+struct tenstorrent_query_mappings_out {
+	struct tenstorrent_mapping mappings[0];
+};
+
+struct tenstorrent_query_mappings {
+	struct tenstorrent_query_mappings_inp in;
+	struct tenstorrent_query_mappings_out out;
+};
+
+struct tlb_2m {
+	uint64_t address: 43;
+	uint64_t x_end: 6;
+	uint64_t y_end: 6;
+	uint64_t x_start: 6;
+	uint64_t y_start: 6;
+	uint64_t noc: 2;
+	uint64_t multicast: 1;
+	uint64_t ordering: 2;
+	uint64_t linked: 1;
+	uint64_t use_static_vc: 1;
+	uint64_t stream_header: 1;
+	uint64_t static_vc: 3;
+	uint64_t: 18; /* Reserved - RAZ / WAZ */
+} __packed __aligned(4);
+_Static_assert(sizeof(struct tlb_2m) == TLB_2M_REG_SIZE, "incongruent struct tlb_2m size");
+
+struct tlb_data {
+	int fd;
+	const char *dev_name;
+	uint16_t pci_device_id;
+	uint8_t tlb_id;
+	volatile uint8_t *tlb;            /* 2MiB tlb window */
+	volatile struct tlb_2m *tlb_regs; /* 4kiB tlb register space */
+	uint64_t programmed_phys; /* last programmed physical address */
+	/* we might not actually need these */
+	uint64_t wc_mapping_base;
+	uint64_t uc_mapping_base;
+};
+
+static struct tlb_data _tlb_data;
+static int verbose;
+
+#define D(level, fmt, ...)                                                      \
+	if (verbose >= level) {                                                 \
+		printf("D: %s(): " fmt "\r\n", __func__, ##__VA_ARGS__);        \
+	}
+
+#define E(fmt, ...) fprintf(stderr, "E: %s(): " fmt "\r\n", __func__, ##__VA_ARGS__)
+
+#define I(fmt, ...)                                                             \
+	if (verbose >= 0) {                                                     \
+		printf(fmt "\r\n", ##__VA_ARGS__);                              \
+	}
+
+static const char *tlb2m2str(volatile struct tlb_2m *reg)
+{
+	static char buf[128] = {0};
+	volatile uint32_t *data = (volatile uint32_t *)reg;
+
+	snprintf(buf, sizeof(buf), "(0x%x, 0x%x, 0x%x)", data[0], data[1], data[2]);
+
+	return buf;
+}
+
+static uint64_t program_noc(struct tlb_data *tlb_data, uint32_t x, uint32_t y,
+			    enum tlb_order order, uint64_t phys)
+{
+	volatile struct tlb_2m *const reg = &tlb_data->tlb_regs[tlb_data->tlb_id];
+
+	uint64_t addr = phys >> TLB_2M_SHIFT;
+
+	if (addr != tlb_data->programmed_phys) {
+		/* Reprogram */
+		*reg = (struct tlb_2m){
+			.address = addr,
+			.x_end = x,
+			.y_end = y,
+			.ordering = order,
+		};
+		tlb_data->programmed_phys = addr;
+	}
+
+	uint64_t adjust = phys & TLB_2M_WINDOW_MASK;
+
+	D(2, "tlb[%u]: %s", tlb_data->tlb_id, tlb2m2str(reg));
+
+	return adjust;
+}
+
+static int open_tt_dev(struct tlb_data *data)
+{
+
+	struct tenstorrent_get_device_info info = {
+		.in.output_size_bytes = sizeof(struct tenstorrent_get_device_info_out),
+	};
+
+	if (data->fd >= 0) {
+		/* already opened or not properly initialized */
+		return 0;
+	}
+	data->fd = open(data->dev_name, O_RDWR);
+	if (data->fd < 0) {
+		E("%s: %s", strerror(errno), data->dev_name);
+		return -errno;
+	}
+	D(1, "opened %s as fd %d", data->dev_name, data->fd);
+
+
+	if (ioctl(data->fd, TENSTORRENT_IOCTL_GET_DEVICE_INFO, &info) < 0) {
+		E("ioctl(TENSTORRENT_IOCTL_GET_DEVICE_INFO): %s", strerror(errno));
+		return -errno;
+	}
+
+	uint16_t vid = info.out.vendor_id;
+	uint16_t did = info.out.device_id;
+	uint8_t bus = info.out.bus_dev_fn >> 8;
+	uint8_t dev = (info.out.bus_dev_fn >> 3) & 0x1f;
+	uint8_t fun = info.out.bus_dev_fn & 0x07;
+
+	D(1, "opened %04x:%04x %02x.%02x.%x", vid, did, bus, dev, fun);
+
+	if (vid != TENSTORRENT_PCI_VENDOR_ID) {
+		E("expected vendor id %04x (not %04x)", TENSTORRENT_PCI_VENDOR_ID, vid);
+		return -ENODEV;
+	}
+
+	if (did != data->pci_device_id) {
+		E("expected device id %04x (not %04x)", data->pci_device_id, did);
+		return -ENODEV;
+	}
+
+	uint64_t buf[(sizeof(struct tenstorrent_query_mappings) +
+		      NUM_TENSTORRENT_QUERY_MAPPINGS * sizeof(struct tenstorrent_mapping)) /
+		     sizeof(uint64_t)] = {0};
+
+	struct tenstorrent_query_mappings *const mapping = (struct tenstorrent_query_mappings *)buf;
+
+	mapping->in.output_mapping_count = NUM_TENSTORRENT_QUERY_MAPPINGS;
+
+	struct tenstorrent_mapping *const omap = mapping->out.mappings;
+
+	if (ioctl(data->fd, TENSTORRENT_IOCTL_QUERY_MAPPINGS, mapping) < 0) {
+		E("ioctl(TENSTORRENT_IOCTL_QUERY_MAPPINGS): %s", strerror(errno));
+		return -errno;
+	}
+
+	for (int i = 0; i < NUM_TENSTORRENT_QUERY_MAPPINGS; ++i) {
+		const char *mapping_name = NULL;
+
+		if (omap[i].mapping_id == TENSTORRENT_MAPPING_RESOURCE0_WC) {
+			data->wc_mapping_base = omap[i].mapping_base;
+			mapping_name = "wc_mapping_base";
+		} else if (omap[i].mapping_id == TENSTORRENT_MAPPING_RESOURCE0_UC) {
+			data->uc_mapping_base = omap[i].mapping_base;
+			mapping_name = "uc_mapping_base";
+		}
+
+		if (mapping_name != NULL) {
+			D(2, "%s: id: %u base: 0x%010" PRIx64 " size: 0x%" PRIx64, mapping_name,
+			  omap[i].mapping_id, omap[i].mapping_base, omap[i].mapping_size);
+		}
+
+		if (omap[i].mapping_size == 0) {
+			continue;
+		}
+	}
+
+	return 0;
+}
+
+static void close_tt_dev(struct tlb_data *data)
+{
+	if (data->fd == -1) {
+		/* not yet opened or already closed */
+		return;
+	}
+
+	if (close(data->fd) < 0) {
+		E("fd %d: %s", data->fd, strerror(errno));
+		return;
+	}
+
+	D(1, "closed fd %d", data->fd);
+
+	data->fd = -1;
+}
+
+/*
+ * Map the 2MiB TLB window. This can remain mapped for the duration of the
+ * application. We simply change where the TLB window points by writing to the TLB config
+ * register.
+ */
+static int map_tlb(struct tlb_data *data)
+{
+	if (data->tlb != MAP_FAILED) {
+		/* already mapped? cons improperly initialized? */
+		return 0;
+	}
+
+	uint64_t offset = data->tlb_id * TLB_2M_WINDOW_SIZE;
+
+	data->tlb = mmap(NULL, TLB_2M_WINDOW_SIZE, PROT_READ | PROT_WRITE, MAP_SHARED, data->fd,
+			 data->uc_mapping_base + offset);
+	if (data->tlb == MAP_FAILED) {
+		E("%s", strerror(errno));
+		return -errno;
+	}
+
+	D(1, "mapped %zu@%08x to %zu@%p for 2MiB TLB window %d", (size_t)TLB_2M_WINDOW_SIZE,
+	  (uint32_t)offset, (size_t)TLB_2M_WINDOW_SIZE, data->tlb, data->tlb_id);
+
+	return 0;
+}
+
+static void unmap_tlb(struct tlb_data *data)
+{
+	if (data->tlb == MAP_FAILED) {
+		/* not currently mapped */
+		return;
+	}
+
+	if (munmap((void *)data->tlb, TLB_2M_WINDOW_SIZE) < 0) {
+		E("%s", strerror(errno));
+		return;
+	}
+
+	D(1, "unmapped %zu@%p", (size_t)TLB_2M_WINDOW_SIZE, data->tlb);
+
+	data->tlb = MAP_FAILED;
+}
+
+static int map_tlb_regs(struct tlb_data *data)
+{
+	/*
+	 * assert that TLB_CONFIG_ADDR is already aligned
+	 * means we don't need an 'adjust' or 'offset' variables
+	 */
+	_Static_assert((TLB_CONFIG_ADDR & PAGE_SIZE) == 0, "Invalid tlb config addr");
+
+	if (data->tlb_regs != MAP_FAILED) {
+		/* already mapped? cons improperly initialized? */
+		return 0;
+	}
+
+	data->tlb_regs = mmap(NULL, PAGE_SIZE, PROT_READ | PROT_WRITE, MAP_SHARED, data->fd,
+			      TLB_CONFIG_ADDR);
+	if (data->tlb_regs == MAP_FAILED) {
+		E("%s", strerror(errno));
+		return -EIO;
+	}
+
+	D(1, "mapped %zu@%08x to %zu@%p", (size_t)PAGE_SIZE, TLB_CONFIG_ADDR, (size_t)PAGE_SIZE,
+	  data->tlb_regs);
+
+	if (verbose > 0) {
+		for (int i = 0; i < BH_NUM_TLBS; ++i) {
+			volatile uint32_t *reg_data = (volatile uint32_t *)&data->tlb_regs[i];
+
+			if ((reg_data[0] == 0) && (reg_data[1] == 0) && (reg_data[2] == 0)) {
+				continue;
+			}
+
+			if ((reg_data[0] == (uint32_t)-1) && (reg_data[1] == (uint32_t)-1) &&
+			    (reg_data[2] == (uint32_t)-1)) {
+				continue;
+			}
+
+			D(2, "tlb[%u]: %s", i, tlb2m2str(&data->tlb_regs[i]));
+		}
+	}
+
+	return 0;
+}
+
+static void unmap_tlb_regs(struct tlb_data *data)
+{
+	if (data->tlb_regs == MAP_FAILED) {
+		/* not currently mapped */
+		return;
+	}
+
+	if (munmap((void *)data->tlb_regs, PAGE_SIZE) < 0) {
+		E("%s", strerror(errno));
+		return;
+	}
+
+	D(1, "unmapped %zu@%p", (size_t)PAGE_SIZE, data->tlb_regs);
+
+	data->tlb_regs = MAP_FAILED;
+}
+
+int tlb_read(uint32_t addr, uint8_t *buf, size_t len)
+{
+	uint64_t adjust = program_noc(&_tlb_data, ARC_X, ARC_Y, TLB_ORDER_STRICT, addr);
+	uint32_t *virt = (uint32_t *)(_tlb_data.tlb + adjust);
+
+	D(2, "read from (%p,%p) (phys,virt)", (void *)(uintptr_t)addr, virt);
+	memcpy(buf, virt, len);
+	return 0;
+}
+
+int tlb_write(uint32_t addr, const uint8_t *buf, size_t len)
+{
+	uint64_t adjust = program_noc(&_tlb_data, ARC_X, ARC_Y, TLB_ORDER_STRICT, addr);
+	uint32_t *virt = (uint32_t *)(_tlb_data.tlb + adjust);
+
+	D(2, "write to (%p,%p) (phys,virt)", (void *)(uintptr_t)addr, virt);
+	memcpy(virt, buf, len);
+	return 0;
+}
+
+int tlb_init(void *data)
+{
+	int ret;
+	struct tlb_init_data *init_data = (struct tlb_init_data *)data;
+
+	_tlb_data.dev_name = init_data->dev_name;
+	_tlb_data.pci_device_id = init_data->pci_device_id;
+	_tlb_data.tlb_id = init_data->tlb_id;
+	_tlb_data.fd = -1;
+	_tlb_data.tlb = MAP_FAILED;
+	_tlb_data.tlb_regs = MAP_FAILED;
+	verbose = init_data->verbose;
+
+	ret = open_tt_dev(&_tlb_data);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = map_tlb_regs(&_tlb_data);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = map_tlb(&_tlb_data);
+	if (ret < 0) {
+		return ret;
+	}
+	return ret;
+}
+
+void tlb_exit(void)
+{
+	unmap_tlb(&_tlb_data);
+	unmap_tlb_regs(&_tlb_data);
+	close_tt_dev(&_tlb_data);
+}

--- a/scripts/tt-console/arc_tlb.h
+++ b/scripts/tt-console/arc_tlb.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2025 Tenstorrent AI ULC
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ */
+
+#ifndef ARC_TLB_H_
+#define ARC_TLB_H_
+
+#include <stdint.h>
+
+struct tlb_init_data {
+	int verbose;
+	uint8_t tlb_id;
+	uint16_t pci_device_id;
+	const char *dev_name;
+};
+
+#define BH_2M_TLB_UC_DYNAMIC_START 190
+#define BH_2M_TLB_UC_DYNAMIC_END   199
+
+int tlb_init(void *data);
+void tlb_exit(void);
+int tlb_write(uint32_t start_addr, const uint8_t *buf, size_t len);
+int tlb_read(uint32_t start_addr, uint8_t *buf, size_t len);
+
+#endif /* ARC_TLB_H_ */

--- a/scripts/tt-console/attrs.x
+++ b/scripts/tt-console/attrs.x
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2025 Tenstorrent AI ULC
  *
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #define __packed __attribute__((packed))

--- a/scripts/tt-console/autogen.sh
+++ b/scripts/tt-console/autogen.sh
@@ -1,9 +1,11 @@
 #
 # Copyright (c) 2025 Tenstorrent AI ULC
 #
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: GPL-2.0-only
 #
 
+(cd ../../../modules/libjaylink; ./autogen.sh)
+libtoolize --automake --copy
 aclocal
 autoheader
 autoconf

--- a/scripts/tt-console/autogen.sh
+++ b/scripts/tt-console/autogen.sh
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+aclocal
+autoheader
+autoconf
+automake --add-missing

--- a/scripts/tt-console/build.sh
+++ b/scripts/tt-console/build.sh
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+./autogen.sh
+./configure
+make -j $(nproc)

--- a/scripts/tt-console/configure.ac
+++ b/scripts/tt-console/configure.ac
@@ -1,6 +1,19 @@
+AC_DEFUN([AX_CONFIG_SUBDIR_OPTION],
+[
+AC_CONFIG_SUBDIRS([$1])
+
+m4_ifblank([$2], [rm -f $srcdir/$1/configure.gnu],
+[printf '#!/bin/sh\nexec "`dirname "'\$'0"`/configure" '"$2"' "'\$'@"\n' > "$srcdir/$1/configure.gnu"
+])
+])
+
 AC_INIT([tt-console], [1.0])
 AM_INIT_AUTOMAKE([-Wall -Werror foreign])
+AM_PROG_AR
 AC_PROG_CC
+LT_INIT
+AX_CONFIG_SUBDIR_OPTION([../../../modules/libjaylink/],
+		[--enable-subproject-build])
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_FILES([
  Makefile

--- a/scripts/tt-console/configure.ac
+++ b/scripts/tt-console/configure.ac
@@ -1,0 +1,8 @@
+AC_INIT([tt-console], [1.0])
+AM_INIT_AUTOMAKE([-Wall -Werror foreign])
+AC_PROG_CC
+AC_CONFIG_HEADERS([config.h])
+AC_CONFIG_FILES([
+ Makefile
+])
+AC_OUTPUT

--- a/scripts/tt-console/console.c
+++ b/scripts/tt-console/console.c
@@ -4,11 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/*
- * Build with:
- * gcc -O0 -g -Wall -Wextra -Werror -std=gnu11 -I ../../include -o tt-console console.c
- */
-
 #ifndef __ZEPHYR__
 #include "attrs.x"
 #endif

--- a/scripts/tt-console/console.c
+++ b/scripts/tt-console/console.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2025 Tenstorrent AI ULC
  *
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef __ZEPHYR__

--- a/scripts/tt-console/test.c
+++ b/scripts/tt-console/test.c
@@ -1,0 +1,251 @@
+/*
+ * Copyright (c) 2025 Tenstorrent AI ULC
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "arc_jtag.h"
+#include "arc_tlb.h"
+
+#define BH_SCRAPPY_PCI_DEVICE_ID  0xb140
+#define TT_DEVICE "/dev/tenstorrent/0"
+
+/* Definition of functions used to access memory */
+struct mem_access_driver {
+	int (*start)(void *init_data);
+	int (*read)(uint32_t addr, uint8_t *buf, size_t len);
+	int (*write)(uint32_t addr, const uint8_t *buf, size_t len);
+	void (*stop)(void);
+};
+
+struct mem_access_driver tlb_driver = {
+	.start = tlb_init,
+	.read = tlb_read,
+	.write = tlb_write,
+	.stop = tlb_exit,
+};
+
+static struct jtag_init_data jtag_init_data = {
+	.verbose = 0,
+	.serial_number = NULL,
+};
+static struct tlb_init_data tlb_init_data = {
+	.dev_name = TT_DEVICE,
+	.pci_device_id = BH_SCRAPPY_PCI_DEVICE_ID,
+	.tlb_id = BH_2M_TLB_UC_DYNAMIC_START + 1,
+	.verbose = 0,
+};
+
+struct mem_access_driver jtag_driver = {
+	.start = arc_jtag_init,
+	.read = arc_jtag_read_mem,
+	.write = arc_jtag_write_mem,
+	.stop = arc_jtag_exit,
+};
+
+#define TEST_MEM_ADDR 0x10000000 /* Start of CSM on ARC */
+
+static int test_read(int (*read_func)(uint32_t, uint8_t *, size_t), uint32_t addr,
+		uint8_t *buf, uint32_t len)
+{
+	int ret = read_func(addr, buf, len);
+
+	if (ret < 0) {
+		fprintf(stderr, "Failed to read memory from address 0x%08X-0x%08X: %d\n",
+			addr, addr + len, ret);
+	}
+	return ret;
+}
+
+static int test_write(int (*write_func)(uint32_t, const uint8_t *, size_t), uint32_t addr,
+		uint8_t *buf, uint32_t len)
+{
+	int ret = write_func(addr, buf, len);
+
+	if (ret < 0) {
+		fprintf(stderr, "Failed to write memory to address 0x%08X-0x%08X: %d\n",
+			addr, addr + len, ret);
+	}
+	return ret;
+}
+
+static int test_memory(void *init_data, struct mem_access_driver *driver)
+{
+	uint8_t test_buf[128];
+	uint8_t check_buf[128];
+	int ret;
+
+	if (driver->start(init_data) < 0) {
+		fprintf(stderr, "Failed to initialize memory access driver\n");
+		return -1;
+	}
+
+	ret = test_read(driver->read, TEST_MEM_ADDR, test_buf, sizeof(test_buf));
+	if (ret < 0) {
+		goto out;
+	}
+	memset(check_buf, 0, sizeof(check_buf));
+	ret = test_read(driver->read, TEST_MEM_ADDR, check_buf, 4);
+	if (ret < 0) {
+		goto out;
+	}
+
+	if (memcmp(test_buf, check_buf, 4) != 0) {
+		fprintf(stderr, "Memory read data mismatch: %d\n", __LINE__);
+		ret = -1;
+		goto out;
+	}
+
+	/* Perform unaligned memory reads */
+	memset(check_buf, 0, sizeof(check_buf));
+	ret = test_read(driver->read, TEST_MEM_ADDR, check_buf, 1);
+	if (ret < 0) {
+		goto out;
+	}
+	if (memcmp(test_buf, check_buf, 1) != 0) {
+		fprintf(stderr, "Memory read data mismatch: %d\n", __LINE__);
+		ret = -1;
+		goto out;
+	}
+	memset(check_buf, 0, sizeof(check_buf));
+	ret = test_read(driver->read, TEST_MEM_ADDR + 1, check_buf, 4);
+	if (ret < 0) {
+		goto out;
+	}
+	if (memcmp(test_buf + 1, check_buf, 4) != 0) {
+		fprintf(stderr, "Memory read data mismatch: %d\n", __LINE__);
+		ret = -1;
+		goto out;
+	}
+
+	memset(check_buf, 0, sizeof(check_buf));
+	ret = test_read(driver->read, TEST_MEM_ADDR + 1, check_buf, 3);
+	if (ret < 0) {
+		goto out;
+	}
+	if (memcmp(test_buf + 1, check_buf, 3) != 0) {
+		fprintf(stderr, "Memory read data mismatch: %d\n", __LINE__);
+		ret = -1;
+		goto out;
+	}
+
+	memset(check_buf, 0, sizeof(check_buf));
+	ret = test_read(driver->read, TEST_MEM_ADDR + 1, check_buf, 10);
+	if (ret < 0) {
+		goto out;
+	}
+	if (memcmp(test_buf + 1, check_buf, 10) != 0) {
+		fprintf(stderr, "Memory read data mismatch: %d\n", __LINE__);
+		ret = -1;
+		goto out;
+	}
+
+	/* Test memory writes */
+	for (int i = 0; i < sizeof(test_buf); i++) {
+		test_buf[i] = i;
+	}
+	ret = test_write(driver->write, TEST_MEM_ADDR, test_buf, sizeof(test_buf));
+	if (ret < 0) {
+		goto out;
+	}
+	memset(check_buf, 0, sizeof(check_buf));
+	ret = test_read(driver->read, TEST_MEM_ADDR, check_buf, sizeof(test_buf));
+	if (ret < 0) {
+		goto out;
+	}
+	if (memcmp(test_buf, check_buf, sizeof(test_buf)) != 0) {
+		fprintf(stderr, "Memory write data mismatch: %d\n", __LINE__);
+		ret = -1;
+		goto out;
+	}
+	for (int i = 0; i < sizeof(test_buf); i++) {
+		test_buf[i] = i + 1;
+	}
+	ret = test_write(driver->write, TEST_MEM_ADDR, test_buf, 4);
+	if (ret < 0) {
+		goto out;
+	}
+	memset(check_buf, 0, sizeof(check_buf));
+	ret = test_read(driver->read, TEST_MEM_ADDR, check_buf, 4);
+	if (ret < 0) {
+		goto out;
+	}
+	if (memcmp(test_buf, check_buf, 4) != 0) {
+		fprintf(stderr, "Memory write data mismatch: %d\n", __LINE__);
+		ret = -1;
+		goto out;
+	}
+	for (int i = 0; i < sizeof(test_buf); i++) {
+		test_buf[i] = i + 2;
+	}
+	ret = test_write(driver->write, TEST_MEM_ADDR, test_buf, 1);
+	if (ret < 0) {
+		goto out;
+	}
+	memset(check_buf, 0, sizeof(check_buf));
+	ret = test_read(driver->read, TEST_MEM_ADDR, check_buf, 1);
+	if (ret < 0) {
+		goto out;
+	}
+	if (memcmp(test_buf, check_buf, 1) != 0) {
+		fprintf(stderr, "Memory write data mismatch: %d\n", __LINE__);
+		ret = -1;
+		goto out;
+	}
+	for (int i = 0; i < sizeof(test_buf); i++) {
+		test_buf[i] = i + 3;
+	}
+	ret = test_write(driver->write, TEST_MEM_ADDR + 1, test_buf, 4);
+	if (ret < 0) {
+		goto out;
+	}
+	memset(check_buf, 0, sizeof(check_buf));
+	ret = test_read(driver->read, TEST_MEM_ADDR + 1, check_buf, 4);
+	if (ret < 0) {
+		goto out;
+	}
+	if (memcmp(test_buf, check_buf, 4) != 0) {
+		fprintf(stderr, "Memory write data mismatch: %d\n", __LINE__);
+		ret = -1;
+		goto out;
+	}
+	for (int i = 0; i < sizeof(test_buf); i++) {
+		test_buf[i] = i + 4;
+	}
+	ret = test_write(driver->write, TEST_MEM_ADDR + 1, test_buf, 10);
+	if (ret < 0) {
+		goto out;
+	}
+	memset(check_buf, 0, sizeof(check_buf));
+	ret = test_read(driver->read, TEST_MEM_ADDR + 1, check_buf, 10);
+	if (ret < 0) {
+		goto out;
+	}
+	if (memcmp(test_buf, check_buf, 10) != 0) {
+		fprintf(stderr, "Memory write data mismatch: %d\n", __LINE__);
+		ret = -1;
+		goto out;
+	}
+
+out:
+	driver->stop();
+	return ret;
+}
+
+int main(int argc, char **argv)
+{
+	if (test_memory(&jtag_init_data, &jtag_driver) < 0) {
+		fprintf(stderr, "Failed to test memory using JTAG driver\n");
+		return -1;
+	}
+	fprintf(stderr, "Successfully tested memory using JTAG driver\n");
+	if (test_memory(&tlb_init_data, &tlb_driver) < 0) {
+		fprintf(stderr, "Failed to test memory using TLB driver\n");
+		return -1;
+	}
+	fprintf(stderr, "Successfully tested memory using TLB driver\n");
+	return 0;
+}

--- a/west.yml
+++ b/west.yml
@@ -18,6 +18,10 @@ manifest:
           - mcuboot
           - nanopb
           - segger
+    - name: libjaylink
+      url: https://gitlab.zapb.de/libjaylink/libjaylink.git
+      revision: 0.3.1
+      path: modules/libjaylink
 
   group-filter:
     - +optional


### PR DESCRIPTION
This PR adds support into tt-console for accessing the console data via JTAG. It includes the following changes (broadly):
- rework of tt-console to split memory access code out from console logic
- inclusion of libjaylink into project as module, to support JTAG access to ARC memory
- support for reading/writing ARC memory within tt-console program
- additional testcases for tt-console program to verify memory access drivers (PCIE and JTAG based) are working
- additional vuart testcase to verify JTAG functionality

> [!WARNING]
> This PR updates the license of tt-console to be GPL-2.0, because we now link it with libjaylink (which is GPL-2.0 only).
> This is required unless we want to use SEGGER's JLink libary (which may have more licensing restrictions and require
> making tt-console closed source)


Once we have tt-console updated on CI machines, we should be able to move to make the VUART serial the default console for the SMC, because we can access the console data even without PCIe enumeration