### PR TITLE
drivers: mspi: mspi_dw: add support for polling mode

### DIFF
--- a/boards/tenstorrent/tt_blackhole/init.c
+++ b/boards/tenstorrent/tt_blackhole/init.c
@@ -12,6 +12,7 @@
 
 #define SPI_RX_TRAIN_ADDR 0x13FFC
 #define SPI_RX_TRAIN_DATA 0xa5a55a5a
+#define SSI_RX_DLY_SR_DEPTH 64
 
 const struct device *mspi_dev = DEVICE_DT_GET_OR_NULL(DT_NODELABEL(spi0));
 const struct device *flash = DEVICE_DT_GET_OR_NULL(DT_NODELABEL(spi_flash));
@@ -189,7 +190,7 @@ static int flash_training_init(void)
 		if (rc < 0) {
 			return rc;
 		}
-	} while ((spi_rx_buf != SPI_RX_TRAIN_DATA) && (rx_delay < 255));
+	} while ((spi_rx_buf != SPI_RX_TRAIN_DATA) && (rx_delay < SSI_RX_DLY_SR_DEPTH));
 	delay_lb = rx_delay;
 	/* Find the upper bound on the delay setting */
 	do {
@@ -202,7 +203,7 @@ static int flash_training_init(void)
 		if (rc < 0) {
 			return rc;
 		}
-	} while ((spi_rx_buf == SPI_RX_TRAIN_DATA) && (rx_delay < 255));
+	} while ((spi_rx_buf == SPI_RX_TRAIN_DATA) && (rx_delay < SSI_RX_DLY_SR_DEPTH));
 	delay_ub = rx_delay - 1;
 
 	/* Find midpoint of both delay settings */

--- a/boards/tenstorrent/tt_blackhole/init.c
+++ b/boards/tenstorrent/tt_blackhole/init.c
@@ -83,6 +83,10 @@ static int flash_reset_init(void)
 
 	if ((spi_device_config.f.normal_spi_mode == SpiOctalMode) &&
 	    (spi_device_id == 0x2c5b1a10)) {
+		if (spi_device_config.f.normal_ddr) {
+			/* MX35 flash in DDR mode. */
+			mspi_dev_cfg.data_rate = MSPI_DATA_RATE_DUAL;
+		}
 		/* MX35 flash. Issue RESET ENABLE and RESET MEMORY commands in octal mode */
 		mspi_dev_cfg.io_mode = MSPI_IO_MODE_OCTAL;
 		rc = mspi_dev_config(mspi_dev, &mspi_dev_id, MSPI_DEVICE_CONFIG_ALL,

--- a/boards/tenstorrent/tt_blackhole/tt_blackhole_tt_blackhole_smc_defconfig
+++ b/boards/tenstorrent/tt_blackhole/tt_blackhole_tt_blackhole_smc_defconfig
@@ -23,3 +23,6 @@ CONFIG_FLASH=y
 
 # enable external spi flash
 CONFIG_FLASH_MSPI_NOR_RUNTIME_PROBE=y
+
+# Use polling mode for DesignWare SSI controller
+CONFIG_MSPI_DW_POLLING=y

--- a/drivers/mspi/Kconfig.dw
+++ b/drivers/mspi/Kconfig.dw
@@ -7,3 +7,13 @@ config MSPI_DW
 	depends on DT_HAS_SNPS_DESIGNWARE_SSI_ENABLED
 	select PINCTRL if $(dt_compat_any_has_prop,$(DT_COMPAT_SNPS_DESIGNWARE_SSI),pinctrl-0)
 	imply MSPI_XIP
+
+config MSPI_DW_POLLING
+	bool "Use polling mode for DesignWare SSI controller"
+	depends on MSPI_DW
+	help
+	  Use polling mode for transfers instead of interrupts. This
+	  will send the entire transfer with interrupts locked, which can
+	  be desirable for this controller, as it will deassert CS
+	  when the TX FIFO is empty, which can cause issues with
+	  systems that have high interrupt latency.

--- a/drivers/mspi/mspi_dw.c
+++ b/drivers/mspi/mspi_dw.c
@@ -269,6 +269,10 @@ static bool mspi_dw_transfer(const struct device *dev, uint32_t int_status)
 		 * shifting out the last frame (the last interrupt occurs when
 		 * the TX FIFO is empty). Wait if it signals that it is busy.
 		 */
+
+		while ((read_sr(dev) & SR_TFE_BIT) == 0) {
+			/* Wait until TX FIFO is empty */
+		}
 		while (read_sr(dev) & SR_BUSY_BIT) {
 		}
 

--- a/drivers/mspi/mspi_dw.c
+++ b/drivers/mspi/mspi_dw.c
@@ -1232,6 +1232,8 @@ static int api_timing_config(const struct device *dev,
 			     const uint32_t param_mask, void *cfg)
 {
 	if (param_mask & MSPI_DW_RX_TIMING_CFG) {
+		/* Disable controller before configuring */
+		write_ssienr(dev, 0);
 		write_rx_sample_dly(dev, (uint32_t)(uintptr_t)cfg);
 		return 0;
 	}

--- a/drivers/mspi/mspi_dw.h
+++ b/drivers/mspi/mspi_dw.h
@@ -50,6 +50,7 @@
 
 /* SR - Status Register */
 #define SR_BUSY_BIT	        BIT(0)
+#define SR_TFE_BIT              BIT(2)
 
 /* IMR - Interrupt Mask Register */
 #define IMR_TXEIM_BIT		BIT(0)


### PR DESCRIPTION
After some time with tracing, I am convinced Synopsis has won. The SPI DW peripheral simply has too small of a TX FIFO (and interrupt latency is too high) to support interrupt driven transfers.

Add support for a polling mode for the MSPI DW driver, which performs transfers with interrupts locked. This should minimize risk of TX FIFO underflows, provided that the SPI frequency is slow enough the CPU can keep pace with the FIFO.