### PR TITLE
tests: boards: tenstorrent: tt_blackhole: clock_control: test wider ranges

### DIFF
--- a/dts/arc/tenstorrent/tt_blackhole_smc.dtsi
+++ b/dts/arc/tenstorrent/tt_blackhole_smc.dtsi
@@ -128,7 +128,7 @@
 		#clock-cells = <0>;
 
 		refdiv = <2>;
-		postdiv = <0>;
+		postdiv = <1>;
 		fbdiv = <128>;
 		ctrl_bus1 = <0x18>;
 		ctrl_bus5 = <1>;
@@ -145,7 +145,7 @@
 		#clock-cells = <0>;
 
 		refdiv = <2>;
-		postdiv = <0>;
+		postdiv = <1>;
 		fbdiv = <192>;
 		ctrl_bus1 = <0x18>;
 		ctrl_bus5 = <1>;
@@ -162,7 +162,7 @@
 		#clock-cells = <0>;
 
 		refdiv = <2>;
-		postdiv = <0>;
+		postdiv = <1>;
 		fbdiv = <68>;
 		ctrl_bus1 = <0x18>;
 		ctrl_bus5 = <1>;
@@ -179,7 +179,7 @@
 		#clock-cells = <0>;
 
 		refdiv = <2>;
-		postdiv = <0>;
+		postdiv = <1>;
 		fbdiv = <120>;
 		ctrl_bus1 = <0x18>;
 		ctrl_bus5 = <1>;
@@ -196,7 +196,7 @@
 		#clock-cells = <0>;
 
 		refdiv = <2>;
-		postdiv = <0>;
+		postdiv = <1>;
 		fbdiv = <64>;
 		ctrl_bus1 = <0x18>;
 		ctrl_bus5 = <1>;

--- a/tests/boards/tenstorrent/tt_blackhole/clock_control/Kconfig
+++ b/tests/boards/tenstorrent/tt_blackhole/clock_control/Kconfig
@@ -1,0 +1,36 @@
+# Copyright (c) 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+menu "Clock control test options"
+
+config CLOCK_CTRL_TOLERANCE_PERCENT
+	int "Tolerance when asserting expected clock frequencies"
+	default 1
+
+config CLOCK_CTRL_GDDRCLK_MIN_RATE
+	int "Minimum rate to set GDDRCLK to"
+	default 750
+
+config CLOCK_CTRL_GDDRCLK_MAX_RATE
+	int "Maximum rate to set GDDRCLK to"
+	default 1000
+
+config CLOCK_CTRL_GDRRCLK_FREQ_INCR
+	int "Increment when changing frequencies for GDDRCLK"
+	default 50
+
+config CLOCK_CTRL_AICLK_MIN_RATE
+	int "Minimum rate to set AICLK to"
+	default 200
+
+config CLOCK_CTRL_AICLK_MAX_RATE
+	int "Maximum rate to set AICLK to"
+	default 1350
+
+config CLOCK_CTRL_AICLK_FREQ_INCR
+	int "Increment when changing frequencies for AICLK"
+	default 50
+
+endmenu
+
+source "Kconfig.zephyr"

--- a/tests/boards/tenstorrent/tt_blackhole/clock_control/prj.conf
+++ b/tests/boards/tenstorrent/tt_blackhole/clock_control/prj.conf
@@ -1,5 +1,4 @@
 CONFIG_ZTEST=y
 
-# enable clock control
+# enable plls
 CONFIG_CLOCK_CONTROL=y
-CONFIG_CLOCK_CONTROL_TT_BH=y


### PR DESCRIPTION
Test a wider range of frequencies for set AI and GDDR clock frequencies

Follow up to #462 