### PR TITLE
scripts: pre-push: update to align with CI check command

### DIFF
--- a/scripts/pre-push.sh
+++ b/scripts/pre-push.sh
@@ -28,7 +28,9 @@ manifest_base=$(west list -f "{abspath}" manifest)
 # ClangFormat and Ruff are excluded as they will return failures, but CI
 # treats these as formatting hints only
 $zep_base/scripts/ci/check_compliance.py \
-	-e Kconfig \
+	-e KconfigBasicNoModules \
+	-e SysbuildKconfigBasic \
+	-e BinaryFiles \
 	-e ClangFormat \
 	-n -o /dev/null \
 	-c main..$HEAD


### PR DESCRIPTION
CI check in tt-zephyr-platforms excludes a different set of checks than the pre push hook did. Update the hook to use the same set of checks.