### PR TITLE
readme: install packages before fetching blobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,14 +29,14 @@ cd ~/tt-zephyr-platforms-work
 # Fetch Zephyr modules
 west update
 
+# Install Python packages
+west packages pip --install
+
 # Verify binary blobs
 west blobs fetch
 
 # Apply local patches
 west patch apply
-
-# Install Python packages
-west packages pip --install
 
 # Set up Zephyr environment
 source zephyr/zephyr-env.sh


### PR DESCRIPTION
On a fresh clone, `west blobs fetch` will fail because the python requests library is not present, so install python packages before running that command.

I should specify, that I kind of half-followed the Zephyr GSG when performing a fresh install.

1. Start container
  ```shell
  docker run --rm -it ubuntu:latest
  ```

2. Update packages (from GSG, without `sudo`)
  ```shell
  apt update
  apt upgrade
  ```

3. Install required utilities (from GSG, without `sudo` and multilib packages)
  ```shell
  sudo apt install --no-install-recommends git cmake ninja-build gperf \
    ccache dfu-util device-tree-compiler wget python3-dev python3-venv python3-tk \
    xz-utils file make gcc libsdl2-dev libmagic1
  ```

4. Set up venv (modified from GSG)
  ```shell
  python3 -m venv ~/tt-zephyr-platforms-work/.venv
  source ~/tt-zephyr-platforms-work/.venv/bin/activate
  ```

5. Install west (from GSG)
  ```shell
  pip install west
  ```

6. Follow TTZP instructions
  ```shell
  # Create a west workspace
  west init -m https://github.com/tenstorrent/tt-zephyr-platforms ~/tt-zephyr-platforms-work
  cd ~/tt-zephyr-platforms-work
  
  # Fetch Zephyr modules
  west update
  
  # Verify binary blobs
  west blobs fetch
  # ^^^ this produces an error
```

```shell
Fetching blob hal_stm32: /root/tt-zephyr-platforms-work/modules/hal/stm32/zephyr/blobs/stm32wba/lib/WBA6_LinkLayer_BLE_Full_lib.a
The module for fetcher "http" could not be imported (No module named 'requests'). This most likely means it is not handling its dependencies properly. Please report this to the zephyr developers.
Traceback (most recent call last):
  File "/root/tt-zephyr-platforms-work/.venv/bin/west", line 8, in <module>
    sys.exit(main())
  File "/root/tt-zephyr-platforms-work/.venv/lib/python3.10/site-packages/west/app/main.py", line 1199, in main
    app.run(argv or sys.argv[1:])
  File "/root/tt-zephyr-platforms-work/.venv/lib/python3.10/site-packages/west/app/main.py", line 278, in run
    self.run_command(argv, early_args)
  File "/root/tt-zephyr-platforms-work/.venv/lib/python3.10/site-packages/west/app/main.py", line 584, in run_command
    self.run_extension(args.command, argv)
  File "/root/tt-zephyr-platforms-work/.venv/lib/python3.10/site-packages/west/app/main.py", line 739, in run_extension
    self.cmd.run(args, unknown, self.topdir, manifest=self.manifest,
  File "/root/tt-zephyr-platforms-work/.venv/lib/python3.10/site-packages/west/commands.py", line 200, in run
    self.do_run(args, unknown)
  File "/root/tt-zephyr-platforms-work/zephyr/scripts/west_commands/blobs.py", line 212, in do_run
    subcmd(args)
  File "/root/tt-zephyr-platforms-work/zephyr/scripts/west_commands/blobs.py", line 187, in fetch
    self.fetch_blob(blob['url'], blob['abspath'])
  File "/root/tt-zephyr-platforms-work/zephyr/scripts/west_commands/blobs.py", line 120, in fetch_blob
    fetcher = fetchers.get_fetcher_cls(scheme)
  File "/root/tt-zephyr-platforms-work/zephyr/scripts/west_commands/fetchers/__init__.py", line 43, in get_fetcher_cls
    raise ValueError('unknown fetcher for scheme "{}"'.format(scheme))
ValueError: unknown fetcher for scheme "https"
```