### PR TITLE
zephyr: patches: update upstreamable status for pwm_api test patch

### DIFF
--- a/zephyr/patches.yml
+++ b/zephyr/patches.yml
@@ -138,9 +138,12 @@ patches:
     author: Alexander Lay
     email: alexanderlay@tenstorrent.com
     date: 2025-06-18
-    upstreamable: true
+    upstreamable: false
+    merge-pr: https://github.com/zephyrproject-rtos/zephyr/pull/92188
     comments: |
-      Add a boolean Kconfig option to skip setting zero duty cycle in pwm api tests.
+      Add a boolean Kconfig option to skip setting zero duty cycle in pwm_api tests.
+      The PR was rejected because the pwm_api test suite was originally designed as
+      a driver test and not a board or actual hardware test.
   - path: zephyr/requirements-compliance.patch
     sha256sum: 8610736ceaf65488a105b6cf828449b890bbd769604c325b076619b0ba7be83a
     module: zephyr


### PR DESCRIPTION
Adds link to upstream PR, which was rejected since the test suite was originally intended to just be used to verify PWM controller device/API and not run on actual hardware