### PR TITLE
license: move non-apache licensing details to readme

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -188,7 +188,3 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-
--------------------------------------------------------------------------------
-
-Additional binary licenses can be found in [zephyr/blobs/license.txt](zephyr/blobs/license.txt)

--- a/LICENSE_understanding.txt
+++ b/LICENSE_understanding.txt
@@ -1,3 +1,0 @@
-For the avoidance of doubt, this software assists in programming Tenstorrent products.
-
-However, making, using, or selling hardware, models, or IP may require the license of rights (such as patent rights) from Tenstorrent or others.

--- a/README.md
+++ b/README.md
@@ -169,3 +169,17 @@ Learn more about `twister`
 
 For more information on creating Zephyr Testsuites, visit
 [this](https://docs.zephyrproject.org/latest/develop/test/ztest.html) page.
+
+## Software License
+
+This source code in this repository is made available under the terms of the
+[Apache-2.0 software license](https://www.apache.org/licenses/LICENSE-2.0), as described in the
+accompanying [LICENSE](LICENSE) file.
+
+Additional binary artifacts are separately licensed with terms be found in
+[zephyr/blobs/license.txt](zephyr/blobs/license.txt).
+
+For the avoidance of doubt, this software assists in programming
+[Tenstorrent](https://tenstorrent.com) products. However, making, using, or selling hardware,
+models, or IP may require the license of rights (such as patent rights) from Tenstorrent or
+others.


### PR DESCRIPTION
* Move non-Apache-2.0 binary blob license details out of the Apache-2.0 `LICENSE` file and into `README.md`
* Move the contents of `LICENSE_understanding.txt` into `README.md`