### PR TITLE
lib: tenstorrent: add a print if PGOOD isn't high during boot

### DIFF
--- a/lib/tenstorrent/jtag_bootrom/jtag_bootrom.c
+++ b/lib/tenstorrent/jtag_bootrom/jtag_bootrom.c
@@ -87,6 +87,9 @@ int jtag_bootrom_reset_asic(struct bh_chip *chip)
 {
 	/* Only check for pgood if we aren't emulating */
 #if !DT_HAS_COMPAT_STATUS_OKAY(zephyr_gpio_emul)
+	if (!gpio_pin_get_dt(&chip->config.pgood)) {
+		printk("Waiting for pgood to rise...\n");
+	}
 	while (!gpio_pin_get_dt(&chip->config.pgood)) {
 	}
 #endif


### PR DESCRIPTION
Add a print statement if PGOOD isn't high during boot. This should help diagnose cases where a card isn't enumerating because PGOOD has gone low, since CI will dump the DMC RTT logs.