### PR TITLE
boards: tenstorrent: improve reliablity when programming P100 flash

### DIFF
--- a/.github/workflows/prepare-zephyr/action.yml
+++ b/.github/workflows/prepare-zephyr/action.yml
@@ -21,8 +21,8 @@ runs:
       shell: bash
       run: |
         TOINSTALL=""
-        cmds=(curl)
-        pkgs=(curl)
+        cmds=(curl protoc)
+        pkgs=(curl protobuf-compiler)
 
         for ((i=0; i < ${#cmds[@]}; i++)); do
           cmd=${cmds[$i]}
@@ -88,3 +88,10 @@ runs:
       shell: bash
       run: |
         west -v patch apply
+
+    - name: Patch pyluwen version
+      shell: bash
+      run: |
+        # Needed as a workaround until the tt-flash/tt-smi dependency chain is
+        # updated to pull in the latest pyluwen
+        pip install pyluwen@git+https://github.com/tenstorrent/luwen.git@d20b8d6f64c0#subdirectory=crates/pyluwen

--- a/app/smc/tracing.overlay
+++ b/app/smc/tracing.overlay
@@ -41,3 +41,11 @@
 &vuart1 {
 	status = "okay";
 };
+
+/*
+ * Slow SPI flash frequency. Otherwise programming will fail with
+ * additional tracing overhead
+ */
+&spi_flash {
+	mspi-max-frequency = <DT_FREQ_M(4)>;
+};

--- a/boards/tenstorrent/tt_blackhole/init.c
+++ b/boards/tenstorrent/tt_blackhole/init.c
@@ -12,6 +12,7 @@
 
 #define SPI_RX_TRAIN_ADDR 0x13FFC
 #define SPI_RX_TRAIN_DATA 0xa5a55a5a
+#define SSI_RX_DLY_SR_DEPTH 64
 
 const struct device *mspi_dev = DEVICE_DT_GET_OR_NULL(DT_NODELABEL(spi0));
 const struct device *flash = DEVICE_DT_GET_OR_NULL(DT_NODELABEL(spi_flash));
@@ -189,7 +190,7 @@ static int flash_training_init(void)
 		if (rc < 0) {
 			return rc;
 		}
-	} while ((spi_rx_buf != SPI_RX_TRAIN_DATA) && (rx_delay < 255));
+	} while ((spi_rx_buf != SPI_RX_TRAIN_DATA) && (rx_delay < SSI_RX_DLY_SR_DEPTH));
 	delay_lb = rx_delay;
 	/* Find the upper bound on the delay setting */
 	do {
@@ -202,7 +203,7 @@ static int flash_training_init(void)
 		if (rc < 0) {
 			return rc;
 		}
-	} while ((spi_rx_buf == SPI_RX_TRAIN_DATA) && (rx_delay < 255));
+	} while ((spi_rx_buf == SPI_RX_TRAIN_DATA) && (rx_delay < SSI_RX_DLY_SR_DEPTH));
 	delay_ub = rx_delay - 1;
 
 	/* Find midpoint of both delay settings */

--- a/boards/tenstorrent/tt_blackhole/init.c
+++ b/boards/tenstorrent/tt_blackhole/init.c
@@ -83,6 +83,10 @@ static int flash_reset_init(void)
 
 	if ((spi_device_config.f.normal_spi_mode == SpiOctalMode) &&
 	    (spi_device_id == 0x2c5b1a10)) {
+		if (spi_device_config.f.normal_ddr) {
+			/* MX35 flash in DDR mode. */
+			mspi_dev_cfg.data_rate = MSPI_DATA_RATE_DUAL;
+		}
 		/* MX35 flash. Issue RESET ENABLE and RESET MEMORY commands in octal mode */
 		mspi_dev_cfg.io_mode = MSPI_IO_MODE_OCTAL;
 		rc = mspi_dev_config(mspi_dev, &mspi_dev_id, MSPI_DEVICE_CONFIG_ALL,


### PR DESCRIPTION
Add changes to improve the reliability of programming the P100 flash. These changes were tested in #243, but this PR removes the commit adding the test and only includes the fixes.