### PR TITLE
blobs: correct sha256sum for fw_pack-wormhole.tar.gz

### DIFF
--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -194,7 +194,7 @@ blobs:
     description: "Modified bootrom to boot Blackhole"
     doc-url: https://tenstorrent.com
   - path: fw_pack-wormhole.tar.gz
-    sha256: b27e10380c7769ceab3c924da3df75620b80269d58a7b82dd6ed1df30dd9d345
+    sha256: 1cd20cd64f1035e12245b36a851a5fa66672032c45ef18fca5b60016ff926f3d
     type: img
     version: '18.4.0-rc1'
     license-path: zephyr/blobs/license.txt


### PR DESCRIPTION
Update the sha256sum for fw_pack-wormhole.tar.gz since that was left out of the previous commit.