### PR TITLE
readme.md: change tt-console path from tt-console to tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ cd $MODULE
 
 ```shell
 # Build tt-console
-gcc -Iinclude -std=gnu11 -o /tmp/tt-console scripts/tt-console/console.c
+gcc -Iinclude -std=gnu11 -o /tmp/tt-console scripts/tooling/console.c
 
 # Build and flash firmware
 west build --sysbuild -p -b tt_blackhole@p100a/tt_blackhole/smc app/smc \


### PR DESCRIPTION
Changed tt-console/console.c to tooling/console.c to match updated console path.