### PR TITLE
pvt: implement sdif done timeout

### DIFF
--- a/doc/release/release-notes-18.6.0.md
+++ b/doc/release/release-notes-18.6.0.md
@@ -17,6 +17,7 @@ Major enhancements with this release include:
 ### Stability Improvements
 
 * Aligned ASIC location definition in the SPI table with that of the telemetry table
+* Implemented SDIF timeout for PVT sensor read
 
 [comment]: <> (H1 Security vulnerabilities fixed?)
 

--- a/lib/tenstorrent/bh_arc/pvt.h
+++ b/lib/tenstorrent/bh_arc/pvt.h
@@ -16,12 +16,10 @@ typedef enum {
 	ReadOk = 0,
 	SampleFault = 1,
 	IncorrectSampleType = 2,
+	SdifTimeout = 3,
 } ReadStatus;
 
 void CATInit(void);
 void PVTInit(void);
-ReadStatus ReadTS(uint32_t id, uint16_t *data);
-ReadStatus ReadVM(uint32_t id, uint16_t *data);
-ReadStatus ReadPD(uint32_t id, uint16_t *data);
 float GetAvgChipTemp(void);
 #endif


### PR DESCRIPTION
cmfw pulls on sdif read for PD and TS reading, if sdif done is not set, then cmfw could hang pulling. Use 10ms as timeout, as TS takes ~1ms for each sample, and PD takes ~0.1ms for each sample.