### PR TITLE
ci: bump tt-flash rev to 3.3.5, tt-smi rev to 3.0.23

### DIFF
--- a/.github/workflows/hardware-long.yml
+++ b/.github/workflows/hardware-long.yml
@@ -62,7 +62,7 @@ jobs:
           sudo chmod -R a+rwX $HOME/.cargo $HOME/.cache
           python -m venv .env
           source .env/bin/activate
-          pip install git+https://github.com/tenstorrent/tt-flash.git@v3.3.3
+          pip install git+https://github.com/tenstorrent/tt-flash.git@v3.3.5
           tt-flash --fw-tar /home/user/tt-metal/fw_pack-*.fwbundle --force
       - name: Run Container Test
         run: |

--- a/.github/workflows/hardware-smoke.yml
+++ b/.github/workflows/hardware-smoke.yml
@@ -297,7 +297,7 @@ jobs:
           sudo chmod -R a+rwX $HOME/.cargo $HOME/.cache
           python -m venv .env
           source .env/bin/activate
-          pip install git+https://github.com/tenstorrent/tt-flash.git@v3.3.3
+          pip install git+https://github.com/tenstorrent/tt-flash.git@v3.3.5
           tt-flash --fw-tar /home/user/tt-metal/fw_pack-*.fwbundle --force
       - name: Run Container Test
         run: |

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -5,5 +5,5 @@ west
 # zephyr-keep-sorted-stop
 
 # tenstorrent utilities (note: pyluwen is a dependency)
-tt-flash @ git+https://github.com/tenstorrent/tt-flash@6d84d80bbde9a12edfa32934557d69581771c4a3
-tt-smi @ git+https://github.com/tenstorrent/tt-smi@7aeeb96ba52bf669cf599c1f67e65535072f67c5
+tt-flash @ git+https://github.com/tenstorrent/tt-flash@v3.3.5
+tt-smi @ git+https://github.com/tenstorrent/tt-smi@v3.0.23


### PR DESCRIPTION
Smoke tests and soak tests were both failing on p150a during the "Flash the firmware" step with the error that there were flash region mismatches. The workflows use version 3.3.3 .

http://bit.ly/45WZ7Rs
http://bit.ly/46eEWyL

However, manual repro on the same p150a machine using version 3.3.5 does not produce any flash region mismatches.

https://pastebin.com/vknhTuZD

Bump the version of the tt-flash to v3.3.5 and bump the version of tt-smi to v3.0.23.