### PR TITLE
drivers: sensor: ina228: promote the power-scaling calculation

### DIFF
--- a/drivers/sensor/ti/ina228/ina228.c
+++ b/drivers/sensor/ti/ina228/ina228.c
@@ -67,7 +67,7 @@ LOG_MODULE_REGISTER(INA228, CONFIG_SENSOR_LOG_LEVEL);
 #define INA228_SHUNT_CAL_SCALING 131072ULL
 
 /** @brief Power scaling value */
-#define INA228_POWER_SCALING(x) ((x) * 32U / 10U)
+#define INA228_POWER_SCALING(x) ((x) * 32ULL / 10ULL)
 
 /** @brief The conversion factor for the bus voltage register, in microvolts/LSB. */
 #define INA228_BUS_VOLTAGE_TO_uV(x) ((x) * 1953125ULL / 10000ULL)


### PR DESCRIPTION
Making this PR on Sherry's request as she is on vacation without access to her laptop.

Promote INA228_POWER_SCALING to 64-bit to prevent overflow when raw values exceed ~134M.