### PR TITLE
scripts: tt-console: properly support vuart input

### DIFF
--- a/drivers/serial/uart_tt_virt.c
+++ b/drivers/serial/uart_tt_virt.c
@@ -324,7 +324,7 @@ static int uart_tt_virt_poll_in(const struct device *dev, unsigned char *p_char)
 	const struct uart_tt_virt_config *config = dev->config;
 	volatile struct tt_vuart *vuart = config->vuart;
 
-	return tt_vuart_poll_in(vuart, p_char, TT_VUART_ROLE_DEVICE);
+	return (tt_vuart_poll_in(vuart, p_char, TT_VUART_ROLE_DEVICE) == -1) ? -1 : 0;
 }
 
 void uart_tt_virt_poll_out(const struct device *dev, unsigned char out_char)


### PR DESCRIPTION
Fix a few issues prevent vuart input from functioning correctly. With these changes the shell works on the SMC:

<img width="699" height="827" alt="image" src="https://github.com/user-attachments/assets/ee586f5c-02b9-4778-ae9d-cd3542c8f86d" />


Note that the SMC ram size (in the LD file) needs to be increased to get the shell to fit without overflowing the SRAM region, but it does work