### PR TITLE
Raise thermal sensor shutdown to 109C, based on Tj,shutdown

### DIFF
--- a/lib/tenstorrent/bh_arc/pvt.c
+++ b/lib/tenstorrent/bh_arc/pvt.c
@@ -281,7 +281,7 @@ static uint16_t TempToDout(float temp)
 
 /* setup 4 sources of interrupts for each type of sensor: */
 /* 1. sample done */
-/* 2. alarm a: failling alarm (see section 14 of PVT controller spec) */
+/* 2. alarm a: rising alarm, ignored (see section 14 of PVT controller spec) */
 /* 3. alarm b: rising alarm (see section 14 of PVT controller spec) */
 /* 4. IP has a fault */
 /* For VM, only enable sample done and fault interrupts, as alarma and alarmb is per channel */

--- a/lib/tenstorrent/bh_arc/pvt.c
+++ b/lib/tenstorrent/bh_arc/pvt.c
@@ -63,7 +63,8 @@
 
 /* therm_trip temperature in degrees C */
 #define ALARM_A_THERM_TRIP_TEMP 83
-#define ALARM_B_THERM_TRIP_TEMP 95
+/* BH prod spec 7.3 gives Tj,shutdown=110C, tmons are +-1C calibrated */
+#define ALARM_B_THERM_TRIP_TEMP 109
 
 #define TS_HYSTERESIS_DELTA 5
 


### PR DESCRIPTION
Alarm B lines of the thermal sensors are ORed together (and also with CAT sensor) and output on GPIO31 for board shutdown. Increase the Alarm B point to 109C based on Tj,shutdown=110C and thermal sensor +-1C accuracy (when calibrated).