### PR TITLE
ci: remove stale lock files before syncing Zephyr

### DIFF
--- a/.github/workflows/prepare-zephyr/action.yml
+++ b/.github/workflows/prepare-zephyr/action.yml
@@ -53,6 +53,12 @@ runs:
         # Remove any stale hal_stm32 blobs directories to avoid west blobs fetch errors
         rm -Rf $(find * -path '*/hal/stm32/zephyr/blobs')
 
+        N_LOCKS=$(find * -path '*/.git/shallow.lock' | wc -l)
+        if [ $N_LOCKS -gt 0 ]; then
+          echo "Cleaning out $N_LOCKS stale .git/shallow.lock files"
+          find * -path '*/.git/shallow.lock' -exec rm -f {} \;
+        fi
+
     # TODO: potentially improve caching strategy
     # Note: this step performs "west init", "west update", and installs zephyr python dependencies
     - name: Set up Zephyr project


### PR DESCRIPTION
Previously, we would see errors like the following somewhat regularly:
```
Run west init -l tt-zephyr-platforms --mf west.yml
fatal: Unable to create .... zephyr/.git/shallow.lock': File exists.
```

Remove stale lock files that otherwise halt CI due to asynchronouos cancellations.

E.g.
https://github.com/tenstorrent/tt-zephyr-platforms/actions/runs/15981295366/job/45076399613?pr=368

```shell
Run west init -l tt-zephyr-platforms --mf west.yml
=== Initializing from existing manifest repository tt-zephyr-platforms
--- Creating /__w/tt-zephyr-platforms/tt-zephyr-platforms/.west and local configuration file
=== Initialized. Now run "west update" inside /__w/tt-zephyr-platforms/tt-zephyr-platforms.
=== updating zephyr (zephyr):
--- zephyr: fetching, need revision v4.1.0
fatal: Unable to create '/__w/tt-zephyr-platforms/tt-zephyr-platforms/zephyr/.git/shallow.lock': File exists.
```