### PR TITLE
boards: tenstorrent: encode a default board ID into flash images

### DIFF
--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/GALAXY/read_only.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/GALAXY/read_only.txt
@@ -19,3 +19,4 @@ reference_values_table {
 }
 vendor_id: 0x1e52
 asic_location: 0
+board_id: 0x47100000000

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/ORION/read_only.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/ORION/read_only.txt
@@ -19,3 +19,4 @@ reference_values_table {
 }
 vendor_id: 0x1e52
 asic_location: 0
+board_id: 0x38100000000

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P100/read_only.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P100/read_only.txt
@@ -19,3 +19,4 @@ reference_values_table {
 }
 vendor_id: 0x1e52
 asic_location: 0
+board_id: 0x36100000000

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P100A/read_only.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P100A/read_only.txt
@@ -19,3 +19,4 @@ reference_values_table {
 }
 vendor_id: 0x1e52
 asic_location: 0
+board_id: 0x43100000000

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P150A/read_only.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P150A/read_only.txt
@@ -19,3 +19,4 @@ reference_values_table {
 }
 vendor_id: 0x1e52
 asic_location: 0
+board_id: 0x40100000000

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P150B/read_only.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P150B/read_only.txt
@@ -19,3 +19,4 @@ reference_values_table {
 }
 vendor_id: 0x1e52
 asic_location: 0
+board_id: 0x41100000000

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P150C/read_only.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P150C/read_only.txt
@@ -19,3 +19,4 @@ reference_values_table {
 }
 vendor_id: 0x1e52
 asic_location: 0
+board_id: 0x42100000000

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300A_L/read_only.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300A_L/read_only.txt
@@ -19,3 +19,4 @@ reference_values_table {
 }
 vendor_id: 0x1e52
 asic_location: 0
+board_id: 0x45100000000

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300A_R/read_only.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300A_R/read_only.txt
@@ -19,3 +19,4 @@ reference_values_table {
 }
 vendor_id: 0x1e52
 asic_location: 1
+board_id: 0x45100000000

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300B_L/read_only.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300B_L/read_only.txt
@@ -19,3 +19,4 @@ reference_values_table {
 }
 vendor_id: 0x1e52
 asic_location: 0
+board_id: 0x44100000000

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300B_R/read_only.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300B_R/read_only.txt
@@ -19,3 +19,4 @@ reference_values_table {
 }
 vendor_id: 0x1e52
 asic_location: 1
+board_id: 0x44100000000

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300C_L/read_only.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300C_L/read_only.txt
@@ -19,3 +19,4 @@ reference_values_table {
 }
 vendor_id: 0x1e52
 asic_location: 0
+board_id: 0x46100000000

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300C_R/read_only.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300C_R/read_only.txt
@@ -19,3 +19,4 @@ reference_values_table {
 }
 vendor_id: 0x1e52
 asic_location: 1
+board_id: 0x46100000000

--- a/scripts/encode_spirom_bins.py
+++ b/scripts/encode_spirom_bins.py
@@ -156,20 +156,12 @@ def main():
     convert_proto_txt_to_bin_file(
         args.board, args.output, "flash_info", flash_info_pb2.FlashInfoTable, False
     )
-    board_type = (
-        int(os.environ.get("DEFAULT_BOARD_TYPE"), 0)
-        if os.environ.get("DEFAULT_BOARD_TYPE")
-        else 0
-    )
-    # Leave rev as 0 to indicate a bad flash
-    board_id = board_type << 36
     convert_proto_txt_to_bin_file(
         args.board,
         args.output,
         "read_only",
         read_only_pb2.ReadOnly,
         False,
-        override={"board_id": board_id},
     )
 
 


### PR DESCRIPTION
Encode a default board ID into the output flash image. This won't be present in the generated tt_boot_fs binary, but can be manually included with tt_boot_fs.py. This is useful for board recovery cases where the board ID has been erased.