### PR TITLE
maintainers: add areas of interest for tenstorrent

### DIFF
--- a/.github/workflows/assigner.yml
+++ b/.github/workflows/assigner.yml
@@ -1,0 +1,50 @@
+name: Pull Request Assigner
+
+on:
+  pull_request_target:
+    types:
+    - opened
+    - synchronize
+    - reopened
+    - ready_for_review
+    branches:
+    - main
+    - v*-branch
+  issues:
+    types:
+    - labeled
+
+jobs:
+  assignment:
+    name: Pull Request Assignment
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-22.04
+
+    steps:
+    - name: Install Python dependencies
+      run: |
+        pip install -U PyGithub>=1.55 west
+
+    - name: Check out source code
+      uses: actions/checkout@v4
+
+    - name: Run assignment script
+      env:
+        GITHUB_TOKEN: ${{ secrets.ZB_GITHUB_TOKEN }}
+      run: |
+        FLAGS="-v"
+        FLAGS+=" -o ${{ github.event.repository.owner.login }}"
+        FLAGS+=" -r ${{ github.event.repository.name }}"
+        FLAGS+=" -M MAINTAINERS.yml"
+        if [ "${{ github.event_name }}" = "pull_request_target" ]; then
+            FLAGS+=" -P ${{ github.event.pull_request.number }}"
+        elif [ "${{ github.event_name }}" = "issues" ]; then
+            FLAGS+=" -I ${{ github.event.issue.number }}"
+        elif [ "${{ github.event_name }}" = "schedule" ]; then
+            FLAGS+=" --modules"
+        else
+          echo "Unknown event: ${{ github.event_name }}"
+          exit 1
+        fi
+
+        python3 scripts/set_assignees.py $FLAGS

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -16,8 +16,7 @@ Release Notes:
   maintainers:
     - cfriedt
   files:
-    - doc/release/release-notes-*
-    - doc/release/release-notes-*
+    - doc/release/
   labels:
     - "release ✅"
 

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -11,6 +11,448 @@ Continuous Integration:
   labels:
     - "ci ♾️"
 
+Bootloaders:
+  # Maintainer needed!
+  status: odd fixes
+  files:
+    - .gitignore
+    # - tests/boot/
+  labels:
+    - "area: Bootloader"
+  tests:
+    - bootloader
+
+Benchmarks:
+  # Maintainer needed!
+  status: odd fixes
+  files:
+    - .gitignore
+    # - tests/benchmarks/
+  labels:
+    - "area: Benchmarks"
+
+Debug:
+  # Maintainer needed!
+  status: odd fixes
+  files:
+    - .gitignore
+    # - include/zephyr/debug/
+    # - subsys/debug/
+    # - tests/subsys/debug/
+    # - scripts/coredump/
+    # - samples/subsys/debug/
+    # - doc/services/debugging/
+  labels:
+    - "area: Debugging"
+  tests:
+    - debug
+
+Documentation:
+  # Maintainer needed!
+  status: odd fixes
+  files:
+    - doc/
+    - README.md
+    - boards/index.rst
+  files-exclude:
+    - doc/release/
+  labels:
+    - "area: Documentation"
+
+"Drivers: Clock control":
+  # Maintainer needed!
+  status: odd fixes
+  files:
+    - .gitignore
+    # - drivers/clock_control/
+    # - dts/bindings/clock/
+    # - include/zephyr/dt-bindings/clock/
+    # - tests/drivers/clock_control/
+    # - include/zephyr/drivers/clock_control/
+  labels:
+    - "area: Clock control"
+  tests:
+    - drivers.clock
+
+"Drivers: Coredump":
+  # Maintainer needed!
+  status: odd fixes
+  files:
+    - .gitignore
+    # - drivers/coredump/
+    # - dts/bindings/coredump/
+    # - tests/drivers/coredump/
+  labels:
+    - "area: Coredump"
+  tests:
+    - debug.codedump
+
+"Drivers: Counter":
+  # Maintainer needed!
+  status: odd fixes
+  files:
+    - .gitignore
+    # - drivers/counter/
+    # - tests/drivers/counter/
+    # - samples/drivers/counter/
+    # - tests/drivers/build_all/counter/
+  labels:
+    - "area: Counter"
+  tests:
+    - drivers.counter
+
+"Drivers: DMA":
+  # Maintainer needed!
+  status: odd fixes
+  files:
+    - .gitignore
+    # - drivers/dma/
+    # - tests/drivers/dma/
+    # - include/zephyr/drivers/dma/
+    # - dts/bindings/dma/
+    # - include/zephyr/dt-bindings/dma/
+  labels:
+    - "area: DMA"
+  tests:
+    - drivers.dma
+
+"Drivers: Ethernet":
+  # Maintainer needed!
+  status: odd fixes
+  files:
+    - .gitignore
+    # - drivers/ethernet/
+    # - include/zephyr/dt-bindings/ethernet/
+    # - tests/drivers/build_all/ethernet/
+    # - dts/bindings/ethernet/
+    # - tests/drivers/ethernet/
+    # - include/zephyr/drivers/ethernet/
+  labels:
+    - "area: Ethernet"
+  tests:
+    - net.ethernet
+
+"Drivers: Flash":
+  # Maintainer needed!
+  status: odd fixes
+  files:
+    - drivers/flash/
+    # - dts/bindings/flash_controller/
+    # - include/zephyr/dt-bindings/flash_controller/
+    - tests/drivers/flash/
+    - test-conf/tests/drivers/flash/
+    # - include/zephyr/drivers/flash/
+    # - tests/drivers/build_all/flash/
+  labels:
+    - "area: Flash"
+  tests:
+    - drivers.flash
+
+"Drivers: GPIO":
+  # Maintainer needed!
+  status: odd fixes
+  files:
+    - drivers/gpio/
+    - dts/bindings/gpio/
+    # - include/zephyr/drivers/gpio/
+    # - include/zephyr/dt-bindings/gpio/
+    # - tests/drivers/gpio/
+    - test-conf/tests/drivers/gpio/
+    # - tests/drivers/build_all/gpio/
+  labels:
+    - "area: GPIO"
+  tests:
+    - drivers.gpio
+
+"Drivers: HW Info":
+  # Maintainer needed!
+  status: odd fixes
+  files:
+    - .gitignore
+    # - drivers/hwinfo/
+    # - dts/bindings/hwinfo/
+    # - tests/drivers/hwinfo/
+  labels:
+    - "area: HWINFO"
+  tests:
+    - drivers.hwinfo
+
+"Drivers: I2C":
+  # Maintainer needed!
+  status: odd fixes
+  files:
+    - drivers/i2c/
+    # - include/zephyr/drivers/i2c/
+    # - dts/bindings/i2c/
+    # - tests/drivers/i2c/
+    # - include/zephyr/dt-bindings/i2c/
+    # - tests/boards/*/i2c/
+    # - tests/drivers/*/i2c/
+    # - samples/drivers/i2c/
+  labels:
+    - "area: I2C"
+  tests:
+    - drivers.i2c
+
+"Drivers: I3C":
+  # Maintainer needed!
+  status: odd fixes
+  files:
+    - .gitignore
+  # - drivers/i3c/
+  # - dts/bindings/i3c/
+  # - include/zephyr/drivers/i3c/
+  # - tests/drivers/build_all/i3c/
+  labels:
+    - "area: I3C"
+  tests:
+    - drivers.i3c
+
+"Drivers: JTAG":
+  # Maintainer needed!
+  status: odd fixes
+  files:
+    - drivers/jtag/
+    - include/tenstorrent/jtag_bootrom.h
+    - include/zephyr/drivers/jtag.h
+    # - dts/bindings/jtag/
+    # - tests/drivers/jtag/
+    # - include/zephyr/dt-bindings/jtag/
+    - tests/lib/tenstorrent/jtag_bootrom/
+  labels:
+    - "area: JTAG"
+  tests:
+    - drivers.jtag
+
+"Drivers: Mbox":
+  # Maintainer needed!
+  status: odd fixes
+  files:
+    - .gitignore
+    # - drivers/mbox/
+    # - samples/drivers/mbox/
+    # - dts/bindings/mbox/
+  labels:
+    - "area: mbox"
+  tests:
+    - sample.drivers.mbox
+
+"Drivers: MEMC":
+  # Maintainer needed!
+  status: odd fixes
+  files:
+    - .gitignore
+    # - drivers/memc/
+    # - samples/drivers/memc/
+    # - tests/drivers/memc/
+    # - include/zephyr/dt-bindings/memory-controller/
+    # - dts/bindings/memory-controllers/
+  labels:
+    - "area: MEMC"
+  tests:
+    - samples.drivers.memc
+    - drivers.memc
+
+"Drivers: MFD":
+  # Maintainer needed!
+  status: odd fixes
+  files:
+    - .gitignore
+  # - drivers/mfd/
+  # - include/zephyr/drivers/mfd/
+  # - dts/bindings/mfd/
+  # - tests/drivers/build_all/mfd/
+  labels:
+    - "area: MFD"
+  tests:
+    - drivers.mfd
+
+"Drivers: PCI":
+  # Maintainer needed!
+  status: odd fixes
+  files:
+    - .gitignore
+    # - drivers/pcie/
+    # - include/zephyr/drivers/pcie/
+    # - dts/bindings/pcie/
+    # - include/zephyr/dt-bindings/pcie/
+  labels:
+    - "area: PCI"
+
+"Drivers: Pin Control":
+  # Maintainer needed!
+  status: odd fixes
+  files:
+    - .gitignore
+    # - include/zephyr/drivers/pinctrl/
+    # - drivers/pinctrl/
+    # - tests/drivers/pinctrl/
+    # - dts/bindings/pinctrl/
+    # - include/zephyr/dt-bindings/pinctrl/
+  labels:
+    - "area: Pinctrl"
+  tests:
+    - drivers.pinctrl
+
+"Drivers: PTP Clock":
+  # Maintainer needed!
+  status: odd fixes
+  files:
+    - .gitignore
+    # - drivers/ptp_clock/
+  labels:
+    - "area: Clocks"
+  tests:
+    - drivers.ptp_clock
+
+"Drivers: PWM":
+  # Maintainer needed!
+  status: odd fixes
+  files:
+    - .gitignore
+    # - drivers/pwm/
+    # - dts/bindings/pwm/
+    # - include/zephyr/dt-bindings/pwm/
+    # - tests/drivers/pwm/
+    # - include/zephyr/*/pwms.h
+    # - tests/drivers/build_all/pwm/
+    # - include/zephyr/drivers/pwm/
+  labels:
+    - "area: PWM"
+  tests:
+    - drivers.pwm
+
+"Drivers: Regulators":
+  # Maintainer needed!
+  status: odd fixes
+  files:
+    - .gitignore
+    # - drivers/regulator/
+    # - include/zephyr/drivers/regulator/
+    # - include/zephyr/dt-bindings/regulator/
+    # - tests/drivers/regulator/
+    # - tests/drivers/build_all/regulator/
+    # - dts/bindings/regulator/
+  labels:
+    - "area: Regulators"
+  tests:
+    - drivers.regulator
+
+"Drivers: Reset":
+  # Maintainer needed!
+  status: odd fixes
+  files:
+    - drivers/reset/
+    - dts/bindings/reset/
+    # - include/zephyr/dt-bindings/reset/
+  tests:
+    - drivers.reset
+
+"Drivers: Sensors":
+  # Maintainer needed!
+  status: odd fixes
+  files:
+    - drivers/sensor/
+    # - samples/sensor/
+    # - tests/drivers/sensor/
+    - dts/bindings/sensor/
+    # - include/zephyr/drivers/sensor/
+    # - include/zephyr/dt-bindings/sensor/
+    # - tests/drivers/build_all/sensor/
+  labels:
+    - "area: Sensors"
+  tests:
+    - drivers.sensors
+
+"Drivers: Serial/UART":
+  # Maintainer needed!
+  status: odd fixes
+  files:
+    - drivers/serial/
+    # - include/zephyr/drivers/uart/
+    - dts/bindings/serial/
+    # - samples/drivers/uart/
+    # - tests/drivers/uart/
+    - test-conf/tests/drivers/uart/
+    # - tests/drivers/build_all/uart/
+    # - include/zephyr/drivers/serial/
+  labels:
+    - "area: UART"
+  tests:
+    - drivers.uart
+
+"Drivers: SMBus":
+  # Maintainer needed!
+  status: odd fixes
+  files:
+    - drivers/smbus/
+    # - dts/bindings/smbus/
+    # - samples/drivers/smbus/
+    # - tests/drivers/smbus/
+  labels:
+    - "area: SMBus"
+  tests:
+    - drivers.smbus
+
+"Drivers: SPI":
+  # Maintainer needed!
+  status: odd fixes
+  files:
+    - .gitignore
+    # - drivers/spi/
+    # - tests/drivers/spi/
+    # - dts/bindings/spi/
+    # - include/zephyr/dt-bindings/spi/
+  labels:
+    - "area: SPI"
+  tests:
+    - drivers.spi
+
+"Drivers: Watchdog":
+  # Maintainer needed!
+  status: odd fixes
+  files:
+    - drivers/watchdog/
+    - dts/bindings/watchdog/
+    # - samples/drivers/watchdog/
+    # - tests/drivers/watchdog/
+    # - tests/drivers/build_all/watchdog/
+  labels:
+    - "area: Watchdog"
+  tests:
+    - drivers.watchdog
+
+IPC:
+  # Maintainer needed!
+  status: odd fixes
+  files:
+    - .gitignore
+    # - include/zephyr/ipc/
+    # - samples/subsys/ipc/
+    # - subsys/ipc/
+    # - tests/subsys/ipc/
+    # - dts/bindings/ipc/
+    # - include/zephyr/dt-bindings/ipc_service/
+  description: |
+    Inter-Processor Communication
+  labels:
+    - "area: IPC"
+  tests:
+    - ipc
+
+MAINTAINERS file:
+  status: maintained
+  maintainers:
+    - cfriedt
+    - danieldegrasse
+    - afongTT
+  files:
+    - MAINTAINERS.yml
+  labels:
+    - "area: Process"
+  description: |
+    TT Zephyr Platforms Maintainers File
+
 Release Notes:
   status: maintained
   maintainers:
@@ -19,6 +461,38 @@ Release Notes:
     - doc/release/
   labels:
     - "release ✅"
+
+Samples:
+  # Maintainer needed!
+  status: odd fixes
+  files:
+    - samples/
+    - test-conf/samples/
+  labels:
+    - "area: Samples"
+
+Telemetry:
+  # Maintainer needed!
+  status: odd fixes
+  files:
+    - .gitignore
+    # - samples/telemetry/
+  labels:
+    - "area: Telemetry"
+
+Tenstorrent Platforms:
+  # Maintainer needed!
+  status: odd fixes
+  # TODO: refine scripts, cmake directories
+  files:
+    - soc/tenstorrent/
+    - boards/tenstorrent/
+    - lib/tenstorrent/
+    # - samples/boards/tenstorrent/
+    - tests/boards/tenstorrent/
+    - tests/lib/tenstorrent/
+  labels:
+    - "platform: Tenstorrent"
 
 "West project: cmsis":
   status: odd fixes

--- a/scripts/set_assignees.py
+++ b/scripts/set_assignees.py
@@ -1,0 +1,427 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2022 Intel Corp.
+# Copyright (c) 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+# Note: this script is borrowed from upstream
+# https://github.com/zephyrproject-rtos/zephyr/blob/main/scripts/set_assignees.py
+#
+# It would be ideal if we could use the upstream script directly without duplication.
+# Any changes or improvements made here should be submitted upstream in the mean time.
+
+import argparse
+import sys
+import os
+import time
+import datetime
+from github import Github, GithubException
+from github.GithubException import UnknownObjectException
+from collections import defaultdict
+from west.manifest import Manifest
+from west.manifest import ManifestProject
+
+TOP_DIR = os.path.join(os.path.dirname(__file__))
+sys.path.insert(0, os.path.join(TOP_DIR, "scripts"))
+from get_maintainer import Maintainers  # noqa: E402
+
+
+def log(s):
+    if args.verbose > 0:
+        print(s, file=sys.stdout)
+
+
+def parse_args():
+    global args
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        allow_abbrev=False,
+    )
+
+    parser.add_argument(
+        "-M",
+        "--maintainer-file",
+        required=False,
+        default="MAINTAINERS.yml",
+        help="Maintainer file to be used.",
+    )
+
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
+        "-P",
+        "--pull_request",
+        required=False,
+        default=None,
+        type=int,
+        help="Operate on one pull-request only.",
+    )
+    group.add_argument(
+        "-I",
+        "--issue",
+        required=False,
+        default=None,
+        type=int,
+        help="Operate on one issue only.",
+    )
+    group.add_argument(
+        "-s", "--since", required=False, help="Process pull-requests since date."
+    )
+    group.add_argument(
+        "-m",
+        "--modules",
+        action="store_true",
+        help="Process pull-requests from modules.",
+    )
+
+    parser.add_argument(
+        "-y", "--dry-run", action="store_true", default=False, help="Dry run only."
+    )
+
+    parser.add_argument(
+        "-o", "--org", default="zephyrproject-rtos", help="Github organisation"
+    )
+
+    parser.add_argument("-r", "--repo", default="zephyr", help="Github repository")
+
+    parser.add_argument(
+        "-v", "--verbose", action="count", default=0, help="Verbose Output"
+    )
+
+    args = parser.parse_args()
+
+
+def process_pr(gh, maintainer_file, number):
+    gh_repo = gh.get_repo(f"{args.org}/{args.repo}")
+    pr = gh_repo.get_pull(number)
+
+    log(
+        f"working on https://github.com/{args.org}/{args.repo}/pull/{pr.number} : {pr.title}"
+    )
+
+    labels = set()
+    area_counter = defaultdict(int)
+    found_maintainers = defaultdict(int)
+
+    num_files = 0
+    all_areas = set()
+    fn = list(pr.get_files())
+
+    for changed_file in fn:
+        if changed_file.filename in ["west.yml", "submanifests/optional.yaml"]:
+            break
+
+    if pr.commits == 1 and (pr.additions <= 1 and pr.deletions <= 1):
+        labels = {"size: XS"}
+
+    if len(fn) > 500:
+        log(f"Too many files changed ({len(fn)}), skipping....")
+        return
+
+    for changed_file in fn:
+        num_files += 1
+        log(f"file: {changed_file.filename}")
+        areas = maintainer_file.path2areas(changed_file.filename)
+
+        if not areas:
+            continue
+
+        all_areas.update(areas)
+        is_instance = False
+        sorted_areas = sorted(areas, key=lambda x: "Platform" in x.name, reverse=True)
+        for area in sorted_areas:
+            c = 1 if not is_instance else 0
+
+            area_counter[area] += c
+            labels.update(area.labels)
+            # FIXME: Here we count the same file multiple times if it exists in
+            # multiple areas with same maintainer
+            for area_maintainer in area.maintainers:
+                found_maintainers[area_maintainer] += c
+
+            if "Platform" in area.name:
+                is_instance = True
+
+    area_counter = dict(
+        sorted(area_counter.items(), key=lambda item: item[1], reverse=True)
+    )
+    log(f"Area matches: {area_counter}")
+    log(f"labels: {labels}")
+
+    # Create a list of collaborators ordered by the area match
+    collab = list()
+    for area in area_counter:
+        collab += maintainer_file.areas[area.name].maintainers
+        collab += maintainer_file.areas[area.name].collaborators
+    collab = list(dict.fromkeys(collab))
+    log(f"collab: {collab}")
+
+    _all_maintainers = dict(
+        sorted(found_maintainers.items(), key=lambda item: item[1], reverse=True)
+    )
+
+    log(f"Submitted by: {pr.user.login}")
+    log(f"candidate maintainers: {_all_maintainers}")
+
+    assignees = []
+    tmp_assignees = []
+
+    # we start with areas with most files changed and pick the maintainer from the first one.
+    # if the first area is an implementation, i.e. driver or platform, we
+    # continue searching for any other areas involved
+    for area, count in area_counter.items():
+        if count == 0:
+            continue
+        if len(area.maintainers) > 0:
+            tmp_assignees = area.maintainers
+            if pr.user.login in area.maintainers:
+                # submitter = assignee, try to pick next area and
+                # assign someone else other than the submitter
+                continue
+            else:
+                assignees = area.maintainers
+
+            if "Platform" not in area.name:
+                break
+
+    if tmp_assignees and not assignees:
+        assignees = tmp_assignees
+
+    if assignees:
+        prop = (found_maintainers[assignees[0]] / num_files) * 100
+        log(f"Picked assignees: {assignees} ({prop:.2f}% ownership)")
+        log("+++++++++++++++++++++++++")
+
+    # Set labels
+    if labels:
+        if len(labels) < 10:
+            for label in labels:
+                log(f"adding label {label}...")
+                if not args.dry_run:
+                    pr.add_to_labels(label)
+        else:
+            log("Too many labels to be applied")
+
+    if collab:
+        reviewers = []
+        existing_reviewers = set()
+
+        revs = pr.get_reviews()
+        for review in revs:
+            existing_reviewers.add(review.user)
+
+        rl = pr.get_review_requests()
+        page = 0
+        for r in rl:
+            existing_reviewers |= set(r.get_page(page))
+            page += 1
+
+        # check for reviewers that remove themselves from list of reviewer and
+        # do not attempt to add them again based on MAINTAINERS file.
+        self_removal = []
+        for event in pr.get_issue_events():
+            if (
+                event.event == "review_request_removed"
+                and event.actor == event.requested_reviewer
+            ):
+                self_removal.append(event.actor)
+
+        for collaborator in collab:
+            try:
+                gh_user = gh.get_user(collaborator)
+                if pr.user == gh_user or gh_user in existing_reviewers:
+                    continue
+                if not gh_repo.has_in_collaborators(gh_user):
+                    log(f"Skip '{collaborator}': not in collaborators")
+                    continue
+                if gh_user in self_removal:
+                    log(f"Skip '{collaborator}': self removed")
+                    continue
+                reviewers.append(collaborator)
+            except UnknownObjectException as e:
+                log(
+                    f"Can't get user '{collaborator}', account does not exist anymore? ({e})"
+                )
+
+        if len(existing_reviewers) < 15:
+            reviewer_vacancy = 15 - len(existing_reviewers)
+            reviewers = reviewers[:reviewer_vacancy]
+
+            if reviewers:
+                try:
+                    log(f"adding reviewers {reviewers}...")
+                    if not args.dry_run:
+                        pr.create_review_request(reviewers=reviewers)
+                except GithubException:
+                    log("can't add reviewer")
+        else:
+            log(
+                "not adding reviewers because the existing reviewer count is greater than or "
+                "equal to 15"
+            )
+
+    ms = []
+    # assignees
+    if assignees and not pr.assignee:
+        try:
+            for assignee in assignees:
+                u = gh.get_user(assignee)
+                ms.append(u)
+        except GithubException:
+            log("Error: Unknown user")
+
+        for mm in ms:
+            log(f"Adding assignee {mm}...")
+            if not args.dry_run:
+                pr.add_to_assignees(mm)
+    else:
+        log("not setting assignee")
+
+    time.sleep(1)
+
+
+def process_issue(gh, maintainer_file, number):
+    gh_repo = gh.get_repo(f"{args.org}/{args.repo}")
+    issue = gh_repo.get_issue(number)
+
+    log(f"Working on {issue.url}: {issue.title}")
+
+    if issue.assignees:
+        print(f"Already assigned {issue.assignees}, bailing out")
+        return
+
+    label_to_maintainer = defaultdict(set)
+    for _, area in maintainer_file.areas.items():
+        if not area.labels:
+            continue
+
+        labels = set()
+        for label in area.labels:
+            labels.add(label.lower())
+        labels = tuple(sorted(labels))
+
+        for maintainer in area.maintainers:
+            label_to_maintainer[labels].add(maintainer)
+
+    # Add extra entries for areas with multiple labels so they match with just
+    # one label if it's specific enough.
+    for areas, maintainers in dict(label_to_maintainer).items():
+        for area in areas:
+            if tuple([area]) not in label_to_maintainer:
+                label_to_maintainer[tuple([area])] = maintainers
+
+    issue_labels = set()
+    for label in issue.labels:
+        label_name = label.name.lower()
+        if tuple([label_name]) not in label_to_maintainer:
+            print(f"Ignoring label: {label}")
+            continue
+        issue_labels.add(label_name)
+    issue_labels = tuple(sorted(issue_labels))
+
+    print(f"Using labels: {issue_labels}")
+
+    if issue_labels not in label_to_maintainer:
+        print("no match for the label set, not assigning")
+        return
+
+    for maintainer in label_to_maintainer[issue_labels]:
+        log(f"Adding {maintainer} to {issue.html_url}")
+        if not args.dry_run:
+            issue.add_to_assignees(maintainer)
+
+
+def process_modules(gh, maintainers_file):
+    manifest = Manifest.from_file()
+
+    repos = {}
+    for project in manifest.get_projects([]):
+        if not manifest.is_active(project):
+            continue
+
+        if isinstance(project, ManifestProject):
+            continue
+
+        area = f"West project: {project.name}"
+        if area not in maintainers_file.areas:
+            log(f"No area for: {area}")
+            continue
+
+        maintainers = maintainers_file.areas[area].maintainers
+        if not maintainers:
+            log(f"No maintainers for: {area}")
+            continue
+
+        collaborators = maintainers_file.areas[area].collaborators
+
+        log(f"Found {area}, maintainers={maintainers}, collaborators={collaborators}")
+
+        repo_name = f"{args.org}/{project.name}"
+        repos[repo_name] = maintainers_file.areas[area]
+
+    query = "is:open is:pr no:assignee"
+    query.join(f" repo:{repo}" for repo in repos)
+
+    issues = gh.search_issues(query=query)
+    for issue in issues:
+        pull = issue.as_pull_request()
+
+        if pull.draft:
+            continue
+
+        if pull.assignees:
+            log(
+                f"ERROR: {pull.html_url} should have no assignees, found {pull.assignees}"
+            )
+            continue
+
+        repo_name = f"{args.org}/{issue.repository.name}"
+        area = repos[repo_name]
+
+        for maintainer in area.maintainers:
+            log(f"Assigning {maintainer} to {pull.html_url}")
+            if not args.dry_run:
+                pull.add_to_assignees(maintainer)
+                pull.create_review_request(maintainer)
+
+        for collaborator in area.collaborators:
+            log(f"Adding {collaborator} to {pull.html_url}")
+            if not args.dry_run:
+                pull.create_review_request(collaborator)
+
+
+def main():
+    parse_args()
+
+    token = os.environ.get("GITHUB_TOKEN", None)
+    if not token:
+        sys.exit(
+            "Github token not set in environment, please set the "
+            "GITHUB_TOKEN environment variable and retry."
+        )
+
+    gh = Github(token)
+    maintainer_file = Maintainers(args.maintainer_file)
+
+    if args.pull_request:
+        process_pr(gh, maintainer_file, args.pull_request)
+    elif args.issue:
+        process_issue(gh, maintainer_file, args.issue)
+    elif args.modules:
+        process_modules(gh, maintainer_file)
+    else:
+        if args.since:
+            since = args.since
+        else:
+            today = datetime.date.today()
+            since = today - datetime.timedelta(days=1)
+
+        common_prs = f"repo:{args.org}/{args.repo} is:open is:pr base:main -is:draft no:assignee created:>{since}"
+        pulls = gh.search_issues(query=f"{common_prs}")
+
+        for issue in pulls:
+            process_pr(gh, maintainer_file, issue.number)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Within the `MAINTAINERS.yml` file, there are or will be several areas of interest to Tenstorrent in terms of code ownership, delegation of responsibility for improvement and bugfixes, testing, and so on.

Add each of those areas with a "Maintainer needed!" comment.

This coincides with a salient point brought up at the recent SysEng F2F meeting where we established that code-ownership is critical to platform stability and management of technical debt.

Being a maintainer or collaborator is a merit-based role. Before anyone is added to the `MAINTAINERS.yml` file, they must demonstrate that they have made contributions to the area, understand what it takes to make improvements in the area, and commit to responding to issues in a timely manner.

The `MAINTAINERS.yml` file is also used by the `assigner.yml` workflow. So anytime someone makes a pull request targeting a specific area, the assigner can look through the affected files and automatically find the correct person to review code. Similarly, it also semi-automates the delegation of issues and bug reports to the correct person.

For more information, please see

https://docs.zephyrproject.org/latest/project/project_roles.html