### PR TITLE
dts: bindings: rename blackhole-reset to bh-reset

### DIFF
--- a/drivers/reset/Kconfig.tt_bh
+++ b/drivers/reset/Kconfig.tt_bh
@@ -4,6 +4,6 @@
 config RESET_TT_BH
 	bool "Tenstorrent Blackhole reset controller"
 	default y
-	depends on DT_HAS_TENSTORRENT_BLACKHOLE_RESET_ENABLED
+	depends on DT_HAS_TENSTORRENT_BH_RESET_ENABLED
 	help
 	  This option enables the Tenstorrent Blackhole reset controller.

--- a/drivers/reset/reset_tt_bh.c
+++ b/drivers/reset/reset_tt_bh.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define DT_DRV_COMPAT tenstorrent_blackhole_reset
+#define DT_DRV_COMPAT tenstorrent_bh_reset
 
 #include <stdbool.h>
 #include <stdint.h>

--- a/dts/arc/tenstorrent/tt_blackhole_smc.dtsi
+++ b/dts/arc/tenstorrent/tt_blackhole_smc.dtsi
@@ -133,7 +133,7 @@
 		ranges;
 
 		global_reset: reset@80030000 {
-			compatible = "tenstorrent,blackhole-reset";
+			compatible = "tenstorrent,bh-reset";
 			reg = <0x80030000 0x4>;
 			#reset-cells = <1>;
 			reset-mask = <0x2383>;
@@ -141,7 +141,7 @@
 		};
 
 		pcie_reset: reset@80030004 {
-			compatible = "tenstorrent,blackhole-reset";
+			compatible = "tenstorrent,bh-reset";
 			reg = <0x80030004 0x4>;
 			#reset-cells = <1>;
 			nresets = <4>;
@@ -149,7 +149,7 @@
 		};
 
 		eth_reset: reset@80030008 {
-			compatible = "tenstorrent,blackhole-reset";
+			compatible = "tenstorrent,bh-reset";
 			reg = <0x80030008 0x4>;
 			#reset-cells = <1>;
 			nresets = <14>;
@@ -157,7 +157,7 @@
 		};
 
 		ddr_reset: reset@80030010 {
-			compatible = "tenstorrent,blackhole-reset";
+			compatible = "tenstorrent,bh-reset";
 			reg = <0x80030010 0x4>;
 			#reset-cells = <1>;
 			nresets = <8>;
@@ -165,7 +165,7 @@
 		};
 
 		l2cpu_reset: reset@80030014 {
-			compatible = "tenstorrent,blackhole-reset";
+			compatible = "tenstorrent,bh-reset";
 			reg = <0x80030014 0x4>;
 			#reset-cells = <1>;
 			nresets = <4>;
@@ -173,7 +173,7 @@
 		};
 
 		tensix_reset0: reset@80030020 {
-			compatible = "tenstorrent,blackhole-reset";
+			compatible = "tenstorrent,bh-reset";
 			reg = <0x80030020 0x4>;
 			#reset-cells = <1>;
 			nresets = <32>;
@@ -181,7 +181,7 @@
 		};
 
 		tensix_reset1: reset@80030024 {
-			compatible = "tenstorrent,blackhole-reset";
+			compatible = "tenstorrent,bh-reset";
 			reg = <0x80030024 0x4>;
 			#reset-cells = <1>;
 			nresets = <32>;
@@ -189,7 +189,7 @@
 		};
 
 		tensix_reset2: reset@80030028 {
-			compatible = "tenstorrent,blackhole-reset";
+			compatible = "tenstorrent,bh-reset";
 			reg = <0x80030028 0x4>;
 			#reset-cells = <1>;
 			nresets = <32>;
@@ -197,7 +197,7 @@
 		};
 
 		tensix_reset3: reset@8003002c {
-			compatible = "tenstorrent,blackhole-reset";
+			compatible = "tenstorrent,bh-reset";
 			reg = <0x8003002c 0x4>;
 			#reset-cells = <1>;
 			nresets = <32>;
@@ -205,7 +205,7 @@
 		};
 
 		tensix_reset4: reset@80030030 {
-			compatible = "tenstorrent,blackhole-reset";
+			compatible = "tenstorrent,bh-reset";
 			reg = <0x80030030 0x4>;
 			#reset-cells = <1>;
 			nresets = <32>;
@@ -213,7 +213,7 @@
 		};
 
 		tensix_reset5: reset@80030034 {
-			compatible = "tenstorrent,blackhole-reset";
+			compatible = "tenstorrent,bh-reset";
 			reg = <0x80030034 0x4>;
 			#reset-cells = <1>;
 			nresets = <32>;
@@ -221,7 +221,7 @@
 		};
 
 		tensix_reset6: reset@80030038 {
-			compatible = "tenstorrent,blackhole-reset";
+			compatible = "tenstorrent,bh-reset";
 			reg = <0x80030038 0x4>;
 			#reset-cells = <1>;
 			nresets = <32>;
@@ -229,7 +229,7 @@
 		};
 
 		tensix_reset7: reset@8003003c {
-			compatible = "tenstorrent,blackhole-reset";
+			compatible = "tenstorrent,bh-reset";
 			#reset-cells = <1>;
 			reg = <0x8003003c 0x4>;
 			nresets = <32>;

--- a/dts/bindings/reset/tenstorrent,bh-reset.yaml
+++ b/dts/bindings/reset/tenstorrent,bh-reset.yaml
@@ -1,13 +1,13 @@
 # Copyright (c) 2024 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
 
-description: Tenstorrrent Blackhole Reset Controller
-
-compatible: "tenstorrent,blackhole-reset"
+compatible: "tenstorrent,bh-reset"
 
 include: [base.yaml, reset-controller.yaml]
 
 description: |
+  Tenstorrent Blackhole Reset Controller
+
   The Tenstorrent Blackhole reset controller is used to manage one bank of reset signals occupying
   a 32-bit memory-mapped address.
 
@@ -16,32 +16,32 @@ description: |
   1. no mask is specified - 32 reset lines are available to the reset controller instance
 
     resetX: reset@abcd1234 {
-    	compatible = "tenstorrent,blackhole-reset";
-     	reg = <0xabcd1234 0x4>;
-    	#reset-cells = <1>;
-    	status = "okay";
+        compatible = "tenstorrent,bh-reset";
+        reg = <0xabcd1234 0x4>;
+        #reset-cells = <1>;
+        status = "okay";
     };
 
   2. a mask is specified. Only the bits (id values) set high in the mask are valid. In the
     example below, id 1 and id 2 are valid.
 
     resetX: reset@abcd1234 {
-    	compatible = "tenstorrent,blackhole-reset";
-     	reg = <0xabcd1234 0x4>;
-    	#reset-cells = <1>;
-      reset-mask = <0x42>;
-    	status = "okay";
+        compatible = "tenstorrent,bh-reset";
+        reg = <0xabcd1234 0x4>;
+        #reset-cells = <1>;
+        reset-mask = <0x42>;
+        status = "okay";
     };
 
   3. a number of resets is specified. In the example below, the least-significant 2 bits are
      available to the reset controller instance. So id 0 and id 1 are valid.
 
     resetX: reset@abcd1234 {
-    	compatible = "tenstorrent,blackhole-reset";
-     	reg = <0xabcd1234 0x4>;
-    	#reset-cells = <1>;
-      nresets = <3>;
-    	status = "okay";
+        compatible = "tenstorrent,bh-reset";
+        reg = <0xabcd1234 0x4>;
+        #reset-cells = <1>;
+        nresets = <3>;
+        status = "okay";
     };
 
   If neither nresets, nor reset-mask is specified, then all 32 reset lines are available.


### PR DESCRIPTION
To make bindings more consistent with other blackhole IP, rename the `tenstorrent,blackhole-reset` compatible to
`tenstorrent,bh-reset`.