### PR TITLE
ci: release: automatically add release notes to draft release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,46 +6,68 @@ on:
       - 'v*'
       - 'v*rc*'
 
+env:
+  RELEASE_NOTES_DIR: doc/release
+  SET_VARS_CMDS: |
+    VERSION=${GITHUB_REF#refs/tags/}
+    echo "VERSION=$VERSION" | tee -a $GITHUB_OUTPUT
+    TRIMMED_VERSION=${VERSION/v}
+    echo "TRIMMED_VERSION=$TRIMMED_VERSION" | tee -a $GITHUB_OUTPUT
+    if [ "$VERSION" = "${VERSION/rc}" ]; then
+      # not an rc, so we should generate release notes
+      echo "RELEASE_NOTES=release-notes-$TRIMMED_VERSION.md" | tee -a $GITHUB_OUTPUT
+    else
+      echo "Not publishing release notes for release candidate $VERSION"
+    fi
+
 jobs:
-  build-spdx:
+  prepare-release:
     runs-on: ubuntu-24.04
     steps:
+      - id: set_vars
+        run: ${{ env.SET_VARS_CMDS }}
       - uses: actions/checkout@v4
-        with:
-          path: tt-zephyr-platforms
-          ref: ${{ github.ref }}
-      - id: get_version
+      - id: check_relnotes_file
         run: |
-          echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
-          echo "TRIMMED_VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
-
+          relnotes_file="${{ env.RELEASE_NOTES_DIR }}/${{ steps.set_vars.outputs.RELEASE_NOTES }}"
+          if [ "${{ steps.set_vars.outputs.RELEASE_NOTES }}" != "" ] && [ ! -f "$relnotes_file" ]; then
+            echo "Release notes file is not present: $relnotes_file"
+            exit 1
+          fi
       - name: REUSE Compliance Check
         uses: fsfe/reuse-action@v5
         with:
-          args: spdx -o tt-zephyr-platforms-${{ steps.get_version.outputs.VERSION }}.spdx
+          args: spdx -o tt-zephyr-platforms-${{ steps.set_vars.outputs.VERSION }}.spdx
 
       - name: Upload SPDX
         uses: actions/upload-artifact@v4
         with:
-          name: tt-zephyr-platforms-${{ steps.get_version.outputs.VERSION }}.spdx
-          path: tt-zephyr-platforms-${{ steps.get_version.outputs.VERSION }}.spdx
+          if-no-files-found: error
+          name: tt-zephyr-platforms-${{ steps.set_vars.outputs.VERSION }}.spdx
+          path: tt-zephyr-platforms-${{ steps.set_vars.outputs.VERSION }}.spdx
+
+      - name: Upload Release Notes
+        if: ${{ steps.set_vars.outputs.RELEASE_NOTES }}
+        uses: actions/upload-artifact@v4
+        with:
+          if-no-files-found: error
+          name: ${{ steps.set_vars.outputs.RELEASE_NOTES }}
+          path: ${{ env.RELEASE_NOTES_DIR }}/${{ steps.set_vars.outputs.RELEASE_NOTES }}
 
   build-release:
+    needs: [prepare-release]
     uses: ./.github/workflows/build-fw.yml
     secrets:
       SIGNATURE_KEY: ${{ secrets.SIGNATURE_KEY }}
 
   publish-release:
-    needs: [build-release, build-spdx]
+    needs: [build-release, prepare-release]
     runs-on: ubuntu-24.04
     permissions:
       contents: write
     steps:
-      - id: get_version
-        run: |
-          echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
-          echo "TRIMMED_VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
-
+      - id: set_vars
+        run: ${{ env.SET_VARS_CMDS }}
       - name: Download firmware artifacts
         uses: actions/download-artifact@v4
         with:
@@ -55,6 +77,17 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: combined-fwbundle
+
+      - name: Download Release Notes
+        if: ${{ steps.set_vars.outputs.RELEASE_NOTES }}
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ steps.set_vars.outputs.RELEASE_NOTES }}
+
+      - name: Download SPDX
+        uses: actions/download-artifact@v4
+        with:
+          name: tt-zephyr-platforms-${{ steps.set_vars.outputs.VERSION }}.spdx
 
       - name: Package firmware artifacts
         run: |
@@ -66,20 +99,18 @@ jobs:
             mv $REV/update.fwbundle $REV.fwbundle
           done
 
-          zip -r -9 tt-zephyr-platforms-${{ steps.get_version.outputs.VERSION }}.zip $BOARD_REVS
-
-      - name: Create empty release notes body
-        run: |
-          echo "TODO: add release overview and notes link" > release-notes.txt
+          zip -r -9 tt-zephyr-platforms-${{ steps.set_vars.outputs.VERSION }}.zip $BOARD_REVS
 
       - name: Create Release
         uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          body_path: release-notes.txt
+          # Note: body path _may_ be empty for release candidates, even with fail_on_unmatched_files == true
+          body_path: ${{ steps.set_vars.outputs.RELEASE_NOTES }}
           draft: true
           prerelease: true
+          fail_on_unmatched_files: true
           files: |
             *.fwbundle
-            tt-zephyr-platforms-${{ steps.get_version.outputs.VERSION }}.zip
-            tt-zephyr-platforms-${{ steps.get_version.outputs.VERSION }}.spdx
+            tt-zephyr-platforms-${{ steps.set_vars.outputs.VERSION }}.zip
+            tt-zephyr-platforms-${{ steps.set_vars.outputs.VERSION }}.spdx


### PR DESCRIPTION
Automatically add release notes to draft release.

Testing Done:

final:
https://github.com/cfriedt/tt-zephyr-platforms/actions/runs/15508836931
https://github.com/cfriedt/tt-zephyr-platforms/releases/tag/v0.0.0

rc:
https://github.com/cfriedt/tt-zephyr-platforms/actions/runs/15512425139
https://github.com/cfriedt/tt-zephyr-platforms/releases/tag/v0.0.0-rc1