### PR TITLE
soc + board: tt_blackhole: add skeleton dt bindings and nodes for missing devices

### DIFF
--- a/boards/tenstorrent/tt_blackhole/tt_blackhole_tt_blackhole_smc.dts
+++ b/boards/tenstorrent/tt_blackhole/tt_blackhole_tt_blackhole_smc.dts
@@ -43,6 +43,48 @@
 
 &i2c1 {
 	status = "disabled";
+
+	regulator0: max20816@64 {
+		compatible = "maxim,max20816";
+		reg = <0x64>;
+		status = "disabled";
+	};
+
+	regulator1: max20816@65 {
+		compatible = "maxim,max20816";
+		reg = <0x65>;
+		status = "disabled";
+	};
+
+	regulator2: mpm3695@33 {
+		compatible = "mps,mpm3695";
+		reg = <0x33>;
+		status = "disabled";
+	};
+
+	regulator3: max20730@54 {
+		compatible = "maxim,max20730";
+		reg = <0x54>;
+		status = "disabled";
+	};
+
+	regulator4: max20730@55 {
+		compatible = "maxim,max20730";
+		reg = <0x55>;
+		status = "disabled";
+	};
+
+	regulator5: max20730@56 {
+		compatible = "maxim,max20730";
+		reg = <0x56>;
+		status = "disabled";
+	};
+
+	regulator6: max20730@57 {
+		compatible = "maxim,max20730";
+		reg = <0x57>;
+		status = "disabled";
+	};
 };
 
 &i2c2 {

--- a/dts/arc/tenstorrent/tt_blackhole_smc.dtsi
+++ b/dts/arc/tenstorrent/tt_blackhole_smc.dtsi
@@ -365,5 +365,11 @@
 			rx-fifo-depth = <255>;
 			clocks = <&sysclk>;
 		};
+
+		cdt0: cdt@80300000 {
+			compatible = "tenstorrent,bh-chip-debug-trace";
+			reg = <0x80300000 0x100>;
+			status = "disabled";
+		};
 	};
 };

--- a/dts/arc/tenstorrent/tt_blackhole_smc.dtsi
+++ b/dts/arc/tenstorrent/tt_blackhole_smc.dtsi
@@ -287,6 +287,16 @@
 		status = "disabled";
 	};
 
+	noc0: bh_noc0 {
+		compatible = "tenstorrent,noc";
+		status = "disabled";
+	};
+
+	noc1: bh_noc1 {
+		compatible = "tenstorrent,noc";
+		status = "disabled";
+	};
+
 	soc {
 		#address-cells = <1>;
 		#size-cells = <1>;

--- a/dts/arc/tenstorrent/tt_blackhole_smc.dtsi
+++ b/dts/arc/tenstorrent/tt_blackhole_smc.dtsi
@@ -177,6 +177,76 @@
 		status = "disabled";
 	};
 
+	eth0: bh_eth0 {
+		compatible = "tenstorrent,bh-eth";
+		status = "disabled";
+	};
+
+	eth1: bh_eth1 {
+		compatible = "tenstorrent,bh-eth";
+		status = "disabled";
+	};
+
+	eth2: bh_eth2 {
+		compatible = "tenstorrent,bh-eth";
+		status = "disabled";
+	};
+
+	eth3: bh_eth3 {
+		compatible = "tenstorrent,bh-eth";
+		status = "disabled";
+	};
+
+	eth4: bh_eth4 {
+		compatible = "tenstorrent,bh-eth";
+		status = "disabled";
+	};
+
+	eth5: bh_eth5 {
+		compatible = "tenstorrent,bh-eth";
+		status = "disabled";
+	};
+
+	eth6: bh_eth6 {
+		compatible = "tenstorrent,bh-eth";
+		status = "disabled";
+	};
+
+	eth7: bh_eth7 {
+		compatible = "tenstorrent,bh-eth";
+		status = "disabled";
+	};
+
+	eth8: bh_eth8 {
+		compatible = "tenstorrent,bh-eth";
+		status = "disabled";
+	};
+
+	eth9: bh_eth9 {
+		compatible = "tenstorrent,bh-eth";
+		status = "disabled";
+	};
+
+	eth10: bh_eth10 {
+		compatible = "tenstorrent,bh-eth";
+		status = "disabled";
+	};
+
+	eth11: bh_eth11 {
+		compatible = "tenstorrent,bh-eth";
+		status = "disabled";
+	};
+
+	eth12: bh_eth12 {
+		compatible = "tenstorrent,bh-eth";
+		status = "disabled";
+	};
+
+	eth13: bh_eth13 {
+		compatible = "tenstorrent,bh-eth";
+		status = "disabled";
+	};
+
 	soc {
 		#address-cells = <1>;
 		#size-cells = <1>;

--- a/dts/arc/tenstorrent/tt_blackhole_smc.dtsi
+++ b/dts/arc/tenstorrent/tt_blackhole_smc.dtsi
@@ -247,6 +247,46 @@
 		status = "disabled";
 	};
 
+	memc0: bh_memc0 {
+		compatible = "tenstorrent,bh-memc";
+		status = "disabled";
+	};
+
+	memc1: bh_memc1 {
+		compatible = "tenstorrent,bh-memc";
+		status = "disabled";
+	};
+
+	memc2: bh_memc2 {
+		compatible = "tenstorrent,bh-memc";
+		status = "disabled";
+	};
+
+	memc3: bh_memc3 {
+		compatible = "tenstorrent,bh-memc";
+		status = "disabled";
+	};
+
+	memc4: bh_memc4 {
+		compatible = "tenstorrent,bh-memc";
+		status = "disabled";
+	};
+
+	memc5: bh_memc5 {
+		compatible = "tenstorrent,bh-memc";
+		status = "disabled";
+	};
+
+	memc6: bh_memc6 {
+		compatible = "tenstorrent,bh-memc";
+		status = "disabled";
+	};
+
+	memc7: bh_memc7 {
+		compatible = "tenstorrent,bh-memc";
+		status = "disabled";
+	};
+
 	soc {
 		#address-cells = <1>;
 		#size-cells = <1>;

--- a/dts/bindings/debug/tenstorrent,bh-chip-debug-trace.yaml
+++ b/dts/bindings/debug/tenstorrent,bh-chip-debug-trace.yaml
@@ -1,0 +1,13 @@
+# Copyright (c) 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+compatible: "tenstorrent,bh-chip-debug-trace"
+
+description: |
+  Tenstorrent Blackhole Chip Debug Trace
+
+include: base.yaml
+
+properties:
+  reg:
+    required: true

--- a/dts/bindings/ethernet/tenstorrent,bh-eth.yaml
+++ b/dts/bindings/ethernet/tenstorrent,bh-eth.yaml
@@ -1,0 +1,11 @@
+# Copyright (c) 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+compatible: "tenstorrent,bh-eth"
+
+description: |
+  Tenstorrent Blackhole Ethernet Controller
+
+include: ["ethernet-controller.yaml", "base.yaml"]
+
+properties: {}

--- a/dts/bindings/memory-controllers/tenstorrent,bh-memc.yaml
+++ b/dts/bindings/memory-controllers/tenstorrent,bh-memc.yaml
@@ -1,0 +1,11 @@
+# Copyright (c) 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+compatible: "tenstorrent,bh-memc"
+
+description: |
+  Tenstorrent Blackhole GDDR Memory Controller
+
+include: base.yaml
+
+properties: {}

--- a/dts/bindings/misc/tenstorrent,noc.yaml
+++ b/dts/bindings/misc/tenstorrent,noc.yaml
@@ -1,0 +1,11 @@
+# Copyright (c) 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+compatible: "tenstorrent,noc"
+
+description: |
+  Tenstorrent Network-on-Chip (NOC) Controller
+
+include: base.yaml
+
+properties: {}

--- a/dts/bindings/regulator/maxim,max20730.yaml
+++ b/dts/bindings/regulator/maxim,max20730.yaml
@@ -1,0 +1,10 @@
+# Copyright (c) 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  Analog devices max20730 step-down switching regulator.
+  See https://www.analog.com/en/products/max20730.html.
+
+compatible: "maxim,max20730"
+
+include: i2c-device.yaml

--- a/dts/bindings/regulator/maxim,max20816.yaml
+++ b/dts/bindings/regulator/maxim,max20816.yaml
@@ -1,0 +1,10 @@
+# Copyright (c) 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  Analog devices max20816 step-down switching regulator.
+  See https://www.analog.com/en/products/max20816.html.
+
+compatible: "maxim,max20816"
+
+include: i2c-device.yaml

--- a/dts/bindings/regulator/mps,mpm3695.yaml
+++ b/dts/bindings/regulator/mps,mpm3695.yaml
@@ -1,0 +1,10 @@
+# Copyright (c) 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  Monolithic Power Systems MPM3695 buck converter.
+  See https://www.monolithicpower.com/en/mpm3695-25.html.
+
+compatible: "mps,mpm3695"
+
+include: i2c-device.yaml


### PR DESCRIPTION
Add skeleton DT bindings and nodes for a number of missing devices in the SMC SoC and board-level devicetrees.

The bindings and node properties should be elaborated when the drivers are implemented.