### PR TITLE
doc: release: v18.3.0: note bmc dmc rename in migration guide

### DIFF
--- a/doc/release/migration-guide-18.3.0.md
+++ b/doc/release/migration-guide-18.3.0.md
@@ -10,3 +10,9 @@ This document lists recommended and required changes for those migrating from th
   of the combined firmware bundles will be of the form
   * `fw_pack-<major>.<minor>.<patch>.fwbundle` for final releases, and
   * `fw_pack-<major>.<minor>.<patch>-rc<N>.fwbundle` for release candidates (pre-releases)
+
+* The Board Management Controller (BMC) on Blackhole cards has been renamed to Device Management
+  Controller (DMC) in order to reduce possible confusion around the standard industry Baseboard
+  Management Controller (BMC) which is part of the [Intelligent Platform Management Interface](https://en.wikipedia.org/wiki/Intelligent_Platform_Management_Interface)
+  (IPMI) specification. Any automation or scripts that refer to that "cpu cluster" (in Zephyr
+  terminology) or application (`app/bmc`) should be adjusted accordingly.


### PR DESCRIPTION
Add a note to the migration guide about renaming the board management controller to device management controller, to avoid confusion with the baseboard management controller from the IPMI specification.