### PR TITLE
doc: release: v18.3.0: note usage of input power instead of current

### DIFF
--- a/doc/release/migration-guide-18.3.0.md
+++ b/doc/release/migration-guide-18.3.0.md
@@ -16,3 +16,5 @@ This document lists recommended and required changes for those migrating from th
   Management Controller (BMC) which is part of the [Intelligent Platform Management Interface](https://en.wikipedia.org/wiki/Intelligent_Platform_Management_Interface)
   (IPMI) specification. Any automation or scripts that refer to that "cpu cluster" (in Zephyr
   terminology) or application (`app/bmc`) should be adjusted accordingly.
+
+* SMC FW telemetry removes board input current reporting, and replaces it with board input power. Any tools using the telemetry entry `TAG_INPUT_CURRENT (39)` should be updated to use `TAG_INPUT_POWER (54)`

--- a/doc/release/release-notes-18.3.0.md
+++ b/doc/release/release-notes-18.3.0.md
@@ -11,6 +11,12 @@ Major enhancements with this release include:
 [comment]: <> (H3 External Project Collaboration Efforts, if applicable)
 [comment]: <> (H3 Stability Improvements, if applicable)
 
+### New Features
+
+* DMC now reads and sends power (instead of current) from INA228 device to SMC
+  * SMC now uses power reading as input to Total Board Power (TBP) throttler instead of `12 * current`
+* DMC support for accessing tca9554a GPIO expanders added
+
 ### Stability Improvements
 
 * Add I2C handshake between SMC and DMC FW to ensure that initialization messages are received
@@ -35,9 +41,14 @@ An overview of required and recommended changes to make when migrating from the 
 [comment]: <> (UL Drivers)
 [comment]: <> (UL Libraries)
 
+### Removed APIs
+* Telemetry no longer reports TAG_INPUT_CURRENT
+
 [comment]: <> (H3 Deprecated APIs, if applicable)
 
 [comment]: <> (H3 New APIs, if applicable)
+### New APIs
+* Telemetry now reports TAG_INPUT_POWER to replace TAG_INPUT_CURRENT
 
 [comment]: <> (H2 New Boards, if applicable)
 


### PR DESCRIPTION
Update release notes and migration guide to note usage of input power instead of input current.