### PR TITLE
app: smc: fall-back to null if wdt0 is disabled

### DIFF
--- a/app/smc/src/main.c
+++ b/app/smc/src/main.c
@@ -27,7 +27,7 @@
 
 LOG_MODULE_REGISTER(main, CONFIG_TT_APP_LOG_LEVEL);
 
-static const struct device *const wdt0 = DEVICE_DT_GET(DT_NODELABEL(wdt0));
+static const struct device *const wdt0 = DEVICE_DT_GET_OR_NULL(DT_NODELABEL(wdt0));
 
 int main(void)
 {


### PR DESCRIPTION
Previouosly, `app/smc` would unconditionally try to get a DT handle on `wdt0`. This would fail, however, when the watchdog timer was not enabled in DT.

Use `DEVICE_DT_GET_OR_NULL()` so that we are not left with an undefined symbol. i.e. get rid of the error that says

```shell
error: '__device_dts_ord_9' undeclared here
```

https://github.com/tenstorrent/tt-zephyr-platforms/actions/runs/15690400288/job/44203933940?pr=319