### PR TITLE
ci: workflows: add permissions to release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,8 @@ jobs:
   publish-release:
     needs: [build-release, build-spdx]
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
     steps:
       - id: get_version
         run: |


### PR DESCRIPTION
Release job needs write permissions on the contents of the repository in order to create a draft release, so add this setting to the workflow.

here is a job failing based on the v18.4.0-rc1 tag: [danieldegrasse/tt-zephyr-platforms/actions/runs/15338904861/job/43162145000](https://github.com/danieldegrasse/tt-zephyr-platforms/actions/runs/15338904861/job/43162145000). I created a 18.4.0-rc2 tag on my fork with the commit in that PR, and the release action succeeds there: [danieldegrasse/tt-zephyr-platforms/actions/runs/15339297827](https://github.com/danieldegrasse/tt-zephyr-platforms/actions/runs/15339297827)