### PR TITLE
ci: do not retry if twister jobs fail

### DIFF
--- a/.github/workflows/hardware-long.yml
+++ b/.github/workflows/hardware-long.yml
@@ -64,8 +64,7 @@ jobs:
           # flash DMC and SMC firmware, but since each chip uses a separate
           # debug adapter this doesn't work. For now, just flash DMC
           # then run twister with SMC firmware
-          ./scripts/twister -i --retry-failed 3 \
-            --retry-interval 5 \
+          ./scripts/twister -i \
             --tag e2e \
             -p $DMC_BOARD --device-testing \
             --hardware-map /opt/tenstorrent/twister/hw-map.yml --west-flash \

--- a/.github/workflows/hardware-smoke.yml
+++ b/.github/workflows/hardware-smoke.yml
@@ -63,8 +63,7 @@ jobs:
         working-directory: zephyr
         run: |
           # Run tests tagged with "smoke"
-          ./scripts/twister -i --retry-failed 3 \
-            --retry-interval 5 \
+          ./scripts/twister -i \
             -p $DMC_BOARD --device-testing \
             --hardware-map /opt/tenstorrent/twister/hw-map.yml --west-flash \
             --tag smoke \
@@ -97,8 +96,7 @@ jobs:
         run: |
           # Flash the DMFW app back onto the DMC. Otherwise the flash device
           # will not be muxed to the SMC, and flash tests will fail
-          ./scripts/twister -i --retry-failed 3 \
-            --retry-interval 5 \
+          ./scripts/twister -i \
             --tag e2e \
             -p $DMC_BOARD --device-testing \
             --hardware-map /opt/tenstorrent/twister/hw-map.yml --west-flash \
@@ -106,8 +104,7 @@ jobs:
             --outdir twister-dmc-e2e
 
           # Run tests tagged with "smoke"
-          ./scripts/twister -i --retry-failed 3 \
-            --retry-interval 5 \
+          ./scripts/twister -i \
             -p $SMC_BOARD --device-testing \
             --hardware-map /opt/tenstorrent/twister/hw-map.yml --west-flash \
             --tag smoke \
@@ -193,8 +190,7 @@ jobs:
           # flash DMC and SMC firmware, but since each chip uses a separate
           # debug adapter this doesn't work. For now, just flash DMC
           # then run twister with SMC firmware
-          ./scripts/twister -i --retry-failed 3 \
-            --retry-interval 5 \
+          ./scripts/twister -i \
             --tag e2e \
             -p $DMC_BOARD --device-testing \
             --hardware-map /opt/tenstorrent/twister/hw-map.yml --west-flash \
@@ -202,7 +198,7 @@ jobs:
             --outdir twister-dmc-e2e
           # Run E2E test to verify DMC and SMC firmware boot, and that
           # the SMC firmware sets up PCIe and ARC messages
-          ./scripts/twister -i --retry-failed 3 \
+          ./scripts/twister -i \
             -p $SMC_BOARD --device-testing \
             --tag e2e \
             --hardware-map /opt/tenstorrent/twister/hw-map.yml --west-flash \

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -43,7 +43,7 @@ jobs:
       - id: run
         shell: bash
         run: |
-          west twister -i --run-only --retry-failed=3 $platforms $roots -v
+          west twister -i --run-only $platforms $roots -v
 
       - name: Upload test results
         if: ${{ always() }}
@@ -83,7 +83,7 @@ jobs:
       - name: build and run
         shell: bash
         run: |
-          west twister -i --retry-failed=3 $platforms $tags $configroots $roots
+          west twister -i $platforms $tags $configroots $roots
 
       - name: Upload test results
         if: ${{ always() }}


### PR DESCRIPTION
Historically, `twister` has required the `--retry-failed` argument and friends because of extremely-difficult-to-guarantee synchronization between the host clock and the "hardware clock" in Qemu guests.

This is most prevalently seen when running kernel benchmarks, SMP locking, and SMP thread stress tests when running multiple SMP Qemu guests in parallel.

It reduces to the fact that one Qemu instance will make assumptions about host CPU availability that break down under heavy load. That causes jitter in the guest "hardware clock", typically on the order of a few ms or sometimes tens of ms.

We don't (yet) run those kinds of stress tests involving multiple Qemu targets in our CI, so retrying is really just exacerbating a problem, which is that if our hardware platform fails on the first try it typically fails on subsequent retries of the same test.

Retrying is therefore just a waste of cycles and clogs-up CI.

Let's eliminate retries until they are absolutely necessary.