### PR TITLE
lib: bh_arc: reduce scratchpad size down from 64 kB to 36kB

### DIFF
--- a/lib/tenstorrent/bh_arc/Kconfig
+++ b/lib/tenstorrent/bh_arc/Kconfig
@@ -77,9 +77,13 @@ config TT_BH_ARC_WDT_FEED_INTERVAL
 
 config TT_BH_ARC_SCRATCHPAD_SIZE
 	hex "Size of scratchpad memory in bytes"
-	default 0x10000
+	default 0x9000
 	help
-	  Size of scratchpad memory in bytes. This is used for various purposes, including
-	  storing firmware state and data.
+	  Size of scratchpad memory in bytes. This is mainly used as a temporary buffer for
+	  loading images from SPI flash. The size can be further reduced if we are able to
+	  load images in smaller chunks. The default size is 0x9000 bytes, which is enough to
+	  load the largest image (ERISC FW) in one go. If using a dynamically allocated
+	  buffer is possible, then we can remove the statically allocated buffer entirely.
+	  If not, the size would likely only be able to be reduced down to 1 page (4096 bytes).
 
 endif

--- a/lib/tenstorrent/bh_arc/Kconfig
+++ b/lib/tenstorrent/bh_arc/Kconfig
@@ -12,11 +12,7 @@ config TT_BH_ARC
 	help
 	  This option enables the Blackhole ARC firmware library.
 
-# This is a hack - the msgqueue test depends on this value but
-# This library depends on nanopb and specifically values from nanopb stored in spi falsh
-# We really cannot depend on nanopb outside of the application.
-# And that definition of application does not include drivers.
-#if TT_BH_ARC
+if TT_BH_ARC
 
 config TT_BH_ARC_NUM_MSG_CODES
 	int "Number of message codes"
@@ -54,8 +50,6 @@ config TT_BH_ARC_I2C_TIMEOUT_DURATION
 	  remains full for this timeout, the I2C controller will attempt to recover the bus by
 	  sending 16 SCL pulses while holding SDA low.
 
-#endif
-
 config TT_SMC_RECOVERY
 	bool "build smc recovery image"
 	help
@@ -80,3 +74,5 @@ config TT_BH_ARC_WDT_FEED_INTERVAL
 	default 250
 	help
 	  Interval to feed watchdog within firmware
+
+endif

--- a/lib/tenstorrent/bh_arc/Kconfig
+++ b/lib/tenstorrent/bh_arc/Kconfig
@@ -75,4 +75,11 @@ config TT_BH_ARC_WDT_FEED_INTERVAL
 	help
 	  Interval to feed watchdog within firmware
 
+config TT_BH_ARC_SCRATCHPAD_SIZE
+	hex "Size of scratchpad memory in bytes"
+	default 0x10000
+	help
+	  Size of scratchpad memory in bytes. This is used for various purposes, including
+	  storing firmware state and data.
+
 endif

--- a/lib/tenstorrent/bh_arc/init_common.h
+++ b/lib/tenstorrent/bh_arc/init_common.h
@@ -23,7 +23,7 @@
 #define RESET_UNIT_TENSIX_RESET_7_REG_ADDR 0x8003003C
 
 #define RESET_UNIT_TENSIX_RISC_RESET_0_REG_ADDR 0x80030040
-#define SCRATCHPAD_SIZE                         0x10000
+#define SCRATCHPAD_SIZE                         CONFIG_TT_BH_ARC_SCRATCHPAD_SIZE
 
 typedef struct {
 	uint32_t system_reset_n: 1;


### PR DESCRIPTION
We had some difficulty building our application with debug information before because the linked binary would not fit into memory reserved for cmfw.

Reduce the large scratchpad size down from 64 kB to 36kB, which is just larger than the size of ERISC firmware. The size can be further reduced by adjusting the firmware loading algorithms to be flash-aware. If using malloc is a possibility then the buffers can be freed when they are no longer required, which would allow for additional runtime memory usage.

Technically, I think we should also be able to extend the boundary within CSM (SRAM) where CMFW may be loaded, but if we can get away with using a smaller static buffer and still meet the same performance and functional requirements, we might as well do that too.