### PR TITLE
scripts: tooling: tt_console: fix rescan within container

### DIFF
--- a/scripts/tooling/console.c
+++ b/scripts/tooling/console.c
@@ -424,7 +424,7 @@ int main(int argc, char **argv)
 		loop_ratelimit();
 
 		ret = loop(&_cons);
-		if (ret == -ENOENT) {
+		if ((ret == -ENOENT) || (ret == -ENXIO)) {
 			/*
 			 * Lost the virtual uart connection OR it was not found in the first place.
 			 * Remove and rescan for the device if possible (requires permissions).

--- a/scripts/tooling/vuart.c
+++ b/scripts/tooling/vuart.c
@@ -446,7 +446,8 @@ static int open_tt_dev(struct vuart_data *vuart)
 
 	vuart->fd = open(vuart->dev_name, O_RDWR);
 	if (vuart->fd < 0) {
-		if (errno == ENOENT) {
+		if ((errno == ENOENT) || (errno == ENXIO)) {
+			/* Device isn't found. This is ok, we can perform a rescan */
 			D(1, "%s: %s", strerror(errno), vuart->dev_name);
 		} else {
 			E("%s: %s", strerror(errno), vuart->dev_name);


### PR DESCRIPTION
Within a container, failing to open the device /dev/tenstorrent/0 will fail with error code ENXIO because we have indicated to docker that /dev/tenstorrent/0 is a "special device" Add this errno code as a special case that triggers a rescan.

This should resolve lingering CI issues with smoke tests.