### PR TITLE
zephyr: patches: backport pr 89386 for dw i2c bus recovery

### DIFF
--- a/zephyr/patches.yml
+++ b/zephyr/patches.yml
@@ -162,3 +162,17 @@ patches:
     comments: |
       This patch is pulled directly from upstream- it will be in the 4.2 release,
       but for now we need it to support building on SDK releases after 0.17.0
+  - path: zephyr/i2c-dw-bus-recovery.patch
+    sha256sum: d03e823435666ead4ddc996276b48c152e98c7d16b3e74a45fabd9c8fbc39a97
+    module: zephyr
+    author: Titan Chen
+    email: titan.chen@realtek.com
+    date: 2025-05-02
+    upstreamable: true
+    merge-pr: https://github.com/zephyrproject-rtos/zephyr/pull/89386
+    merge-date: 2025-05-28
+    merge-status: true
+    comments: |
+      Already upstream change (merged after v4.1.0) to add bus recovery support for the DesignWare
+      I2C controller. This can simply be removed once we upgrade to v4.2.0. Also contains
+      follow-up changes that are already upstream for error checking, etc.

--- a/zephyr/patches/zephyr/i2c-dw-bus-recovery.patch
+++ b/zephyr/patches/zephyr/i2c-dw-bus-recovery.patch
@@ -1,0 +1,781 @@
+diff --git a/drivers/i2c/i2c_dw.c b/drivers/i2c/i2c_dw.c
+index 2915a79debc..1ee30a647dc 100644
+--- a/drivers/i2c/i2c_dw.c
++++ b/drivers/i2c/i2c_dw.c
+@@ -707,8 +707,15 @@ static int i2c_dw_transfer(const struct device *dev, struct i2c_msg *msgs, uint8
+ 		/* Wait for transfer to be done */
+ 		ret = k_sem_take(&dw->device_sync_sem, K_MSEC(CONFIG_I2C_DW_RW_TIMEOUT_MS));
+ 		if (ret != 0) {
++			if (test_bit_con_master_mode(reg_base)) {
++				/* Trigger abort and wait for it to complete. */
++				set_bit_enable_abort(reg_base);
++				(void)k_sem_take(&dw->device_sync_sem, K_MSEC(1));
++			}
+ 			write_intr_mask(DW_DISABLE_ALL_I2C_INT, reg_base);
+ 			value = read_clr_intr(reg_base);
++			ret = -ETIMEDOUT;
++			k_sem_reset(&dw->device_sync_sem);
+ 			break;
+ 		}
+ 
+diff --git a/drivers/i2c/i2c_dw_registers.h b/drivers/i2c/i2c_dw_registers.h
+index 117fcb196d0..12966b6ab7d 100644
+--- a/drivers/i2c/i2c_dw_registers.h
++++ b/drivers/i2c/i2c_dw_registers.h
+@@ -203,9 +203,11 @@ DEFINE_MM_REG_READ(clr_rx_done, DW_IC_REG_CLR_RX_DONE, 32)
+ DEFINE_MM_REG_READ(clr_rd_req, DW_IC_REG_CLR_RD_REQ, 32)
+ DEFINE_MM_REG_READ(clr_activity, DW_IC_REG_CLR_ACTIVITY, 32)
+ 
+-#define DW_IC_ENABLE_EN_BIT (0)
++#define DW_IC_ENABLE_EN_BIT    (0)
++#define DW_IC_ENABLE_ABORT_BIT (1)
+ DEFINE_CLEAR_BIT_OP(enable_en, DW_IC_REG_ENABLE, DW_IC_ENABLE_EN_BIT)
+ DEFINE_SET_BIT_OP(enable_en, DW_IC_REG_ENABLE, DW_IC_ENABLE_EN_BIT)
++DEFINE_SET_BIT_OP(enable_abort, DW_IC_REG_ENABLE, DW_IC_ENABLE_ABORT_BIT)
+ 
+ #define DW_IC_STATUS_ACTIVITY_BIT (0)
+ #define DW_IC_STATUS_TFNT_BIT     (1)
+diff --git a/drivers/i2c/Kconfig.dw b/drivers/i2c/Kconfig.dw
+index d666b2aceb2f..549dd20419b0 100644
+--- a/drivers/i2c/Kconfig.dw
++++ b/drivers/i2c/Kconfig.dw
+@@ -28,3 +29,9 @@ config I2C_DW_RW_TIMEOUT_MS
+ 	int "Set the Read/Write timeout in milliseconds"
+ 	depends on I2C_DW
+ 	default 100
++
++config I2C_DW_EXTENDED_SUPPORT
++	bool "Extended DW features"
++	help
++	  This option enables support for the SCL/SDA timeout registers and some
++	  additional features of the DW I2C controller.
+diff --git a/drivers/i2c/i2c_dw.c b/drivers/i2c/i2c_dw.c
+index 1ee30a647dcf..3136cbcd7362 100644
+--- a/drivers/i2c/i2c_dw.c
++++ b/drivers/i2c/i2c_dw.c
+@@ -6,6 +6,11 @@
+  *
+  * SPDX-License-Identifier: Apache-2.0
+  */
++
++#include <zephyr/arch/cpu.h>
++#include <cmsis_core.h>
++#include <soc.h>
++
+ #include <stddef.h>
+ #include <zephyr/types.h>
+ #include <stdlib.h>
+@@ -16,6 +21,7 @@
+ #include <zephyr/init.h>
+ #include <zephyr/pm/device.h>
+ #include <zephyr/arch/cpu.h>
++#include <zephyr/irq.h>
+ #include <string.h>
+ 
+ #if defined(CONFIG_PINCTRL)
+@@ -53,6 +59,57 @@ static inline uint32_t get_regs(const struct device *dev)
+ 	return (uint32_t)DEVICE_MMIO_GET(dev);
+ }
+ 
++/*
++ * @param dev: DW I2C device instance
++ * @param wrapper_dev: Callers device instance
++ */
++void i2c_dw_register_recover_bus_cb(const struct device *dev, i2c_api_recover_bus_t recover_bus_cb,
++				    const struct device *wrapper_dev)
++{
++	struct i2c_dw_dev_config *const dw = dev->data;
++
++	dw->recover_bus_cb = recover_bus_cb;
++	dw->recover_bus_dev = (struct device *)wrapper_dev;
++}
++
++/* it might call from i2c_transfer api and have already
++ * lock the bus, no need to lock bus again here
++ */
++static int i2c_recovery_bus(const struct device *dev)
++{
++	int ret = 0;
++	struct i2c_dw_dev_config *const dw = dev->data;
++
++	if (dw->recover_bus_cb) {
++		/* callback customize recovery function */
++		ret = dw->recover_bus_cb(dw->recover_bus_dev);
++		if (ret == 0) {
++			/* recovery success */
++			dw->state = I2C_DW_STATE_READY;
++		}
++	}
++	return ret;
++}
++
++int i2c_dw_recovery_bus(const struct device *dev)
++{
++
++	int ret = 0;
++	struct i2c_dw_dev_config *const dw = dev->data;
++
++	/* lock bus */
++	ret = k_sem_take(&dw->bus_sem, K_FOREVER);
++	if (ret != 0) {
++		return ret;
++	}
++	/* do bus recovery */
++	ret = i2c_recovery_bus(dev);
++	/* unlock bus */
++	k_sem_give(&dw->bus_sem);
++
++	return ret;
++}
++
+ #ifdef CONFIG_I2C_DW_LPSS_DMA
+ void i2c_dw_enable_idma(const struct device *dev, bool enable)
+ {
+@@ -346,7 +403,11 @@ static inline void i2c_dw_transfer_complete(const struct device *dev)
+ 
+ 	write_intr_mask(DW_DISABLE_ALL_I2C_INT, reg_base);
+ 	value = read_clr_intr(reg_base);
+-
++#ifdef CONFIG_CPU_CORTEX_M
++	const struct i2c_dw_rom_config *const rom = dev->config;
++	/* clear pending interrupt */
++	NVIC_ClearPendingIRQ(rom->irqnumber);
++#endif
+ 	k_sem_give(&dw->device_sync_sem);
+ }
+ 
+@@ -398,9 +459,12 @@ static void i2c_dw_isr(const struct device *port)
+ 
+ 		/* Bail early if there is any error. */
+ 		if ((DW_INTR_STAT_TX_ABRT | DW_INTR_STAT_TX_OVER | DW_INTR_STAT_RX_OVER |
+-		     DW_INTR_STAT_RX_UNDER) &
++		     DW_INTR_STAT_RX_UNDER | DW_INTR_STAT_SCL_STUCK_LOW) &
+ 		    intr_stat.raw) {
+ 			dw->state = I2C_DW_CMD_ERROR;
++#if CONFIG_I2C_ALLOW_NO_STOP_TRANSACTIONS
++			dw->need_setup = true;
++#endif
+ 			goto done;
+ 		}
+ 
+@@ -438,6 +502,9 @@ static void i2c_dw_isr(const struct device *port)
+ 		/* STOP detected: finish processing this message */
+ 		if (intr_stat.bits.stop_det) {
+ 			value = read_clr_stop_det(reg_base);
++#if CONFIG_I2C_ALLOW_NO_STOP_TRANSACTIONS
++			dw->need_setup = true;
++#endif
+ 			goto done;
+ 		}
+ 
+@@ -495,11 +562,22 @@ static int i2c_dw_setup(const struct device *dev, uint16_t slave_address)
+ 	union ic_tar_register ic_tar;
+ 	uint32_t reg_base = get_regs(dev);
+ 
++#if CONFIG_I2C_ALLOW_NO_STOP_TRANSACTIONS
++	if (!dw->need_setup) {
++		return 0;
++	}
++#endif
++
+ 	ic_con.raw = 0U;
+ 
+ 	/* Disable the device controller to be able set TAR */
+ 	clear_bit_enable_en(reg_base);
+ 
++	/* enable bus clear feature */
++	ic_con.bits.bus_clear = 1U;
++	/* enable tx empty control to fix timing issue */
++	ic_con.bits.tx_empty_ctl = 1U;
++
+ 	/* Disable interrupts */
+ 	write_intr_mask(0, reg_base);
+ 
+@@ -611,9 +689,32 @@ static int i2c_dw_setup(const struct device *dev, uint16_t slave_address)
+ 
+ 	write_tar(ic_tar.raw, reg_base);
+ 
++#if CONFIG_I2C_ALLOW_NO_STOP_TRANSACTIONS
++	dw->need_setup = false;
++#endif
+ 	return 0;
+ }
+ 
++bool i2c_dw_is_busy(const struct device *dev)
++{
++	struct i2c_dw_dev_config *const dw = dev->data;
++	uint32_t reg_base = get_regs(dev);
++
++#if CONFIG_I2C_ALLOW_NO_STOP_TRANSACTIONS
++	/* The application explicitly started a transaction without
++	 * a STOP.  Allow the application to continue sending transactions.
++	 */
++	if (!dw->need_setup) {
++		return false;
++	}
++#endif
++	if (test_bit_status_activity(reg_base) || (dw->state & I2C_DW_BUSY)) {
++		return true;
++	}
++
++	return false;
++}
++
+ static int i2c_dw_transfer(const struct device *dev, struct i2c_msg *msgs, uint8_t num_msgs,
+ 			   uint16_t slave_address)
+ {
+@@ -630,13 +731,27 @@ static int i2c_dw_transfer(const struct device *dev, struct i2c_msg *msgs, uint8
+ 		return 0;
+ 	}
+ 
+-	ret = k_mutex_lock(&dw->bus_mutex, K_FOREVER);
++	/* semaphore to support I2C_CALLBACK */
++	ret = k_sem_take(&dw->bus_sem, K_FOREVER);
+ 	if (ret != 0) {
+ 		return ret;
+ 	}
+ 
+-	/* First step, check if there is current activity */
+-	if (test_bit_status_activity(reg_base) || (dw->state & I2C_DW_BUSY)) {
++	/* check if the state is sda/scl stuck at low state */
++	if (dw->state & I2C_DW_STUCK_ERR_MASK) {
++		/* try to recovery */
++		if (i2c_recovery_bus(dev)) {
++			ret = -ETIME;
++			goto error;
++		}
++		/* reset state */
++		dw->state = I2C_DW_STATE_READY;
++	}
++
++	/* First step, check if there is current activity
++	 * Skip if last read did not stop
++	 */
++	if (i2c_dw_is_busy(dev)) {
+ 		ret = -EBUSY;
+ 		goto error;
+ 	}
+@@ -730,6 +845,15 @@ static int i2c_dw_transfer(const struct device *dev, struct i2c_msg *msgs, uint8
+ 			break;
+ 		}
+ 
++		if (dw->state & I2C_DW_ERR_MASK) {
++			if (dw->state & (I2C_DW_SDA_STUCK | I2C_DW_SCL_STUCK)) {
++				ret = -ETIME;
++			} else if (dw->state & (I2C_DW_NACK | I2C_DW_CMD_ERROR)) {
++				ret = -EIO;
++			}
++			break;
++		}
++
+ 		cur_msg++;
+ 		msg_left--;
+ 	}
+@@ -737,8 +861,9 @@ static int i2c_dw_transfer(const struct device *dev, struct i2c_msg *msgs, uint8
+ 	pm_device_busy_clear(dev);
+ 
+ error:
+-	dw->state = I2C_DW_STATE_READY;
+-	k_mutex_unlock(&dw->bus_mutex);
++	/* keep error mask for bus recovery */
++	dw->state &= I2C_DW_STUCK_ERR_MASK;
++	k_sem_give(&dw->bus_sem);
+ 
+ 	return ret;
+ }
+@@ -1033,6 +1158,7 @@ static DEVICE_API(i2c, funcs) = {
+ #ifdef CONFIG_I2C_RTIO
+ 	.iodev_submit = i2c_iodev_submit_fallback,
+ #endif
++	.recover_bus = i2c_dw_recovery_bus,
+ };
+ 
+ static int i2c_dw_initialize(const struct device *dev)
+@@ -1041,6 +1167,10 @@ static int i2c_dw_initialize(const struct device *dev)
+ 	struct i2c_dw_dev_config *const dw = dev->data;
+ 	union ic_con_register ic_con;
+ 	int ret = 0;
++#ifdef CONFIG_I2C_DW_EXTENDED_SUPPORT
++	uint32_t sda_timeout = rom->sda_timeout_value * CONFIG_I2C_DW_CLOCK_SPEED * 1000;
++	uint32_t scl_timeout = rom->scl_timeout_value * CONFIG_I2C_DW_CLOCK_SPEED * 1000;
++#endif
+ 
+ #if defined(CONFIG_RESET)
+ 	if (rom->reset.dev) {
+@@ -1097,7 +1227,7 @@ static int i2c_dw_initialize(const struct device *dev)
+ 	}
+ 
+ 	k_sem_init(&dw->device_sync_sem, 0, K_SEM_MAX_LIMIT);
+-	k_mutex_init(&dw->bus_mutex);
++	k_sem_init(&dw->bus_sem, 1, 1);
+ 
+ 	uint32_t reg_base = get_regs(dev);
+ 
+@@ -1134,6 +1264,14 @@ static int i2c_dw_initialize(const struct device *dev)
+ 	}
+ 
+ 	dw->state = I2C_DW_STATE_READY;
++#if CONFIG_I2C_ALLOW_NO_STOP_TRANSACTIONS
++	dw->need_setup = true;
++#endif
++#ifdef CONFIG_I2C_DW_EXTENDED_SUPPORT
++	write_sdatimeout(sda_timeout, reg_base);
++	write_scltimeout(scl_timeout, reg_base);
++#endif
++	LOG_DBG("initialize done");
+ 
+ 	return ret;
+ }
+@@ -1147,7 +1285,7 @@ static int i2c_dw_initialize(const struct device *dev)
+ #endif
+ 
+ #if defined(CONFIG_RESET)
+-#define RESET_DW_CONFIG(n)                                                    \
++#define RESET_DW_CONFIG(n)                                                                         \
+ 	IF_ENABLED(DT_INST_NODE_HAS_PROP(n, resets),                          \
+ 		   (.reset = RESET_DT_SPEC_INST_GET(n),))
+ #else
+@@ -1208,6 +1346,14 @@ static int i2c_dw_initialize(const struct device *dev)
+ 	(.dma_dev = DEVICE_DT_GET(DT_INST_DMAS_CTLR_BY_IDX(n, 0)),),	\
+ 	())), ())
+ 
++#ifdef CONFIG_I2C_DW_EXTENDED_SUPPORT
++#define TIMEOUT_DW_CONFIG(n)                                                                       \
++	.sda_timeout_value = DT_INST_PROP_OR(n, sda_timeout_value, __UINT32_MAX__),                \
++	.scl_timeout_value = DT_INST_PROP_OR(n, scl_timeout_value, __UINT32_MAX__),
++#else
++#define TIMEOUT_DW_CONFIG(n)
++#endif
++
+ #define I2C_DEVICE_INIT_DW(n)                                                                      \
+ 	PINCTRL_DW_DEFINE(n);                                                                      \
+ 	I2C_PCIE_DEFINE(n);                                                                        \
+@@ -1215,9 +1361,10 @@ static int i2c_dw_initialize(const struct device *dev)
+ 	static const struct i2c_dw_rom_config i2c_config_dw_##n = {                                \
+ 		I2C_CONFIG_REG_INIT(n).config_func = i2c_config_##n,                               \
+ 		.bitrate = DT_INST_PROP(n, clock_frequency),                                       \
++		.irqnumber = DT_INST_IRQN(n),                                                      \
+ 		.lcnt_offset = (int16_t)DT_INST_PROP_OR(n, lcnt_offset, 0),                        \
+ 		.hcnt_offset = (int16_t)DT_INST_PROP_OR(n, hcnt_offset, 0),                        \
+-		RESET_DW_CONFIG(n) PINCTRL_DW_CONFIG(n) I2C_DW_INIT_PCIE(n)                        \
++		TIMEOUT_DW_CONFIG(n) RESET_DW_CONFIG(n) PINCTRL_DW_CONFIG(n) I2C_DW_INIT_PCIE(n)   \
+ 			I2C_CONFIG_DMA_INIT(n)};                                                   \
+ 	static struct i2c_dw_dev_config i2c_##n##_runtime;                                         \
+ 	I2C_DEVICE_DT_INST_DEFINE(n, i2c_dw_initialize, NULL, &i2c_##n##_runtime,                  \
+diff --git a/drivers/i2c/i2c_dw.h b/drivers/i2c/i2c_dw.h
+index 2a4f64cd86bd..d6457cb13145 100644
+--- a/drivers/i2c/i2c_dw.h
++++ b/drivers/i2c/i2c_dw.h
+@@ -39,10 +39,24 @@ typedef void (*i2c_isr_cb_t)(const struct device *port);
+ #define I2C_DW_CMD_RECV    (1 << 1)
+ #define I2C_DW_CMD_ERROR   (1 << 2)
+ #define I2C_DW_BUSY        (1 << 3)
++#define I2C_DW_TX_ABRT     (1 << 4)
++#define I2C_DW_NACK        (1 << 5)
++#define I2C_DW_SCL_STUCK   (1 << 6)
++#define I2C_DW_SDA_STUCK   (1 << 7)
+ 
++#define I2C_DW_ERR_MASK (I2C_DW_CMD_ERROR | I2C_DW_SCL_STUCK | I2C_DW_SDA_STUCK | I2C_DW_NACK)
++
++#define I2C_DW_STUCK_ERR_MASK (I2C_DW_SCL_STUCK | I2C_DW_SDA_STUCK)
++
++#ifdef CONFIG_I2C_DW_EXTENDED_SUPPORT
++#define DW_ENABLE_TX_INT_I2C_MASTER                                                                \
++	(DW_INTR_STAT_TX_OVER | DW_INTR_STAT_TX_EMPTY | DW_INTR_STAT_TX_ABRT |                     \
++	 DW_INTR_STAT_STOP_DET | DW_INTR_STAT_SCL_STUCK_LOW)
++#else
+ #define DW_ENABLE_TX_INT_I2C_MASTER                                                                \
+ 	(DW_INTR_STAT_TX_OVER | DW_INTR_STAT_TX_EMPTY | DW_INTR_STAT_TX_ABRT |                     \
+ 	 DW_INTR_STAT_STOP_DET)
++#endif
+ #define DW_ENABLE_RX_INT_I2C_MASTER                                                                \
+ 	(DW_INTR_STAT_RX_UNDER | DW_INTR_STAT_RX_OVER | DW_INTR_STAT_RX_FULL |                     \
+ 	 DW_INTR_STAT_STOP_DET)
+@@ -84,6 +98,7 @@ struct i2c_dw_rom_config {
+ 	DEVICE_MMIO_ROM;
+ 	i2c_isr_cb_t config_func;
+ 	uint32_t bitrate;
++	uint32_t irqnumber;
+ 	int16_t lcnt_offset;
+ 	int16_t hcnt_offset;
+ 
+@@ -101,17 +116,22 @@ struct i2c_dw_rom_config {
+ #ifdef CONFIG_I2C_DW_LPSS_DMA
+ 	const struct device *dma_dev;
+ #endif
++
++#ifdef CONFIG_I2C_DW_EXTENDED_SUPPORT
++	uint32_t sda_timeout_value;
++	uint32_t scl_timeout_value;
++#endif
+ };
+ 
+ struct i2c_dw_dev_config {
+ 	DEVICE_MMIO_RAM;
+ 	struct k_sem device_sync_sem;
+-	struct k_mutex bus_mutex;
++	struct k_sem bus_sem;
+ 	uint32_t app_config;
+ 
+-	uint8_t *xfr_buf;
+-	uint32_t xfr_len;
+-	uint32_t rx_pending;
++	volatile uint8_t *xfr_buf;
++	volatile uint32_t xfr_len;
++	volatile uint32_t rx_pending;
+ 
+ 	uint16_t hcnt;
+ 	uint16_t lcnt;
+@@ -128,6 +148,12 @@ struct i2c_dw_dev_config {
+ #endif
+ 
+ 	struct i2c_target_config *slave_cfg;
++
++	i2c_api_recover_bus_t recover_bus_cb;
++	struct device *recover_bus_dev;
++#if CONFIG_I2C_ALLOW_NO_STOP_TRANSACTIONS
++	bool need_setup;
++#endif
+ };
+ 
+ #define Z_REG_READ(__sz)  sys_read##__sz
+@@ -165,6 +191,10 @@ struct i2c_dw_dev_config {
+ 		return Z_REG_TEST_BIT(addr + __reg_off, __bit);                                    \
+ 	}
+ 
++void i2c_dw_register_recover_bus_cb(const struct device *dw_i2c_dev,
++				    i2c_api_recover_bus_t recover_bus_cb,
++				    const struct device *wrapper_dev);
++
+ #ifdef __cplusplus
+ }
+ #endif
+diff --git a/drivers/i2c/i2c_dw_registers.h b/drivers/i2c/i2c_dw_registers.h
+index 12966b6ab7de..b98ba31c4a12 100644
+--- a/drivers/i2c/i2c_dw_registers.h
++++ b/drivers/i2c/i2c_dw_registers.h
+@@ -25,6 +25,8 @@ union ic_con_register {
+ 		uint32_t stop_det: 1 __packed;
+ 		uint32_t tx_empty_ctl: 1 __packed;
+ 		uint32_t rx_fifo_full: 1 __packed;
++		uint32_t stop_det_mstactive: 1 __packed;
++		uint32_t bus_clear: 1 __packed;
+ 	} bits;
+ };
+ 
+@@ -35,20 +37,21 @@ union ic_con_register {
+ #define IC_DATA_CMD_RESTART  BIT(10)
+ 
+ /* DesignWare Interrupt bits positions */
+-#define DW_INTR_STAT_RX_UNDER    BIT(0)
+-#define DW_INTR_STAT_RX_OVER     BIT(1)
+-#define DW_INTR_STAT_RX_FULL     BIT(2)
+-#define DW_INTR_STAT_TX_OVER     BIT(3)
+-#define DW_INTR_STAT_TX_EMPTY    BIT(4)
+-#define DW_INTR_STAT_RD_REQ      BIT(5)
+-#define DW_INTR_STAT_TX_ABRT     BIT(6)
+-#define DW_INTR_STAT_RX_DONE     BIT(7)
+-#define DW_INTR_STAT_ACTIVITY    BIT(8)
+-#define DW_INTR_STAT_STOP_DET    BIT(9)
+-#define DW_INTR_STAT_START_DET   BIT(10)
+-#define DW_INTR_STAT_GEN_CALL    BIT(11)
+-#define DW_INTR_STAT_RESTART_DET BIT(12)
+-#define DW_INTR_STAT_MST_ON_HOLD BIT(13)
++#define DW_INTR_STAT_RX_UNDER      BIT(0)
++#define DW_INTR_STAT_RX_OVER       BIT(1)
++#define DW_INTR_STAT_RX_FULL       BIT(2)
++#define DW_INTR_STAT_TX_OVER       BIT(3)
++#define DW_INTR_STAT_TX_EMPTY      BIT(4)
++#define DW_INTR_STAT_RD_REQ        BIT(5)
++#define DW_INTR_STAT_TX_ABRT       BIT(6)
++#define DW_INTR_STAT_RX_DONE       BIT(7)
++#define DW_INTR_STAT_ACTIVITY      BIT(8)
++#define DW_INTR_STAT_STOP_DET      BIT(9)
++#define DW_INTR_STAT_START_DET     BIT(10)
++#define DW_INTR_STAT_GEN_CALL      BIT(11)
++#define DW_INTR_STAT_RESTART_DET   BIT(12)
++#define DW_INTR_STAT_MST_ON_HOLD   BIT(13)
++#define DW_INTR_STAT_SCL_STUCK_LOW BIT(14)
+ 
+ #define DW_INTR_MASK_RX_UNDER    BIT(0)
+ #define DW_INTR_MASK_RX_OVER     BIT(1)
+@@ -83,6 +86,32 @@ union ic_interrupt_register {
+ 		uint32_t gen_call: 1 __packed;
+ 		uint32_t restart_det: 1 __packed;
+ 		uint32_t mst_on_hold: 1 __packed;
++		uint32_t scl_stuck_low: 1 __packed;
++		uint32_t reserved: 2 __packed;
++	} bits;
++};
++
++union ic_txabrt_register {
++	uint32_t raw;
++	struct {
++		uint32_t ADDR7BNACK: 1 __packed;
++		uint32_t ADDR10BNACK1: 1 __packed;
++		uint32_t ADDR10BNACK2: 1 __packed;
++		uint32_t TXDATANACK: 1 __packed;
++		uint32_t GCALLNACK: 1 __packed;
++		uint32_t GCALLREAD: 1 __packed;
++		uint32_t HSACKDET: 1 __packed;
++		uint32_t SBYTEACKET: 1 __packed;
++		uint32_t HSNORSTRT: 1 __packed;
++		uint32_t SBYTENORSTRT: 1 __packed;
++		uint32_t ADDR10BRDNORSTRT: 1 __packed;
++		uint32_t MASTERIDS: 1 __packed;
++		uint32_t ARBLOST: 1 __packed;
++		uint32_t SLVFLUSHTXFIFO: 1 __packed;
++		uint32_t SLVARBLOST: 1 __packed;
++		uint32_t SLVRDINTX: 1 __packed;
++		uint32_t USRABRT: 1 __packed;
++		uint32_t SDASTUCKLOW: 1 __packed;
+ 		uint32_t reserved: 2 __packed;
+ 	} bits;
+ };
+@@ -127,6 +156,7 @@ union ic_comp_param_1_register {
+ #define DW_IC_REG_HS_SCL_LCNT   (0x28)
+ #define DW_IC_REG_INTR_STAT     (0x2C)
+ #define DW_IC_REG_INTR_MASK     (0x30)
++#define DW_IC_REG_RAWINTR_MASK  (0x34)
+ #define DW_IC_REG_RX_TL         (0x38)
+ #define DW_IC_REG_TX_TL         (0x3C)
+ #define DW_IC_REG_CLR_INTR      (0x40)
+@@ -144,11 +174,15 @@ union ic_comp_param_1_register {
+ #define DW_IC_REG_STATUS        (0x70)
+ #define DW_IC_REG_TXFLR         (0x74)
+ #define DW_IC_REG_RXFLR         (0x78)
++#define DW_IC_REG_SDAHOLD       (0x7c)
++#define DW_IC_REG_TXABRTSRC     (0x80)
+ #define DW_IC_REG_DMA_CR        (0x88)
+ #define DW_IC_REG_TDLR          (0x8C)
+ #define DW_IC_REG_RDLR          (0x90)
+ #define DW_IC_REG_FS_SPKLEN     (0xA0)
+ #define DW_IC_REG_HS_SPKLEN     (0xA4)
++#define DW_IC_REG_SCL_TIMEOUT   (0xAC)
++#define DW_IC_REG_SDA_TIMEOUT   (0xB0)
+ #define DW_IC_REG_COMP_PARAM_1  (0xF4)
+ #define DW_IC_REG_COMP_TYPE     (0xFC)
+ 
+@@ -167,6 +201,11 @@ DEFINE_TEST_BIT_OP(con_master_mode, DW_IC_REG_CON, DW_IC_CON_MASTER_MODE_BIT)
+ DEFINE_MM_REG_WRITE(con, DW_IC_REG_CON, 32)
+ DEFINE_MM_REG_READ(con, DW_IC_REG_CON, 32)
+ 
++DEFINE_MM_REG_READ(tar, DW_IC_REG_TAR, 32)
++DEFINE_MM_REG_WRITE(tar, DW_IC_REG_TAR, 32)
++
++DEFINE_MM_REG_WRITE(sar, DW_IC_REG_SAR, 32)
++
+ DEFINE_MM_REG_WRITE(cmd_data, DW_IC_REG_DATA_CMD, 32)
+ DEFINE_MM_REG_READ(cmd_data, DW_IC_REG_DATA_CMD, 32)
+ 
+@@ -184,6 +223,8 @@ DEFINE_MM_REG_READ(intr_stat, DW_IC_REG_INTR_STAT, 32)
+ DEFINE_TEST_BIT_OP(intr_stat_tx_abrt, DW_IC_REG_INTR_STAT, DW_IC_INTR_STAT_TX_ABRT_BIT)
+ 
+ DEFINE_MM_REG_WRITE(intr_mask, DW_IC_REG_INTR_MASK, 32)
++DEFINE_MM_REG_READ(rawintr_stat, DW_IC_REG_RAWINTR_MASK, 32)
++
+ #define DW_IC_INTR_MASK_TX_EMPTY_BIT (4)
+ DEFINE_CLEAR_BIT_OP(intr_mask_tx_empty, DW_IC_REG_INTR_MASK, DW_IC_INTR_MASK_TX_EMPTY_BIT)
+ DEFINE_SET_BIT_OP(intr_mask_tx_empty, DW_IC_REG_INTR_MASK, DW_IC_INTR_MASK_TX_EMPTY_BIT)
+@@ -203,22 +244,41 @@ DEFINE_MM_REG_READ(clr_rx_done, DW_IC_REG_CLR_RX_DONE, 32)
+ DEFINE_MM_REG_READ(clr_rd_req, DW_IC_REG_CLR_RD_REQ, 32)
+ DEFINE_MM_REG_READ(clr_activity, DW_IC_REG_CLR_ACTIVITY, 32)
+ 
+-#define DW_IC_ENABLE_EN_BIT    (0)
+-#define DW_IC_ENABLE_ABORT_BIT (1)
++#define DW_IC_ENABLE_EN_BIT         (0)
++#define DW_IC_ENABLE_ABORT_BIT      (1)
++#define DW_IC_ENABLE_BLOCK_BIT      (2)
++#define DW_IC_ENABLE_SDARECOVEN_BIT (3)
++#define DW_IC_ENABLE_CLK_RESET_BIT  (16)
+ DEFINE_CLEAR_BIT_OP(enable_en, DW_IC_REG_ENABLE, DW_IC_ENABLE_EN_BIT)
+ DEFINE_SET_BIT_OP(enable_en, DW_IC_REG_ENABLE, DW_IC_ENABLE_EN_BIT)
+ DEFINE_SET_BIT_OP(enable_abort, DW_IC_REG_ENABLE, DW_IC_ENABLE_ABORT_BIT)
++DEFINE_TEST_BIT_OP(enable_abort, DW_IC_REG_ENABLE, DW_IC_ENABLE_ABORT_BIT)
++DEFINE_CLEAR_BIT_OP(enable_block, DW_IC_REG_ENABLE, DW_IC_ENABLE_BLOCK_BIT)
++DEFINE_SET_BIT_OP(enable_block, DW_IC_REG_ENABLE, DW_IC_ENABLE_BLOCK_BIT)
++DEFINE_CLEAR_BIT_OP(enable_sdarecov, DW_IC_REG_ENABLE, DW_IC_ENABLE_SDARECOVEN_BIT)
++DEFINE_SET_BIT_OP(enable_sdarecov, DW_IC_REG_ENABLE, DW_IC_ENABLE_SDARECOVEN_BIT)
++DEFINE_TEST_BIT_OP(enable_sdarecov, DW_IC_REG_ENABLE, DW_IC_ENABLE_SDARECOVEN_BIT)
++DEFINE_CLEAR_BIT_OP(enable_clk_reset, DW_IC_REG_ENABLE, DW_IC_ENABLE_CLK_RESET_BIT)
++DEFINE_SET_BIT_OP(enable_clk_reset, DW_IC_REG_ENABLE, DW_IC_ENABLE_CLK_RESET_BIT)
++DEFINE_TEST_BIT_OP(enable_clk_reset, DW_IC_REG_ENABLE, DW_IC_ENABLE_CLK_RESET_BIT)
+ 
+-#define DW_IC_STATUS_ACTIVITY_BIT (0)
+-#define DW_IC_STATUS_TFNT_BIT     (1)
+-#define DW_IC_STATUS_RFNE_BIT     (3)
++#define DW_IC_STATUS_ACTIVITY_BIT    (0)
++#define DW_IC_STATUS_TFNT_BIT        (1)
++#define DW_IC_STATUS_RFNE_BIT        (3)
++#define DW_IC_STATUS_SDANOTRECOV_BIT (11)
+ DEFINE_TEST_BIT_OP(status_activity, DW_IC_REG_STATUS, DW_IC_STATUS_ACTIVITY_BIT)
+ DEFINE_TEST_BIT_OP(status_tfnt, DW_IC_REG_STATUS, DW_IC_STATUS_TFNT_BIT)
+ DEFINE_TEST_BIT_OP(status_rfne, DW_IC_REG_STATUS, DW_IC_STATUS_RFNE_BIT)
++DEFINE_TEST_BIT_OP(status_sdanotrecov, DW_IC_REG_STATUS, DW_IC_STATUS_SDANOTRECOV_BIT)
+ 
+ DEFINE_MM_REG_READ(txflr, DW_IC_REG_TXFLR, 32)
+ DEFINE_MM_REG_READ(rxflr, DW_IC_REG_RXFLR, 32)
+ 
++DEFINE_MM_REG_READ(sdahold, DW_IC_REG_SDAHOLD, 32)
++DEFINE_MM_REG_WRITE(sdahold, DW_IC_REG_SDAHOLD, 32)
++
++DEFINE_MM_REG_READ(txabrt_src, DW_IC_REG_TXABRTSRC, 32)
++
+ DEFINE_MM_REG_READ(dma_cr, DW_IC_REG_DMA_CR, 32)
+ DEFINE_MM_REG_WRITE(dma_cr, DW_IC_REG_DMA_CR, 32)
+ 
+@@ -230,11 +290,13 @@ DEFINE_MM_REG_WRITE(rdlr, DW_IC_REG_RDLR, 32)
+ DEFINE_MM_REG_READ(fs_spklen, DW_IC_REG_FS_SPKLEN, 32)
+ DEFINE_MM_REG_READ(hs_spklen, DW_IC_REG_HS_SPKLEN, 32)
+ 
++DEFINE_MM_REG_WRITE(scltimeout, DW_IC_REG_SCL_TIMEOUT, 32)
++DEFINE_MM_REG_READ(scltimeout, DW_IC_REG_SCL_TIMEOUT, 32)
++DEFINE_MM_REG_WRITE(sdatimeout, DW_IC_REG_SDA_TIMEOUT, 32)
++DEFINE_MM_REG_READ(sdatimeout, DW_IC_REG_SDA_TIMEOUT, 32)
++
+ DEFINE_MM_REG_READ(comp_param_1, DW_IC_REG_COMP_PARAM_1, 32)
+ DEFINE_MM_REG_READ(comp_type, DW_IC_REG_COMP_TYPE, 32)
+-DEFINE_MM_REG_READ(tar, DW_IC_REG_TAR, 32)
+-DEFINE_MM_REG_WRITE(tar, DW_IC_REG_TAR, 32)
+-DEFINE_MM_REG_WRITE(sar, DW_IC_REG_SAR, 32)
+ 
+ #ifdef __cplusplus
+ }
+diff --git a/dts/bindings/i2c/snps,designware-i2c.yaml b/dts/bindings/i2c/snps,designware-i2c.yaml
+index cc02989d9275..653ddbc199a3 100644
+--- a/dts/bindings/i2c/snps,designware-i2c.yaml
++++ b/dts/bindings/i2c/snps,designware-i2c.yaml
+@@ -20,3 +20,15 @@ properties:
+     type: int
+     description: |
+       A fixed offset to apply to the SCL hcnt setting.
++
++  sda-timeout-value:
++    type: int
++    default: 30
++    description: |
++      Describe the SDA stuck at low timeout value, unit in ms
++
++  scl-timeout-value:
++    type: int
++    default: 30
++    description: |
++      Describe the SCL stuck at low timeout value, unit in ms
+
+diff --git a/drivers/i2c/i2c_dw.c b/drivers/i2c/i2c_dw.c
+index 3136cbcd7362..e0d316e59a1c 100644
+--- a/drivers/i2c/i2c_dw.c
++++ b/drivers/i2c/i2c_dw.c
+@@ -110,6 +110,48 @@ int i2c_dw_recovery_bus(const struct device *dev)
+ 	return ret;
+ }
+ 
++static int i2c_dw_error_chk(const struct device *dev)
++{
++	struct i2c_dw_dev_config *const dw = dev->data;
++	uint32_t reg_base = get_regs(dev);
++	union ic_interrupt_register intr_stat;
++	union ic_txabrt_register ic_txabrt_src;
++	uint32_t value;
++	/* Cache ic_intr_stat and txabrt_src for processing,
++	 * so there is no need to read the register multiple times.
++	 */
++	intr_stat.raw = read_intr_stat(reg_base);
++	ic_txabrt_src.raw = read_txabrt_src(reg_base);
++	/* NACK and SDA_STUCK are below TX_Abort */
++	if (intr_stat.bits.tx_abrt) {
++		/* check 7bit NACK Tx Abort */
++		if (ic_txabrt_src.bits.ADDR7BNACK) {
++			dw->state |= I2C_DW_NACK;
++			LOG_ERR("NACK on %s", dev->name);
++		}
++		/* check SDA stuck low Tx abort, need to do bus recover */
++		if (ic_txabrt_src.bits.SDASTUCKLOW) {
++			dw->state |= I2C_DW_SDA_STUCK;
++			LOG_ERR("SDA Stuck Low on %s", dev->name);
++		}
++		/* clear RTS5912_INTR_STAT_TX_ABRT */
++		value = read_clr_tx_abrt(reg_base);
++	}
++	/* check SCL stuck low */
++	if (intr_stat.bits.scl_stuck_low) {
++		dw->state |= I2C_DW_SCL_STUCK;
++		LOG_ERR("SCL Stuck Low on %s", dev->name);
++	}
++	if (dw->state & I2C_DW_ERR_MASK) {
++#if CONFIG_I2C_ALLOW_NO_STOP_TRANSACTIONS
++		dw->need_setup = true;
++#endif
++		LOG_ERR("IO Fail on %s", dev->name);
++		return -EIO;
++	}
++	return 0;
++}
++
+ #ifdef CONFIG_I2C_DW_LPSS_DMA
+ void i2c_dw_enable_idma(const struct device *dev, bool enable)
+ {
+@@ -312,6 +354,10 @@ static inline void i2c_dw_data_ask(const struct device *dev)
+ 
+ 		write_cmd_data(data, reg_base);
+ 
++		if (i2c_dw_error_chk(dev)) {
++			return;
++		}
++
+ 		dw->rx_pending++;
+ 		dw->request_bytes--;
+ 		cnt--;
+@@ -340,6 +386,10 @@ static void i2c_dw_data_read(const struct device *dev)
+ 		if (dw->xfr_len == 0U) {
+ 			break;
+ 		}
++
++		if (i2c_dw_error_chk(dev)) {
++			return;
++		}
+ 	}
+ #endif
+ 	/* Nothing to receive anymore */
+@@ -390,6 +440,10 @@ static int i2c_dw_data_send(const struct device *dev)
+ 		if (test_bit_intr_stat_tx_abrt(reg_base)) {
+ 			return -EIO;
+ 		}
++
++		if (i2c_dw_error_chk(dev)) {
++			return -EIO;
++		}
+ 	}
+ 
+ 	return 0;
+@@ -462,6 +516,7 @@ static void i2c_dw_isr(const struct device *port)
+ 		     DW_INTR_STAT_RX_UNDER | DW_INTR_STAT_SCL_STUCK_LOW) &
+ 		    intr_stat.raw) {
+ 			dw->state = I2C_DW_CMD_ERROR;
++			i2c_dw_error_chk(port);
+ #if CONFIG_I2C_ALLOW_NO_STOP_TRANSACTIONS
+ 			dw->need_setup = true;
+ #endif
+@@ -774,7 +829,7 @@ static int i2c_dw_transfer(const struct device *dev, struct i2c_msg *msgs, uint8
+ 	 * not execute PM policies that would turn off this ip block, causing an
+ 	 * ongoing hw transaction to be left in an inconsistent state.
+ 	 * Note : This is just a sample to show a possible use of the API, it is
+-	 * upto the driver expert to see, if he actually needs it here, or
++	 * up to the driver expert to see, if he actually needs it here, or
+ 	 * somewhere else, or not needed as the driver's suspend()/resume()
+ 	 * can handle everything
+ 	 */
+diff --git a/drivers/i2c/i2c_dw.c b/drivers/i2c/i2c_dw.c
+index e0d316e59a1..5092ccfd01b 100644
+--- a/drivers/i2c/i2c_dw.c
++++ b/drivers/i2c/i2c_dw.c
+@@ -8,7 +8,9 @@
+  */
+ 
+ #include <zephyr/arch/cpu.h>
++#ifdef CONFIG_CPU_CORTEX_M
+ #include <cmsis_core.h>
++#endif
+ #include <soc.h>
+ 
+ #include <stddef.h>


### PR DESCRIPTION
Backport the changes made in upstream PR 89386 to facilitate i2c bus recovery in the designware i2c driver.