### PR TITLE
ci: re-enable p100 metal tests

### DIFF
--- a/.github/workflows/hardware-long.yml
+++ b/.github/workflows/hardware-long.yml
@@ -21,10 +21,9 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          # disabled until #253 is resolved
-          # - board: p100
-          #  runs-on:
-          #    - p100-jtag
+          - board: p100
+            runs-on:
+              - p100-jtag
           - board: p100a
             runs-on:
               - p100a-jtag

--- a/.github/workflows/hardware-smoke.yml
+++ b/.github/workflows/hardware-smoke.yml
@@ -275,10 +275,9 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          # disabled until #253 is resolved
-          # - board: p100
-          #  runs-on:
-          #    - p100-jtag
+          - board: p100
+            runs-on:
+              - p100-jtag
           - board: p100a
             runs-on:
               - p100a-jtag


### PR DESCRIPTION
Re-enable p100 tests for metal.

Fixes #253