### PR TITLE
readme: drop .git suffix of module repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ all Python dependencies, and the Zephyr SDK are already installed and activated.
 ```shell
 # Create a west workspace
 MODULE=tt-zephyr-platforms
-west init -m https://github.com/tenstorrent/tt-zephyr-platforms.git ~/$MODULE-work
+west init -m https://github.com/tenstorrent/$MODULE ~/$MODULE-work
 cd ~/$MODULE-work
 
 # Fetch Zephyr modules


### PR DESCRIPTION
Drop the .git suffix of the module repo so that when it is checked-out it is checked-out to tt-zephyr-platforms-work/tt-zephyr-platforms instead of tt-zephyr-platforms-work/tt-zephyr-platforms.git .

Testing done:
```shell
$ MODULE=tt-zephyr-platforms
$ west init -m https://github.com/tenstorrent/$MODULE /tmp/$MODULE-work
$ cd /tmp/$MODULE-work
$ ls
tt-zephyr-platforms
```