### PR TITLE
scripts: build-combined-fwbundle: use semantic version in filename

### DIFF
--- a/doc/release/migration-guide-18.3.0.md
+++ b/doc/release/migration-guide-18.3.0.md
@@ -5,3 +5,8 @@
 This document lists recommended and required changes for those migrating from the previous v18.2.0 firmware release to the new v18.3.0 firmware release.
 
 [comment]: <> (UL by area, indented as necessary)
+
+* Going forward, and following the more standard semantic versioning of firmware, the filename
+  of the combined firmware bundles will be of the form
+  * `fw_pack-<major>.<minor>.<patch>.fwbundle` for final releases, and
+  * `fw_pack-<major>.<minor>.<patch>-rc<N>.fwbundle` for release candidates (pre-releases)

--- a/scripts/build-combined-fwbundle.sh
+++ b/scripts/build-combined-fwbundle.sh
@@ -69,7 +69,7 @@ for REV in $BOARD_REVS; do
     >/dev/null 2>&1
 done
 
-echo "Creating fw_pack-$PRELEASE.fwbundle"
+echo "Creating fw_pack-$RELEASE.fwbundle"
 # construct arguments..
 ARGS="-c $PWD/$TTZP_BASE/zephyr/blobs/fw_pack-grayskull.tar.gz"
 ARGS="$ARGS -c $PWD/$TTZP_BASE/zephyr/blobs/fw_pack-wormhole.tar.gz"
@@ -80,5 +80,5 @@ done
 # shellcheck disable=SC2086
 tt_boot_fs.py fwbundle \
   -v "$PRELEASE" \
-  -o "fw_pack-$PRELEASE.fwbundle" \
+  -o "fw_pack-$RELEASE.fwbundle" \
   $ARGS


### PR DESCRIPTION
Use the semantic version in the filename of the firmware bundle rather than the quad-dotted versioning scheme historically used.

Going forward, release candidate firmware packs will have names like `fw_pack-18.3.0-rc1.fwbundle` rather than `fw_pack-18.3.0.1.fwbundle`, and
final releases will have names like `fw_pack-18.3.0.fwbundle` rather than
`fw_pack-18.3.0.0.fwbundle`.

Fixes #228

Testing done (manual, but also from the "build combined fwbundle" job in this PR):
```shell
Creating fw_pack-18.3.0-rc1.fwbundle
Wrote fwbundle to fw_pack-18.3.0-rc1.fwbundle
```
