### PR TITLE
lib: tenstorrent: add definitions for SMBUS registers, remove cm2dm duplication

### DIFF
--- a/app/dmc/src/main.c
+++ b/app/dmc/src/main.c
@@ -98,7 +98,7 @@ void process_cm2dm_message(struct bh_chip *chip)
 		cm2dmMessage message = msg.msg;
 
 		switch (message.msg_id) {
-		case 0x1:
+		case kCm2DmMsgIdResetReq:
 			switch (message.data) {
 			case 0x0:
 				jtag_bootrom_reset_sequence(chip, true);
@@ -112,16 +112,16 @@ void process_cm2dm_message(struct bh_chip *chip)
 				break;
 			}
 			break;
-		case 0x2:
+		case kCm2DmMsgIdPing:
 			/* Respond to ping request from CMFW */
 			bharc_smbus_word_data_write(&chip->config.arc, CMFW_SMBUS_PING, 0xA5A5);
 			break;
-		case 0x3:
+		case kCm2DmMsgIdFanSpeedUpdate:
 			if (IS_ENABLED(CONFIG_TT_FAN_CTRL)) {
 				set_fan_speed((uint8_t)message.data & 0xFF);
 			}
 			break;
-		case 0x4:
+		case kCm2DmMsgIdReady:
 			chip->data.arc_needs_init_msg = true;
 			break;
 		}

--- a/app/dmc/src/main.c
+++ b/app/dmc/src/main.c
@@ -26,6 +26,7 @@
 #include <tenstorrent/bh_arc.h>
 #include <tenstorrent/event.h>
 #include <tenstorrent/jtag_bootrom.h>
+#include <tenstorrent/tt_smbus_regs.h>
 
 LOG_MODULE_REGISTER(main, CONFIG_TT_APP_LOG_LEVEL);
 
@@ -113,7 +114,7 @@ void process_cm2dm_message(struct bh_chip *chip)
 			break;
 		case 0x2:
 			/* Respond to ping request from CMFW */
-			bharc_smbus_word_data_write(&chip->config.arc, 0x21, 0xA5A5);
+			bharc_smbus_word_data_write(&chip->config.arc, CMFW_SMBUS_PING, 0xA5A5);
 			break;
 		case 0x3:
 			if (IS_ENABLED(CONFIG_TT_FAN_CTRL)) {

--- a/include/tenstorrent/bh_arc.h
+++ b/include/tenstorrent/bh_arc.h
@@ -12,6 +12,14 @@
 #include <zephyr/drivers/smbus.h>
 #include <zephyr/drivers/gpio.h>
 
+typedef enum {
+	kCm2DmMsgIdNull = 0,
+	kCm2DmMsgIdResetReq = 1,
+	kCm2DmMsgIdPing = 2,
+	kCm2DmMsgIdFanSpeedUpdate = 3,
+	kCm2DmMsgIdReady = 4,
+} Cm2DmMsgId;
+
 typedef struct dmStaticInfo {
 	/*
 	 * Non-zero for valid data

--- a/include/tenstorrent/tt_smbus_regs.h
+++ b/include/tenstorrent/tt_smbus_regs.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2025 Tenstorrent AI ULC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef TT_SMBUS_MSGS_H_
+#define TT_SMBUS_MSGS_H_
+
+/*
+ * This header file contains the definitions for the SMBus registers used to
+ * communicate with the CMFW over the SMBus interface. It is also used by
+ * the DMFW, as that FW is the SMBus master on PCIe cards.
+ * All SMBus registers used by the CMFW should be defined here.
+ */
+
+enum CMFWSMBusReg {
+	/* RO, 48 bits. Read cm2dmMessage struct describing request from CMFW */
+	CMFW_SMBUS_REQ = 0x10,
+	/* WO, 16 bits. Write with sequence number and message ID to ack cm2dmMessage */
+	CMFW_SMBUS_ACK = 0x11,
+	/* WO, 96 bits. Write with dmStaticInfo struct including DMFW version */
+	CMFW_SMBUS_DM_FW_VERSION = 0x20,
+	/* WO, 16 bits. Write with 0xA5A5 to respond to CMFW request `kCm2DmMsgIdPing` */
+	CMFW_SMBUS_PING = 0x21,
+	/* WO, 16 bits. Write with fan speed to responsd to CMFW request
+	 * `kCm2DmMsgIdFanSpeedUpdate`
+	 */
+	CMFW_SMBUS_FAN_RPM = 0x23,
+	/* WO, 16 bits. Write with input power limit for board */
+	CMFW_SMBUS_POWER_LIMIT = 0x24,
+	/* WO, 16 bits. Write with current input power for board */
+	CMFW_SMBUS_POWER_INSTANT = 0x25,
+	/* RO, 8 bits. Issue a test read from CMFW scratch register */
+	CMFW_SMBUS_TEST_READ = 0xD8,
+	/* WO, 8 bits. Write to CMFW scratch register */
+	CMFW_SMBUS_TEST_WRITE = 0xD9,
+	/* RO, 16 bits. Issue a test read from CMFW scratch register */
+	CMFW_SMBUS_TEST_READ_WORD = 0xDA,
+	/* WO, 16 bits. Write to CMFW scratch register */
+	CMFW_SMBUS_TEST_WRITE_WORD = 0xDB,
+	/* RO, 32 bits. Issue a test read from CMFW scratch register */
+	CMFW_SMBUS_TEST_READ_BLOCK = 0xDC,
+	/* WO, 32 bits. Write to CMFW scratch register */
+	CMFW_SMBUS_TEST_WRITE_BLOCK = 0xDD,
+	CMFW_SMBUS_MSG_MAX,
+};
+
+/* Request IDs that the CMFW can issue within the */
+
+#endif /* TT_SMBUS_MSGS_H_ */

--- a/lib/tenstorrent/bh_arc/cm2dm_msg.c
+++ b/lib/tenstorrent/bh_arc/cm2dm_msg.c
@@ -24,7 +24,7 @@
 typedef struct {
 	uint8_t curr_msg_valid;
 	uint8_t next_seq_num;
-	Cm2DmSmbusReqMsg curr_msg;
+	cm2dmMessage curr_msg;
 } Cm2DmMsgState;
 
 static Cm2DmMsgState cm2dm_msg_state;
@@ -67,12 +67,12 @@ int32_t Cm2DmMsgReqSmbusHandler(uint8_t *data, uint8_t size)
 
 int32_t Cm2DmMsgAckSmbusHandler(const uint8_t *data, uint8_t size)
 {
-	BUILD_ASSERT(sizeof(Cm2DmSmbusAckMsg) == 2, "Unexpected size of Cm2DmSmbusAckMsg");
-	if (size != sizeof(Cm2DmSmbusAckMsg)) {
+	BUILD_ASSERT(sizeof(cm2dmAck) == 2, "Unexpected size of cm2dmAck");
+	if (size != sizeof(cm2dmAck)) {
 		return -1;
 	}
 
-	Cm2DmSmbusAckMsg *ack = (Cm2DmSmbusAckMsg *)data;
+	cm2dmAck *ack = (cm2dmAck *)data;
 
 	if (cm2dm_msg_state.curr_msg_valid && ack->msg_id == cm2dm_msg_state.curr_msg.msg_id &&
 	    ack->seq_num == cm2dm_msg_state.curr_msg.seq_num) {

--- a/lib/tenstorrent/bh_arc/cm2dm_msg.h
+++ b/lib/tenstorrent/bh_arc/cm2dm_msg.h
@@ -8,30 +8,12 @@
 
 #include <stdint.h>
 #include <zephyr/toolchain.h>
-
-typedef enum {
-	kCm2DmMsgIdNull = 0,
-	kCm2DmMsgIdResetReq = 1,
-	kCm2DmMsgIdPing = 2,
-	kCm2DmMsgIdFanSpeedUpdate = 3,
-	kCm2DmMsgIdReady = 4,
-} Cm2DmMsgId;
+#include <tenstorrent/bh_arc.h>
 
 typedef struct {
 	uint8_t msg_id;
 	uint32_t data;
 } Cm2DmMsg;
-
-typedef struct {
-	uint8_t msg_id;
-	uint8_t seq_num;
-	uint32_t data;
-} __packed Cm2DmSmbusReqMsg;
-
-typedef struct {
-	uint8_t msg_id;
-	uint8_t seq_num;
-} __packed Cm2DmSmbusAckMsg;
 
 int32_t EnqueueCm2DmMsg(const Cm2DmMsg *msg);
 int32_t Cm2DmMsgReqSmbusHandler(uint8_t *data, uint8_t size);
@@ -41,14 +23,6 @@ int32_t ResetBoardByte(uint8_t *data, uint8_t size);
 void ChipResetRequest(void *arg);
 void UpdateFanSpeedRequest(uint32_t fan_speed);
 void Dm2CmReadyRequest(void);
-
-typedef struct dmStaticInfo {
-	/* Non-zero for valid data */
-	/* Allows for breaking changes */
-	uint32_t version;
-	uint32_t bl_version;
-	uint32_t app_version;
-} __packed dmStaticInfo;
 
 int32_t Dm2CmSendDataHandler(const uint8_t *data, uint8_t size);
 int32_t Dm2CmPingHandler(const uint8_t *data, uint8_t size);

--- a/lib/tenstorrent/bh_arc/smbus_target.c
+++ b/lib/tenstorrent/bh_arc/smbus_target.c
@@ -14,6 +14,7 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/i2c.h>
+#include <tenstorrent/tt_smbus_regs.h>
 
 /* DMFW to CMFW i2c interface is on I2C0 of tensix_sm */
 #define CM_I2C_DM_TARGET_INST 0
@@ -154,48 +155,48 @@ static SmbusData smbus_data = {
 };
 static SmbusConfig smbus_config = {
 	.cmd_defs = {
-		[0x10] = {.valid = 1,
+		[CMFW_SMBUS_REQ] = {.valid = 1,
 			  .trans_type = kSmbusTransBlockRead,
 			  .expected_blocksize = 6,
 			  .handler = {.send_handler = &Cm2DmMsgReqSmbusHandler}},
-		[0x11] = {.valid = 1,
+		[CMFW_SMBUS_ACK] = {.valid = 1,
 			  .trans_type = kSmbusTransWriteWord,
 			  .handler = {.rcv_handler = &Cm2DmMsgAckSmbusHandler}},
-		[0x20] = {.valid = 1,
+		[CMFW_SMBUS_DM_FW_VERSION] = {.valid = 1,
 			  .trans_type = kSmbusTransBlockWrite,
 			  .expected_blocksize = sizeof(dmStaticInfo),
 			  .handler = {.rcv_handler = &Dm2CmSendDataHandler}},
-		[0x21] = {.valid = 1,
+		[CMFW_SMBUS_PING] = {.valid = 1,
 			  .trans_type = kSmbusTransWriteWord,
 			  .handler = {.rcv_handler = &Dm2CmPingHandler}},
-		[0x23] = {.valid = 1,
+		[CMFW_SMBUS_FAN_RPM] = {.valid = 1,
 			  .trans_type = kSmbusTransWriteWord,
 			  .handler = {.rcv_handler = &Dm2CmSendFanRPMHandler}},
 #ifndef CONFIG_TT_SMC_RECOVERY
-		[0x24] = {.valid = 1,
+		[CMFW_SMBUS_POWER_LIMIT] = {.valid = 1,
 			  .trans_type = kSmbusTransWriteWord,
 			  .handler = {.rcv_handler = &Dm2CmSetBoardPowerLimit}},
-		[0x25] = {.valid = 1,
+		[CMFW_SMBUS_POWER_INSTANT] = {.valid = 1,
 			  .trans_type = kSmbusTransWriteWord,
 			  .handler = {.rcv_handler = &Dm2CmSendPowerHandler}},
 #endif
-		[0xD8] = {.valid = 1,
+		[CMFW_SMBUS_TEST_READ] = {.valid = 1,
 			  .trans_type = kSmbusTransReadByte,
 			  .handler = {.send_handler = &ReadByteTest}},
-		[0xD9] = {.valid = 1,
+		[CMFW_SMBUS_TEST_WRITE] = {.valid = 1,
 			  .trans_type = kSmbusTransWriteByte,
 			  .handler = {.rcv_handler = &WriteByteTest}},
-		[0xDA] = {.valid = 1,
+		[CMFW_SMBUS_TEST_READ_WORD] = {.valid = 1,
 			  .trans_type = kSmbusTransReadWord,
 			  .handler = {.send_handler = &ReadWordTest}},
-		[0xDB] = {.valid = 1,
+		[CMFW_SMBUS_TEST_WRITE_WORD] = {.valid = 1,
 			  .trans_type = kSmbusTransWriteWord,
 			  .handler = {.rcv_handler = &WriteWordTest}},
-		[0xDC] = {.valid = 1,
+		[CMFW_SMBUS_TEST_READ_BLOCK] = {.valid = 1,
 			  .trans_type = kSmbusTransBlockRead,
 			  .expected_blocksize = 4,
 			  .handler = {.send_handler = &BlockReadTest}},
-		[0xDD] = {.valid = 1,
+		[CMFW_SMBUS_TEST_WRITE_BLOCK] = {.valid = 1,
 			  .trans_type = kSmbusTransBlockWrite,
 			  .expected_blocksize = 4,
 			  .handler = {.rcv_handler = &BlockWriteTest}},

--- a/lib/tenstorrent/bh_chip/bh_chip.c
+++ b/lib/tenstorrent/bh_chip/bh_chip.c
@@ -9,6 +9,7 @@
 #include <tenstorrent/bh_chip.h>
 #include <tenstorrent/fan_ctrl.h>
 #include <tenstorrent/event.h>
+#include <tenstorrent/tt_smbus_regs.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include <string.h>
@@ -34,7 +35,7 @@ cm2dmMessageRet bh_chip_get_cm2dm_message(struct bh_chip *chip)
 	uint8_t count = sizeof(output.msg);
 	uint8_t buf[32]; /* Max block counter per API */
 
-	output.ret = bharc_smbus_block_read(&chip->config.arc, 0x10, &count, buf);
+	output.ret = bharc_smbus_block_read(&chip->config.arc, CMFW_SMBUS_REQ, &count, buf);
 	memcpy(&output.msg, buf, sizeof(output.msg));
 
 	if (output.ret == 0 && output.msg.msg_id != 0) {
@@ -46,7 +47,8 @@ cm2dmMessageRet bh_chip_get_cm2dm_message(struct bh_chip *chip)
 
 		wire_ack.f = ack;
 		output.ack = ack;
-		output.ack_ret = bharc_smbus_word_data_write(&chip->config.arc, 0x11, wire_ack.val);
+		output.ack_ret = bharc_smbus_word_data_write(&chip->config.arc,
+							     CMFW_SMBUS_ACK, wire_ack.val);
 	}
 
 	return output;
@@ -56,8 +58,8 @@ int bh_chip_set_static_info(struct bh_chip *chip, dmStaticInfo *info)
 {
 	int ret;
 
-	ret = bharc_smbus_block_write(&chip->config.arc, 0x20, sizeof(dmStaticInfo),
-				      (uint8_t *)info);
+	ret = bharc_smbus_block_write(&chip->config.arc, CMFW_SMBUS_DM_FW_VERSION,
+				      sizeof(dmStaticInfo), (uint8_t *)info);
 
 	return ret;
 }
@@ -66,7 +68,7 @@ int bh_chip_set_input_power(struct bh_chip *chip, uint16_t power)
 {
 	int ret;
 
-	ret = bharc_smbus_word_data_write(&chip->config.arc, 0x25, power);
+	ret = bharc_smbus_word_data_write(&chip->config.arc, CMFW_SMBUS_POWER_INSTANT, power);
 
 	return ret;
 }
@@ -75,7 +77,7 @@ int bh_chip_set_input_power_lim(struct bh_chip *chip, uint16_t max_power)
 {
 	int ret;
 
-	ret = bharc_smbus_word_data_write(&chip->config.arc, 0x24, max_power);
+	ret = bharc_smbus_word_data_write(&chip->config.arc, CMFW_SMBUS_POWER_LIMIT, max_power);
 
 	return ret;
 }
@@ -84,7 +86,7 @@ int bh_chip_set_fan_rpm(struct bh_chip *chip, uint16_t rpm)
 {
 	int ret;
 
-	ret = bharc_smbus_word_data_write(&chip->config.arc, 0x23, rpm);
+	ret = bharc_smbus_word_data_write(&chip->config.arc, CMFW_SMBUS_FAN_RPM, rpm);
 
 	return ret;
 }


### PR DESCRIPTION
Rather than using magic numbers for SMBUS registers within the DMFW and
CMFW, define all SMBUS registers in a header file, and reuse this header
file in the DMFW and CMFW to avoid potential mismatches.

Additionally, remove duplicated cm2dm messaging structure definitions, and use the ones provided by the DMFW in both firmwares.


This PR is exclusively code cleanup, it has no functional changes