### PR TITLE
lib: telemetry: reduce tag values to comply with pyluwen tag parsing

### DIFF
--- a/lib/tenstorrent/bh_arc/telemetry.c
+++ b/lib/tenstorrent/bh_arc/telemetry.c
@@ -234,6 +234,7 @@ static void write_static_telemetry(uint32_t app_version)
 							 * meaning of an existing tag
 							 */
 	telemetry_table.entry_count = TAG_COUNT; /* Runtime count of telemetry entries */
+	telemetry[TAG_TELEM_ENUM_COUNT] = TAG_COUNT; /* Count of telemetry tags */
 
 	/* Get the static values */
 	telemetry[TAG_BOARD_ID_HIGH] = get_read_only_table()->board_id >> 32;

--- a/lib/tenstorrent/bh_arc/telemetry.h
+++ b/lib/tenstorrent/bh_arc/telemetry.h
@@ -69,13 +69,14 @@
 #define TAG_ASIC_LOCATION        52
 #define TAG_BOARD_POWER_LIMIT    53
 #define TAG_INPUT_POWER          54
-#define TAG_THERM_TRIP_COUNT	 61
-#define TAG_ASIC_ID_HIGH         62
-#define TAG_ASIC_ID_LOW          63
+#define TAG_THERM_TRIP_COUNT     60
+#define TAG_ASIC_ID_HIGH         61
+#define TAG_ASIC_ID_LOW          62
 /* Not a real tag, signifies the last tag in the list.
- * MUST be incremented if new tags are defined
+ * MUST be incremented if new tags are defined.
+ * Note tt-smi currently only supports up to 62 tags on blackhole.
  */
-#define TAG_COUNT                64
+#define TAG_COUNT                63
 
 /* Telemetry tags are at offset `tag` in the telemetry buffer */
 #define TELEM_OFFSET(tag) (tag)


### PR DESCRIPTION
pyluwen parses tag indices as a u8 on blackhole, and each tag occupies 32 bits. When the tag index is converted into an offset by multiplying by 4, we hit an effective limit of 62 tag values (max tag value of 62), as otherwise the pyluwen tag parsing code hits an overflow when slicing from the tag data array (63 * 4 + 4 = 256).

To correct this, reduce tag values for asic IDs to fit within the boundary. Also, properly populate the tag count within the telemetry block.