### PR TITLE
.github: workflows: cleanup-branches: remove dry run

### DIFF
--- a/.github/workflows/cleanup-branches.yml
+++ b/.github/workflows/cleanup-branches.yml
@@ -4,11 +4,6 @@ on:
   schedule:
     - cron: '0 5 * * *'
   workflow_dispatch:
-    inputs:
-      dry_run:
-        required: true
-        type: boolean
-        default: true
 
 jobs:
   cleanup-branches:
@@ -33,10 +28,7 @@ jobs:
             fi
 
             echo -e "  \033[31mDeleting\033[0m"
-
-            if [[ "${{ github.event.inputs.dry_run }}" == "false" ]]; then
-              git push origin --delete "$branch"
-            fi
+            git push origin --delete "$branch"
           done
 
           echo "Done"


### PR DESCRIPTION
Clean up branches workflow has been tested and removes feature branches as expected. The dry run feature is now removed.

Here's the output from last night's dry run
<img width="743" alt="Screenshot 2025-06-19 at 9 46 50 AM" src="https://github.com/user-attachments/assets/99d8bc2d-9f94-44ee-8397-bbee64e0dc3d" />
