### PR TITLE
scripts:verify-blob: add blob sha256sum checks

### DIFF
--- a/.github/workflows/verify-blob.yml
+++ b/.github/workflows/verify-blob.yml
@@ -1,0 +1,46 @@
+name: Verify Blob
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - edited
+    branches:
+      - main
+      - v*-branch
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  verify_blob:
+    runs-on: ubuntu-22.04
+    name: Verify & update verify blob sha256sum
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{github.ref}}
+          path: tt-zephyr-platforms
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.13
+
+      - name: Install PyYAML
+        run: pip install pyyaml
+
+      - name: Verify blob
+        working-directory: tt-zephyr-platforms
+        run: |
+          python scripts/verify_blob.py

--- a/scripts/verify_blob.py
+++ b/scripts/verify_blob.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+import yaml
+import hashlib
+import os
+import sys
+
+# relative path from the root directory tt-zephyr_platforms to module.yml and blobs directory
+MODULE_YAML_PATH = "zephyr/module.yml"
+BLOBS_BASE_DIR = "zephyr/blobs/"
+
+
+def get_cur_blobs():
+    # Get the blobs defined in the module.yml file return as list of dicts
+    if not os.path.exists(MODULE_YAML_PATH):
+        print(f"Module YAML file {MODULE_YAML_PATH} does not exist.")
+        return []
+    with open(MODULE_YAML_PATH, "r") as file:
+        module_data = yaml.safe_load(file)
+    blobs = module_data.get("blobs", [])
+    return blobs
+
+
+def generate_expected_blob_sha256(blob):
+    # Generate new/expected blob SHA256 checksums for the given blob file path
+    blob_path = os.path.join(BLOBS_BASE_DIR, blob["path"])
+    with open(blob_path, "rb") as file:
+        content = file.read()
+        expected_blob_sha256 = hashlib.sha256(content).hexdigest()
+    return expected_blob_sha256
+
+
+def verify_blobs():
+    # Compare existing and most updated blob SHA256 checksums to see if they match
+    cur_blobs = get_cur_blobs()
+    if not cur_blobs:
+        print("No blobs found in module.yml.")
+        return 0
+
+    for blob in cur_blobs:
+        if not os.path.exists(os.path.join(BLOBS_BASE_DIR, blob["path"])):
+            # blob file no longer exists, skip
+            print(f"Blob file {blob['path']} does not exist.")
+            continue
+
+        cur_blob_sha256 = blob["sha256"]
+        expected_blob_sha256 = generate_expected_blob_sha256(blob)
+        if cur_blob_sha256 != expected_blob_sha256:
+            print(
+                f"Blob {blob['path']} has changed! Expected SHA256: {expected_blob_sha256}, but got {cur_blob_sha256}."
+            )
+            return 1
+
+    print("All blobs SHA256sum verified successfully.")
+    return 0
+
+
+def main():
+    return verify_blobs()
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Merging outdated blob sha256sum in module.yml can break CI.

Implemented blob sha256sum checks.

sample output when mismatched blob is detected
```
Blob tt_blackhole_gddr_init.bin has changed. Expected SHA256: df1ceefa477e5d8fbb02f37b1e5e0a0c7aabb875669167e6db2f7ce7cb9e6325, but got 97372fed110dd3fe8d3feba4260e6f48db8e30b0bf08ced31a0628b0ba4ed7e8.
Error: Process completed with exit code 1.
```