### PR TITLE
scripts: pre-push: add ruff to check list

### DIFF
--- a/scripts/pre-push.sh
+++ b/scripts/pre-push.sh
@@ -30,7 +30,6 @@ manifest_base=$(west list -f "{abspath}" manifest)
 $zep_base/scripts/ci/check_compliance.py \
 	-e Kconfig \
 	-e ClangFormat \
-	-e Ruff \
 	-n -o /dev/null \
 	-c main..$HEAD
 


### PR DESCRIPTION
Ruff check should not be excluded from git hook, as it is run by the CI checker github