### PR TITLE
boards: tt_blackhole: default sysclk to 800 MHz

### DIFF
--- a/app/smc/boards/tt_blackhole_tt_blackhole_smc.overlay
+++ b/app/smc/boards/tt_blackhole_tt_blackhole_smc.overlay
@@ -11,14 +11,6 @@
 	status = "disabled";
 };
 
-/*
- * ARC clock will be raised to 800MHz in the application
- */
-&sysclk {
-	status = "okay";
-	clock-frequency = <800000000>;
-};
-
 &wdt0 {
 	status = "okay";
 };

--- a/dts/arc/tenstorrent/tt_blackhole_smc.dtsi
+++ b/dts/arc/tenstorrent/tt_blackhole_smc.dtsi
@@ -184,7 +184,7 @@
 
 	sysclk: system-clock {
 		compatible = "fixed-clock";
-		clock-frequency = <500000000>;
+		clock-frequency = <800000000>;
 		#clock-cells = <0>;
 	};
 

--- a/soc/tenstorrent/tt_blackhole/Kconfig.defconfig.tt_blackhole_smc
+++ b/soc/tenstorrent/tt_blackhole/Kconfig.defconfig.tt_blackhole_smc
@@ -25,7 +25,7 @@ config RGF_NUM_BANKS
 	default 1
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	default 540000000
+	default 800000000
 
 config CODE_DENSITY
 	default y


### PR DESCRIPTION
Set sysclk to 800 MHz instead of 500, or 540.