### PR TITLE
ci: workflows: upload device log

### DIFF
--- a/.github/workflows/hardware-smoke.yml
+++ b/.github/workflows/hardware-smoke.yml
@@ -88,6 +88,7 @@ jobs:
             zephyr/twister-dmc-smoke/**/*.map
             zephyr/twister-dmc-smoke/**/zephyr.elf
             zephyr/twister-dmc-smoke/**/*.lst
+            zephyr/twister-dmc-smoke/**/device.log
             zephyr/twister-dmc-smoke/twister.log
             zephyr/twister-dmc-smoke/twister.json
 
@@ -130,6 +131,7 @@ jobs:
             zephyr/twister-smc-smoke/**/*.map
             zephyr/twister-smc-smoke/**/zephyr.elf
             zephyr/twister-smc-smoke/**/*.lst
+            zephyr/twister-smc-smoke/**/device.log
             zephyr/twister-smc-smoke/twister.log
             zephyr/twister-smc-smoke/twister.json
 
@@ -233,6 +235,7 @@ jobs:
             zephyr/twister-*e2e*/**/*.map
             zephyr/twister-*e2e*/**/zephyr.elf
             zephyr/twister-*e2e*/**/*.lst
+            zephyr/twister-*e2e*/**/device.log
             zephyr/twister-*e2e*/twister.log
             zephyr/twister-*e2e*/twister.json
             zephyr/twister-*e2e*/**/update.fwbundle


### PR DESCRIPTION
Upload device log from twister runs, so we can debug why flashing steps failed