### PR TITLE
scripts: tooling: ensure tt-console works across flashes and rescans

### DIFF
--- a/app/smc/pytest/vuart.py
+++ b/app/smc/pytest/vuart.py
@@ -37,8 +37,8 @@ def test_compile_tt_console(tt_console: Path):
 def test_boot_banner(tt_console: Path, arc_chip):
     arc_chip.axi_read32(ARC_STATUS)
 
-    # run 'tt-console' in quiet mode, and timeout after 500ms
-    cmd = f"{tt_console} -q -w 500"
+    # run 'tt-console' in quiet mode, and timeout after 3 s
+    cmd = f"{tt_console} -q -w 3000"
     proc = subprocess.run(cmd.split(), capture_output=True, check=True)
 
     out = proc.stdout.decode("utf-8")

--- a/scripts/tooling/vuart.h
+++ b/scripts/tooling/vuart.h
@@ -9,6 +9,14 @@
 
 #include <sys/mman.h>
 
+#ifndef UART_TT_VIRT_MAGIC
+#define UART_TT_VIRT_MAGIC 0x775e21a1
+#endif
+
+#ifndef UART_TT_VIRT_DISCOVERY_ADDR
+#define UART_TT_VIRT_DISCOVERY_ADDR 0x800304a0
+#endif
+
 #define VUART_DATA_INIT(_dev_name, _addr, _magic, _pci_device_id, _channel)                        \
 	{.dev_name = _dev_name,                                                                    \
 	 .addr = _addr,                                                                            \
@@ -95,5 +103,19 @@ size_t vuart_space(struct vuart_data *data);
  * @return -EAGAIN if no data is available
  */
 int vuart_read(struct vuart_data *data, uint8_t *buf, size_t size);
+
+/**
+ * @brief Remove all tenstorrent PCIe devices from the system.
+ *
+ * @return 0 on success, or a negative error code on failure.
+ */
+int pcie_remove(void);
+
+/**
+ * @brief Rescan PCIe devices.
+ *
+ * @return 0 on success, or a negative error code on failure.
+ */
+int pcie_rescan(void);
 
 #endif /* SCRIPTS_TOOLING_VUART_H_ */


### PR DESCRIPTION
* ensure that the virtual uart can still work between card resets and flashes.
* if the timeout parameter is specified, trigger `SIGALRM` via timer

Currently, even with a manual rescan of the pcie bus, `tt-console` does _not_ properly reconnect to the virtual uart. 

With this change, the gif below shows production firmware interleaved with the flash performance test output repeated twice (i.e. is able to reconnect to the virtual uart multiple times).

![console-working-across-flashes](https://github.com/user-attachments/assets/ddfc00f9-b9b4-45db-ac82-6135ba8c2ab5)