### PR TITLE
gddr: adding comment for HW test to prevent removal

### DIFF
--- a/lib/tenstorrent/bh_arc/gddr.c
+++ b/lib/tenstorrent/bh_arc/gddr.c
@@ -399,6 +399,7 @@ static int gddr_training(void)
 	}
 
 	if (!init_errors) {
+		/* this is needed to securely wipe DRAM */
 		if (CheckGddrHwTest() < 0) {
 			LOG_ERR("GDDR HW test failed");
 			return -EIO;


### PR DESCRIPTION
Adding comment for HW mem test to prevent HW test being removed