### PR TITLE
ci: hardware: remove use of hardware-map definition

### DIFF
--- a/.github/workflows/hardware-long.yml
+++ b/.github/workflows/hardware-long.yml
@@ -57,6 +57,12 @@ jobs:
           DMC_BOARD="$(./scripts/rev2board.sh "${{ matrix.config.board }}" dmc)"
           echo "DMC_BOARD=$DMC_BOARD" >> "$GITHUB_ENV"
 
+      - name: build-tt-smc_console
+        working-directory: tt-zephyr-platforms/scripts/tooling
+        run: |
+          # Build tt-console
+          make
+
       - name: run-e2e-stress-test
         working-directory: zephyr
         run: |
@@ -68,7 +74,9 @@ jobs:
             --retry-interval 5 \
             --tag e2e \
             -p $DMC_BOARD --device-testing \
-            --hardware-map /opt/tenstorrent/twister/hw-map.yml --west-flash \
+            --device-serial-pty ../tt-zephyr-platforms/scripts/dmc_rtt.py \
+            --flash-before \
+            --west-flash \
             -T ../tt-zephyr-platforms/app \
             --outdir twister-dmc-e2e
           # Rescan PCIe before we run tt-flash
@@ -79,7 +87,8 @@ jobs:
             --west-flash="--force" \
             --west-runner tt_flash \
             --device-testing -c \
-            --device-serial-pty rtt \
+            --device-serial-pty ../tt-zephyr-platforms/scripts/smc_console.py \
+            --flash-before \
             --outdir twister-e2e-stress
 
       - name: Upload Stress Test results

--- a/.github/workflows/hardware-smoke.yml
+++ b/.github/workflows/hardware-smoke.yml
@@ -59,6 +59,12 @@ jobs:
           DMC_BOARD="$(./scripts/rev2board.sh "${{ matrix.config.board }}" dmc)"
           echo "DMC_BOARD=$DMC_BOARD" >> "$GITHUB_ENV"
 
+      - name: build-tt-smc_console
+        working-directory: tt-zephyr-platforms/scripts/tooling
+        run: |
+          # Build tt-console
+          make
+
       - name: run-dmc-tests
         working-directory: zephyr
         run: |
@@ -66,7 +72,9 @@ jobs:
           ./scripts/twister -i --retry-failed 3 \
             --retry-interval 5 \
             -p $DMC_BOARD --device-testing \
-            --hardware-map /opt/tenstorrent/twister/hw-map.yml --west-flash \
+            --west-flash \
+            --device-serial-pty ../tt-zephyr-platforms/scripts/dmc_rtt.py \
+            --flash-before \
             --tag smoke \
             --alt-config-root ../tt-zephyr-platforms/test-conf/samples \
             --alt-config-root ../tt-zephyr-platforms/test-conf/tests \
@@ -101,7 +109,9 @@ jobs:
             --retry-interval 5 \
             --tag e2e \
             -p $DMC_BOARD --device-testing \
-            --hardware-map /opt/tenstorrent/twister/hw-map.yml --west-flash \
+            --device-serial-pty ../tt-zephyr-platforms/scripts/dmc_rtt.py \
+            --west-flash \
+            --flash-before \
             -T ../tt-zephyr-platforms/app \
             --outdir twister-dmc-e2e
 
@@ -109,7 +119,9 @@ jobs:
           ./scripts/twister -i --retry-failed 3 \
             --retry-interval 5 \
             -p $SMC_BOARD --device-testing \
-            --hardware-map /opt/tenstorrent/twister/hw-map.yml --west-flash \
+            --device-serial-pty ../tt-zephyr-platforms/scripts/smc_console.py \
+            --west-flash \
+            --flash-before \
             --tag smoke \
             --alt-config-root ../tt-zephyr-platforms/test-conf/samples \
             --alt-config-root ../tt-zephyr-platforms/test-conf/tests \
@@ -197,7 +209,9 @@ jobs:
             --retry-interval 5 \
             --tag e2e \
             -p $DMC_BOARD --device-testing \
-            --hardware-map /opt/tenstorrent/twister/hw-map.yml --west-flash \
+            --device-serial-pty ../tt-zephyr-platforms/scripts/dmc_rtt.py \
+            --flash-before \
+            --west-flash \
             -T ../tt-zephyr-platforms/app \
             --outdir twister-dmc-e2e
           # Run E2E test to verify DMC and SMC firmware boot, and that
@@ -205,7 +219,9 @@ jobs:
           ./scripts/twister -i --retry-failed 3 \
             -p $SMC_BOARD --device-testing \
             --tag e2e \
-            --hardware-map /opt/tenstorrent/twister/hw-map.yml --west-flash \
+            --device-serial-pty ../tt-zephyr-platforms/scripts/smc_console.py \
+            --flash-before \
+            --west-flash \
             -T ../tt-zephyr-platforms/app \
             --outdir twister-smc-e2e
 
@@ -219,6 +235,7 @@ jobs:
             --west-runner tt_flash \
             --device-testing -c \
             --device-serial-pty ../tt-zephyr-platforms/scripts/smc_console.py \
+            --flash-before \
             --outdir twister-e2e-flash
 
       - name: Upload E2E Test results

--- a/scripts/smc_console.py
+++ b/scripts/smc_console.py
@@ -22,7 +22,7 @@ DEFAULT_CFG = (
 
 TT_CONSOLE_SEARCH_DIRS = [
     Path("/opt/tenstorrent/bin"),
-    Path(__file__).parents[0] / "tt-console",
+    Path(__file__).parents[0] / "tooling",
 ]
 DEFAULT_SEARCH_BASE = 0x10000000
 DEFAULT_SEARCH_RANGE = 0x80000


### PR DESCRIPTION
We don't strictly *need* the hardware map file currently, as we only
have one DUT per test system. While the file represents a convenient way
to encode multiple flash options, it resides outside of version control
and has caused CI headaches in the past.

Encode twister run options directly into commands used in CI and use
tt-console built from source, so that all portions of the test are version
controlled.