### PR TITLE
ci: re-enable p100 for metal-test

### DIFF
--- a/.github/workflows/hardware-smoke.yml
+++ b/.github/workflows/hardware-smoke.yml
@@ -259,10 +259,9 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          # disabled until #253 is resolved
-          # - board: p100
-          #  runs-on:
-          #    - p100-jtag
+          - board: p100
+            runs-on:
+              - p100-jtag
           - board: p100a
             runs-on:
               - p100a-jtag


### PR DESCRIPTION
Re-enable testing on p100 for metal-test in the hardware-smoke workflow.