### PR TITLE
app: smc: pytest: add pytest for SPI read/write

### DIFF
--- a/app/smc/sample.yaml
+++ b/app/smc/sample.yaml
@@ -2,6 +2,7 @@ sample:
   description: Tenstorrent Blackhole Chip Management Firmware
   name: bh-cmfw
 common:
+  timeout: 120
   platform_allow:
     - tt_blackhole@p100/tt_blackhole/smc
     - tt_blackhole@p100a/tt_blackhole/smc


### PR DESCRIPTION
Add test for SPI read/write. This test should help catch issues with SPI access before we utilize tt-flash to write firmware, and will help catch any issues with the flash driver code