### PR TITLE
pcie: enable CEM1 in RC mode

### DIFF
--- a/lib/tenstorrent/bh_arc/gpio.h
+++ b/lib/tenstorrent/bh_arc/gpio.h
@@ -11,6 +11,7 @@
 #define GPIO_THERM_TRIP         31
 #define GPIO_PCIE_TRISTATE_CTRL 34
 #define GPIO_CEM0_PERST         37
+#define GPIO_CEM1_PERST         39
 
 void GpioEnableOutput(uint32_t pin);
 void GpioDisableOutput(uint32_t pin);

--- a/lib/tenstorrent/bh_arc/pcie.c
+++ b/lib/tenstorrent/bh_arc/pcie.c
@@ -274,14 +274,17 @@ static void TogglePerst(void)
 	/* GPIO34 is TRISTATE of level shifter, GPIO37 is PERST input to the level shifter */
 	GpioEnableOutput(GPIO_PCIE_TRISTATE_CTRL);
 	GpioEnableOutput(GPIO_CEM0_PERST);
+	GpioEnableOutput(GPIO_CEM1_PERST);
 
 	/* put device into reset for 1 ms */
 	GpioSet(GPIO_PCIE_TRISTATE_CTRL, 1);
 	GpioSet(GPIO_CEM0_PERST, 0);
+	GpioSet(GPIO_CEM1_PERST, 0);
 	WaitMs(1);
 
 	/* take device out of reset */
 	GpioSet(GPIO_CEM0_PERST, 1);
+	GpioSet(GPIO_CEM1_PERST, 1);
 }
 
 static PCIeInitStatus PollForLinkUp(uint8_t pcie_inst)


### PR DESCRIPTION
drive PERST of CEM1 slot when operating in RC mode