### PR TITLE
manifest: update revision for librpmi to remove build warning

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -13,7 +13,7 @@ manifest:
     - name: librpmi
       remote: cfriedt
       path: modules/lib/librpmi
-      revision: 8e36df098b5114201b5d7808ed8ffd056d9fe3a0
+      revision: e94e842eadc20e0269ae02d8d069de2604cd5f41
     - name: zephyr
       remote: zephyrproject-rtos
       revision: v4.2.0


### PR DESCRIPTION
Previously, builds would receive the following warning when CONFIG_RISCV_RPMI was not set.

```
CMake Warning at .../zephyr/CMakeLists.txt:1028 (message):
  No SOURCES given to Zephyr library: rpmi
```

Only name the rpmi library as a built-artifact when CONFIG_RISCV_RPMI=y.