### PR TITLE
ci: use download-artifact@v3

### DIFF
--- a/.github/workflows/build-fw.yml
+++ b/.github/workflows/build-fw.yml
@@ -166,7 +166,7 @@ jobs:
           ref: ${{ github.ref }}
 
       - name: Download firmware artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           pattern: firmware-*
           path: tt-zephyr-platforms

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,12 +45,12 @@ jobs:
           echo "TRIMMED_VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
 
       - name: Download firmware artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           pattern: firmware-*
 
       - name: Download combined firmware bundle
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: combined-fwbundle
 


### PR DESCRIPTION
There is an important note on [the landing page](https://github.com/actions/download-artifact) for actions/download-artifact in that it warns users of GHES that v4+ is not currently supported on GitHub Enterprise Server.

<img width="961" alt="Screenshot 2025-05-21 at 4 31 51 PM" src="https://github.com/user-attachments/assets/4d6a421b-63be-45f3-82bb-9d7000e84488" />

It's not 100% certain if that applies to us, but I guess it doesn't hurt to try? ¯\_(ツ)_/¯.