### PR TITLE
ci: hardware-long: pin revision of tt-flash

### DIFF
--- a/.github/workflows/hardware-long.yml
+++ b/.github/workflows/hardware-long.yml
@@ -62,7 +62,7 @@ jobs:
           sudo chmod -R a+rwX $HOME/.cargo $HOME/.cache
           python -m venv .env
           source .env/bin/activate
-          pip install git+https://github.com/tenstorrent/tt-flash.git
+          pip install git+https://github.com/tenstorrent/tt-flash.git@v3.3.3
           tt-flash --fw-tar /home/user/tt-metal/fw_pack-*.fwbundle --force
       - name: Run Container Test
         run: |


### PR DESCRIPTION
Pin revision of tt-flash to v3.3.3, as this is the latest that will compile and install in the metal container (due to an older cargo version)