### PR TITLE
.github: workflows: cleanup-branches: remove dry run

### DIFF
--- a/.github/workflows/cleanup-branches.yml
+++ b/.github/workflows/cleanup-branches.yml
@@ -4,11 +4,6 @@ on:
   schedule:
     - cron: '0 5 * * *'
   workflow_dispatch:
-    inputs:
-      dry_run:
-        required: true
-        type: boolean
-        default: true
 
 jobs:
   cleanup-branches:
@@ -33,10 +28,7 @@ jobs:
             fi
 
             echo -e "  \033[31mDeleting\033[0m"
-
-            if [[ "${{ github.event.inputs.dry_run }}" == "false" ]]; then
-              git push origin --delete "$branch"
-            fi
+            git push origin --delete "$branch"
           done
 
           echo "Done"


### PR DESCRIPTION
Clean up branches workflow has been tested and removes feature branches as expected. The dry run feature is now removed.

This is the output from the dry run,

<img width="743" alt="Screenshot 2025-06-19 at 9 46 50 AM" src="https://github.com/user-attachments/assets/d744ee78-0526-42d4-a863-6e1e6044f534" />
