### PR TITLE
scripts: dmc_reset: fix Failed to reset DMC None error

### DIFF
--- a/scripts/dmc_reset.py
+++ b/scripts/dmc_reset.py
@@ -69,7 +69,6 @@ def parse_args():
     parser.add_argument(
         "-i",
         "--jtag-id",
-        default="auto",
         help="Specify the JTAG ID / serial number for the debug adapter",
         metavar="ID",
     )
@@ -258,11 +257,7 @@ def main():
     if args.debug > 0:
         logging.basicConfig(level=logging.DEBUG)
 
-    if not args.hw_map.is_file():
-        logger.info("No hardware map provided, using first ST-Link")
-        args.jtag_id = None
-
-    if args.jtag_id == "auto" and args.hw_map.is_file():
+    if args.jtag_id is None and args.hw_map.is_file():
         logger.debug("Auto-detecting JTAG ID..")
 
         try:


### PR DESCRIPTION
Previously, if I ran `./scripts/dmc_reset.py`, I would see this on a p100 machine. Not sure if it's the same everywhere.

```shell
./scripts/dmc_reset.py
Failed to reset DMC: None
```

Expanding the verbosity (with `-d`), i was able to determine if i took out `-c 'adapter serial auto'`, then the command would work as expected.

It seems like there was a minor inconsistency with using the default value "auto". Removing it seems to make the script work reliably again.