### PR TITLE
scripts: build-combined-fwbundle: remove stale comment

### DIFF
--- a/scripts/build-combined-fwbundle.sh
+++ b/scripts/build-combined-fwbundle.sh
@@ -26,7 +26,6 @@ TTZP_BASE="$(dirname "$mPATH")"
 # put tt_boot_fs.py in the path (use it to combine .fwbundle files)
 PATH="$mPATH:$PATH"
 
-# TODO: read boards / board revs from a YAML file
 BOARD_REVS="$(jq -r -c ".[]" "$TTZP_BASE/.github/boards.json")"
 
 MAJOR="$(grep "^VERSION_MAJOR" "$TTZP_BASE/VERSION" | awk '{print $3}')"


### PR DESCRIPTION
There was a lingering TODO comment that said to load board revisions from a yaml file. We do that now (well, a JSON file technically), so can remove the comment.