### PR TITLE
zephyr: use a dedicated name for our module

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ west patch apply
 source zephyr/zephyr-env.sh
 
 # Enter the module
-cd $MODULE.git
+cd $MODULE
 ```
 
 ### Build & Flash

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -3,6 +3,7 @@
 
 # See https://docs.zephyrproject.org/latest/develop/modules.html
 
+name: tt-zephyr-platforms
 build:
   cmake: .
   kconfig: Kconfig


### PR DESCRIPTION
By filling-in the 'name' field of our module as `tt-zephyr-platforms`, it will be checked-out to `tt-zephyr-platforms` instead of `tt-zephyt-platforms.git`, and we can use the variable `ZEPHYR_TT_ZEPHYR_PLATFORMS_MODULE_DIR` in CMake.

https://docs.zephyrproject.org/latest/develop/modules.html#module-name