### PR TITLE
scripts: pre-push: update to align with CI checks

### DIFF
--- a/scripts/pre-push.sh
+++ b/scripts/pre-push.sh
@@ -31,7 +31,6 @@ $zep_base/scripts/ci/check_compliance.py \
 	-e KconfigBasicNoModules \
 	-e SysbuildKconfigBasic \
 	-e BinaryFiles \
-	-e ClangFormat \
 	-n -o /dev/null \
 	-c main..$HEAD
 


### PR DESCRIPTION
CI compliance checks now care about clang-format, so make the pre-push checks do the same.