### PR TITLE
scripts: tt_boot_fs: correct binary padding to 4 bytes

### DIFF
--- a/scripts/tt_boot_fs.py
+++ b/scripts/tt_boot_fs.py
@@ -295,7 +295,7 @@ class BootImage:
                 )
             binary += bytes(padto - len(binary))
         # We always need to pad binaries to 4 byte offsets for checksum verification
-        binary += bytes((len(binary) % 8))
+        binary += bytes((len(binary) % 4))
 
         if len(tag) > MAX_TAG_LEN:
             raise ValueError(f"{tag} is longer than the maximum allowed tag size (8).")


### PR DESCRIPTION
We were previously padding all binaries to 8 bytes, which makes protobufs no longer function. Change padding to 4 bytes to resolve this.