### PR TITLE
ci: compliance: mitigate weird compliance error about libxml write mode

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -102,7 +102,7 @@ jobs:
           # Increase rename limit to allow for large PRs
           git config diff.renameLimit 10000
           $ZEPHYR_BASE/scripts/ci/check_compliance.py --annotate \
-            -e BinaryFiles -c origin/${BASE_REF}..
+            -e SphinxLint -e BinaryFiles -c origin/${BASE_REF}..
 
       - name: check-warns
         run: |


### PR DESCRIPTION
There was a very strange compliance error about libxml write mode "wb" when the output is encoded "utf-8". Hoping this gets rid of it.