### PR TITLE
bh_arc: expose fused ASIC ID in telemetry

### DIFF
--- a/lib/tenstorrent/bh_arc/functional_efuse.h
+++ b/lib/tenstorrent/bh_arc/functional_efuse.h
@@ -12,8 +12,8 @@
 
 #define FUSE_ASIC_ID_OLD_START_BIT                    1056
 #define FUSE_ASIC_ID_OLD_END_BIT                      1071
-#define FUSE_ASIC_ID_START_BIT                        1600
-#define FUSE_ASIC_ID_END_BIT                          1615
+#define FUSE_ASIC_ID_LOW_START_BIT                    1600
+#define FUSE_ASIC_ID_LOW_END_BIT                      1631
 #define FUSE_ATE_TENSIX_ROW0_TEST_STATUS_START_BIT    3168
 #define FUSE_ATE_TENSIX_ROW0_TEST_STATUS_END_BIT      3199
 #define FUSE_ATE_TENSIX_ROW1_TEST_STATUS_START_BIT    3200
@@ -68,6 +68,8 @@
 #define FUSE_SLT_ETH_CTRL_TEST_STATUS_END_BIT         5535
 #define FUSE_SLT_HARVESTED_TENSIX_COLUMNS_START_BIT   5536
 #define FUSE_SLT_HARVESTED_TENSIX_COLUMNS_END_BIT     5551
+#define FUSE_ASIC_ID_HIGH_START_BIT                   5568
+#define FUSE_ASIC_ID_HIGH_END_BIT                     5599
 
 /* Use this helper macro to read functional efuse fields */
 /* Note that it only works for fields that are 32-bits or smaller */

--- a/lib/tenstorrent/bh_arc/telemetry.c
+++ b/lib/tenstorrent/bh_arc/telemetry.c
@@ -6,6 +6,7 @@
 
 #include "cm2dm_msg.h"
 #include "fan_ctrl.h"
+#include "functional_efuse.h"
 #include "fw_table.h"
 #include "harvesting.h"
 #include "pll.h"
@@ -48,7 +49,6 @@ static struct telemetry_table telemetry_table = {
 	.tag_table = {
 		[0] = {TAG_BOARD_ID_HIGH, TELEM_OFFSET(TAG_BOARD_ID_HIGH)},
 		[1] = {TAG_BOARD_ID_LOW, TELEM_OFFSET(TAG_BOARD_ID_LOW)},
-		[2] = {TAG_ASIC_ID, TELEM_OFFSET(TAG_ASIC_ID)},
 		[3] = {TAG_HARVESTING_STATE, TELEM_OFFSET(TAG_HARVESTING_STATE)},
 		[4] = {TAG_UPDATE_TELEM_SPEED, TELEM_OFFSET(TAG_UPDATE_TELEM_SPEED)},
 		[5] = {TAG_VCORE, TELEM_OFFSET(TAG_VCORE)},
@@ -98,7 +98,9 @@ static struct telemetry_table telemetry_table = {
 		[49] = {TAG_ASIC_LOCATION, TELEM_OFFSET(TAG_ASIC_LOCATION)},
 		[50] = {TAG_BOARD_POWER_LIMIT, TELEM_OFFSET(TAG_BOARD_POWER_LIMIT)},
 		[51] = {TAG_INPUT_POWER, TELEM_OFFSET(TAG_INPUT_POWER)},
-		[52] = {TAG_TELEM_ENUM_COUNT, TELEM_OFFSET(TAG_TELEM_ENUM_COUNT)},
+		[52] = {TAG_ASIC_ID_HIGH, TELEM_OFFSET(TAG_ASIC_ID_HIGH)},
+		[53] = {TAG_ASIC_ID_LOW, TELEM_OFFSET(TAG_ASIC_ID_LOW)},
+		[54] = {TAG_TELEM_ENUM_COUNT, TELEM_OFFSET(TAG_TELEM_ENUM_COUNT)},
 	},
 };
 static uint32_t *telemetry = &telemetry_table.telemetry[0];
@@ -235,7 +237,8 @@ static void write_static_telemetry(uint32_t app_version)
 	/* Get the static values */
 	telemetry[TAG_BOARD_ID_HIGH] = get_read_only_table()->board_id >> 32;
 	telemetry[TAG_BOARD_ID_LOW] = get_read_only_table()->board_id & 0xFFFFFFFF;
-	telemetry[TAG_ASIC_ID] = 0x00000000; /* Might be subject to redesign */
+	telemetry[TAG_ASIC_ID_HIGH] = READ_FUNCTIONAL_EFUSE(ASIC_ID_HIGH);
+	telemetry[TAG_ASIC_ID_LOW] = READ_FUNCTIONAL_EFUSE(ASIC_ID_LOW);
 	telemetry[TAG_HARVESTING_STATE] = 0x00000000;
 	telemetry[TAG_UPDATE_TELEM_SPEED] = telem_update_interval; /* Expected speed of
 								    * update in ms

--- a/lib/tenstorrent/bh_arc/telemetry.h
+++ b/lib/tenstorrent/bh_arc/telemetry.h
@@ -69,10 +69,12 @@
 #define TAG_ASIC_LOCATION        52
 #define TAG_BOARD_POWER_LIMIT    53
 #define TAG_INPUT_POWER          54
+#define TAG_ASIC_ID_HIGH         62
+#define TAG_ASIC_ID_LOW          63
 /* Not a real tag, signifies the last tag in the list.
  * MUST be incremented if new tags are defined
  */
-#define TAG_COUNT                55
+#define TAG_COUNT                64
 
 /* Telemetry tags are at offset `tag` in the telemetry buffer */
 #define TELEM_OFFSET(tag) (tag)


### PR DESCRIPTION
Each BH ASIC is fused with a unique 64 bit ASIC ID during testing. Add two new fields to telemetry to expose this, ASIC_ID_HIGH and ASIC_ID_LOW.

Remove ASIC_ID from telemetry table, which was added when a 32 bit value was expected.