### PR TITLE
dmc: prevent invalid overwrite of dmc init time

### DIFF
--- a/lib/tenstorrent/bh_arc/cm2dm_msg.c
+++ b/lib/tenstorrent/bh_arc/cm2dm_msg.c
@@ -212,11 +212,7 @@ int32_t Dm2CmSendDataHandler(const uint8_t *data, uint8_t size)
 	if (info->version != 0) {
 		UpdateDmFwVersion(info->bl_version, info->app_version);
 		WriteReg(ARC_START_TIME_REG_ADDR, info->arc_start_time);
-
-		/* prevent overwrite from smi reset as it is invalid */
-		if (info->dm_init_duration != 0) {
-			WriteReg(PERST_TO_DMFW_INIT_DONE_REG_ADDR, info->dm_init_duration);
-		}
+		WriteReg(PERST_TO_DMFW_INIT_DONE_REG_ADDR, info->dm_init_duration);
 		return 0;
 	}
 #endif

--- a/lib/tenstorrent/jtag_bootrom/jtag_bootrom.c
+++ b/lib/tenstorrent/jtag_bootrom/jtag_bootrom.c
@@ -259,11 +259,7 @@ uint32_t get_arc_start_time(void)
 
 uint32_t get_dm_init_duration(void)
 {
-	uint32_t delta_cycles = 0;
-
-	if (perst_seen) {
-		delta_cycles = dm_init_done - perst_start_time;
-	}
+	uint32_t delta_cycles = dm_init_done - perst_start_time;
 	return delta_cycles;
 }
 
@@ -292,6 +288,7 @@ void jtag_bootrom_soft_reset_arc(struct bh_chip *chip)
 	/* store DMC init done timestamp */
 	if (perst_seen) {
 		dm_init_done = k_cycle_get_32();
+		perst_seen = false;
 	}
 
 	/* store ASIC refclk timestamp of DMC starts bootcode execution as a reference for cmfw. */


### PR DESCRIPTION
Prevent invalid overwrite of dmc init time by clearing perst seen after recording dm init done.
tt-smi reset does not reset DMC. Since perst seen is not cleared, it causes invalid overwrite of dmc init duration.
In cases where DMC get reset, dmc will just write 0 as init duration.