### PR TITLE
doc: release: release-notes-18.8.md: add note on firmware telem values

### DIFF
--- a/doc/release/release-notes-18.8.md
+++ b/doc/release/release-notes-18.8.md
@@ -46,6 +46,8 @@ Major enhancements with this release include:
 [comment]: <> (UL Drivers)
 [comment]: <> (UL Libraries)
 
+* Expose firmware telemetry values `AICLK_MAX`, `VDD_LIMIT`, `THM_LIMIT` and `TDC_LIMIT` in the telemetry table for `tt-smi`.
+
 [comment]: <> (H2 New Boards, if applicable)
 
 ## Migration guide


### PR DESCRIPTION
Add note in release doc regarding the firmware telemetry values AICLK_MAX, VDD_LIMIT, THM_LIMIT and TDC_LIMIT being exposed for tt-smi.