### PR TITLE
ci: release: quote output of jq

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,8 @@ jobs:
       - uses: actions/checkout@v4
       - id: genboards
         run: |
-          echo "boards=$(jq -r -c ".[]" .github/boards.json)" | tee -a $GITHUB_OUTPUT
+          BOARDS="$(jq -r -c ".[]" .github/boards.json)"
+          echo boards="$BOARDS" | tee -a $GITHUB_OUTPUT
       - id: check_relnotes_file
         run: |
           relnotes_file="${{ env.RELEASE_NOTES_DIR }}/${{ steps.set_vars.outputs.RELEASE_NOTES }}"


### PR DESCRIPTION
Quote output of jq so that the output does not spill over multiple lines.

This addresses the error linked below in the release workflow.
https://github.com/tenstorrent/tt-zephyr-platforms/actions/runs/16062574984/job/45331264386