### PR TITLE
app: smc: test_arc_watchdog: increase delay before polling DMC

### DIFF
--- a/app/smc/pytest/e2e_smoke.py
+++ b/app/smc/pytest/e2e_smoke.py
@@ -199,7 +199,7 @@ def test_arc_watchdog(arc_chip):
     with pytest.raises(Exception):
         # This should fail, since the ARC should have been reset
         arc_chip = pyluwen.detect_chips()[0]
-    time.sleep(0.5)
+    time.sleep(1.0)
     rescan_pcie()
     # ARC should now be back online
     arc_chip = pyluwen.detect_chips()[0]


### PR DESCRIPTION
Increase delay before checking if SMC has communication with DMC, to improve reliability of the arc watchdog test