### PR TITLE
app: smc: e2e_test: arc_watchdog: vastly extend the time before DMC ping

### DIFF
--- a/app/smc/pytest/e2e_smoke.py
+++ b/app/smc/pytest/e2e_smoke.py
@@ -199,7 +199,7 @@ def test_arc_watchdog(arc_chip):
     with pytest.raises(Exception):
         # This should fail, since the ARC should have been reset
         arc_chip = pyluwen.detect_chips()[0]
-    time.sleep(1.0)
+    time.sleep(5.0)
     rescan_pcie()
     # ARC should now be back online
     arc_chip = pyluwen.detect_chips()[0]


### PR DESCRIPTION
Extend the time before DMC ping to an unreasonably long value. If CI fails after this point, we can safely assume that there is an intermittent failure with the DMC pinging the SMC after watchdog reset