### PR TITLE
lib: tenstorrent: bh_arc: telemetry.c: update aiclk and vdd telemetry

### DIFF
--- a/doc/release/migration-guide-18.8.md
+++ b/doc/release/migration-guide-18.8.md
@@ -5,3 +5,8 @@
 This document lists recommended and required changes for those migrating from the previous v18.7.0 firmware release to the new v18.8.0 firmware release.
 
 [comment]: <> (UL by area, indented as necessary)
+
+* Update `luwen`, `tt-smi` and `tt-flash` to support more firmware telemetry values being added.
+  * `luwen` >= 0.7.2
+  * `tt-smi` >= v3.0.22
+  * `tt-flash` >= v3.3.4

--- a/dts/arc/tenstorrent/tt_blackhole_smc.dtsi
+++ b/dts/arc/tenstorrent/tt_blackhole_smc.dtsi
@@ -134,7 +134,6 @@
 		ctrl_bus5 = <1>;
 		post_divs = <3 0 0 0>;
 		use_post_divs = <1 1 1 1>;
-		max_freqs = <1650 0 0 0>;
 		status = "disabled";
 	};
 

--- a/dts/bindings/clock/tenstorrent,bh-clock-control.yaml
+++ b/dts/bindings/clock/tenstorrent,bh-clock-control.yaml
@@ -36,6 +36,3 @@ properties:
   use_post_divs:
     type: array
     required: true
-
-  max_freqs:
-    type: array

--- a/lib/tenstorrent/bh_arc/cat.c
+++ b/lib/tenstorrent/bh_arc/cat.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include "cat.h"
 #include "reg.h"
 #include "timer.h"
 #include "pvt.h"
@@ -21,7 +22,6 @@
 #define RESET_UNIT_CATMON_THERM_TRIP_CNTL_REG_DEFAULT 0x00000318
 
 #define CAT_EARLY_TRIP_TEMP 100
-#define T_J_SHUTDOWN        110 /* BH Prod Spec 7.3 */
 /* It would be more principled to use the nearly-worst-case 25C error
  * from the datasheet, but previously catmon was set to 100C.
  */

--- a/lib/tenstorrent/bh_arc/cat.h
+++ b/lib/tenstorrent/bh_arc/cat.h
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2025 Tenstorrent AI ULC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef CAT_H
+#define CAT_H
+
+#define T_J_SHUTDOWN 110 /* BH Prod Spec 7.3 */
+
+#endif

--- a/lib/tenstorrent/bh_arc/telemetry.h
+++ b/lib/tenstorrent/bh_arc/telemetry.h
@@ -24,7 +24,7 @@
 #define TAG_TDP                  7
 #define TAG_TDC                  8
 #define TAG_VDD_LIMITS           9
-#define TAG_THM_LIMITS           10
+#define TAG_THM_LIMIT_SHUTDOWN   10
 #define TAG_ASIC_TEMPERATURE     11
 #define TAG_VREG_TEMPERATURE     12
 #define TAG_BOARD_TEMPERATURE    13
@@ -69,11 +69,17 @@
 #define TAG_ASIC_LOCATION        52
 #define TAG_BOARD_POWER_LIMIT    53
 #define TAG_INPUT_POWER          54
+#define TAG_TDC_LIMIT_MAX        55
+#define TAG_THM_LIMIT_THROTTLE   56
+#define TAG_FW_BUILD_DATE        57
+#define TAG_TT_FLASH_VERSION     58
+#define TAG_ENABLED_TENSIX_ROW   59
 #define TAG_THERM_TRIP_COUNT     60
 #define TAG_ASIC_ID_HIGH         61
 #define TAG_ASIC_ID_LOW          62
-#define TAG_AICLK_MAX            63
-#define TAG_TDC_MAX              64
+#define TAG_AICLK_LIMIT_MAX      63
+#define TAG_TDP_LIMIT_MAX        64
+
 /* Not a real tag, signifies the last tag in the list.
  * MUST be incremented if new tags are defined.
  */


### PR DESCRIPTION
Get AICLK from firmware table instead of devicetree, and store VDD min and max in the VDD LIMITS tag.

cc @afongTT 