### PR TITLE
ci: add custom concurrency group for build-fw workflow

### DIFF
--- a/.github/workflows/build-fw.yml
+++ b/.github/workflows/build-fw.yml
@@ -23,7 +23,7 @@ on:
       - v*-branch
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-build-fw-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 # TODO: read boards / board revs from a YAML file (generate a matrix)


### PR DESCRIPTION
build-fw workflow requires a custom concurrency group, because it is used as a reusable workflow within the hardware-smoke workflow. This will cause a deadlock conflict in CI if the concurrency group names are the same, so add a custom string into the concurrency group.