### PR TITLE
doc: release: process: minor correction on tag push

### DIFF
--- a/doc/release/release-process.md
+++ b/doc/release/release-process.md
@@ -163,7 +163,7 @@ Signed-off-by: Your Name <your@email.com>
 git checkout main
 git pull
 git tag -s -m "tt-firmware 1.2.3" v1.2.3
-git push --tags
+git push git@github.com:tenstorrent/tt-firmware.git v1.2.3
 ```
 
 8. Create a new `tt-firmware`


### PR DESCRIPTION
Previously, `git push --tags` was in the release process doc. However that can possibly have side-effects because it pushes all local tags. We want to restrict the tag that we push to only the newly created one. For that purpose, use `git push git@github.com:tenstorrent/tt-firmware.git <tag>`.