### PR TITLE
scripts: support multiple PCIe cards in rescan step

### DIFF
--- a/scripts/pcie_utils.py
+++ b/scripts/pcie_utils.py
@@ -10,17 +10,18 @@ from pathlib import Path
 TT_PCIE_VID = "0x1e52"
 
 
-def find_tt_bus():
+def find_tt_devs():
     """
-    Finds PCIe path for device to power off
+    Finds PCIe paths for devices to power off
     """
+    devs = []
     for root, dirs, _ in os.walk("/sys/bus/pci/devices"):
         for d in dirs:
             with open(os.path.join(root, d, "vendor"), "r") as f:
                 vid = f.read()
                 if vid.strip() == TT_PCIE_VID:
-                    return os.path.join(root, d)
-    return None
+                    devs.append(os.path.join(root, d))
+    return devs
 
 
 def rescan_pcie():
@@ -28,8 +29,8 @@ def rescan_pcie():
     Helper to rescan PCIe bus
     """
     # First, we must find the PCIe card to power it off
-    dev = find_tt_bus()
-    if dev is not None:
+    devs = find_tt_devs()
+    for dev in devs:
         print(f"Powering off device at {dev}")
         remove_path = Path(dev) / "remove"
         try:

--- a/scripts/rescan-pcie.sh
+++ b/scripts/rescan-pcie.sh
@@ -25,7 +25,6 @@ pciremove() {
     if [ "$(cat $d/vendor)" = "0x${TT_PCI_VID}" ]; then
       echo "Removing PCI device $d with vendor id ${TT_PCI_VID}"
       echo 1 | stee $d/remove
-      break
     fi
   done
 }


### PR DESCRIPTION
Support multiple PCIe cards in bus rescan step for python and bash scripting. This is required for P300, which enumerates in bifurcation mode.