### PR TITLE
lib: tenstorrent: fan_ctrl: disable initial fan spin-up

### DIFF
--- a/app/dmc/src/main.c
+++ b/app/dmc/src/main.c
@@ -259,7 +259,7 @@ int main(void)
 
 	if (IS_ENABLED(CONFIG_TT_FAN_CTRL)) {
 		ret = init_fan();
-		set_fan_speed(100); /* Set fan speed to 100 by default */
+		set_fan_speed(25); /* Start fan speed at 25% */
 		if (ret != 0) {
 			LOG_ERR("%s() failed: %d", "init_fan", ret);
 			return ret;

--- a/lib/tenstorrent/fan_ctrl/fan_ctrl.c
+++ b/lib/tenstorrent/fan_ctrl/fan_ctrl.c
@@ -29,8 +29,9 @@ int init_fan(void)
 	if (ret != 0) {
 		return ret;
 	}
-	/* disable pulse stretching, deassert THERM, set PWM frequency to high */
-	ret = smbus_byte_data_write(smbus1, FAN_CTRL_ADDR, FAN1_CONFIG_3, 0x23);
+	/* disable fan spin-up, disable pulse stretching, deassert THERM, set PWM frequency to high
+	 */
+	ret = smbus_byte_data_write(smbus1, FAN_CTRL_ADDR, FAN1_CONFIG_3, 0xA3);
 	if (ret != 0) {
 		return ret;
 	}


### PR DESCRIPTION
Disable fan spin-up and set initial fan speed to 25% on active-cooled boards. This is to address customer concerns about the fan spin-up being loud.