### PR TITLE
MAINTAINERS: add danieldegrasse to release team

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -457,6 +457,7 @@ Release Notes:
   status: maintained
   maintainers:
     - cfriedt
+    - danieldegrasse
   files:
     - doc/release/
   labels:


### PR DESCRIPTION
We don't have an official "release team" in TT GitHub, but we should, since it's a role that can be rotated semi-regularly. The upstream release team have triage and merge privileges, whereas maintainers and contributors have approval privileges.

In any case, Daniel completed the release for Zephyr v4.2.0, so he can be added to the Tenstorrent release team.