### PR TITLE
.github: workflows: cleanup-branches.yml: add delete permissions

### DIFF
--- a/.github/workflows/cleanup-branches.yml
+++ b/.github/workflows/cleanup-branches.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   cleanup-branches:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -32,5 +34,3 @@ jobs:
           done
 
           echo "Done"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Add write permissions to the workflow so it can properly delete
branches.

Remove the GitHub token as it is not needed.

Fixes: SYS-1660