### PR TITLE
lib: tenstorrent: bh_arc: extend time waiting for DMC ping response

### DIFF
--- a/lib/tenstorrent/bh_arc/cm2dm_msg.c
+++ b/lib/tenstorrent/bh_arc/cm2dm_msg.c
@@ -208,7 +208,7 @@ static uint8_t ping_dm_handler(uint32_t msg_code, const struct request *request,
 	dmfw_ping_valid = false;
 	EnqueueCm2DmMsg(&msg);
 	/* Delay to allow DMFW to respond */
-	k_msleep(50);
+	k_msleep(100);
 
 	/* Encode response from DMFW */
 	response->data[1] = dmfw_ping_valid;


### PR DESCRIPTION
Extend the time waiting for a DMC ping response. It seems that the DMC sometimes does not respond within 50 ms, and this may be the root cause of the periodic failure in the ARC watchdog test.