### PR TITLE
fan_ctrl: enabling forced fan speed msg for both chips

### DIFF
--- a/app/dmc/src/main.c
+++ b/app/dmc/src/main.c
@@ -31,7 +31,7 @@
 #include <tenstorrent/jtag_bootrom.h>
 #include <tenstorrent/tt_smbus_regs.h>
 
-#define RESET_UNIT_ARC_PC_CORE_0                0x80030C00
+#define RESET_UNIT_ARC_PC_CORE_0 0x80030C00
 
 LOG_MODULE_REGISTER(main, CONFIG_TT_APP_LOG_LEVEL);
 
@@ -48,6 +48,13 @@ static const struct device *const max6639_pwm_dev =
 	DEVICE_DT_GET_OR_NULL(DT_NODELABEL(max6639_pwm));
 static const struct device *const max6639_sensor_dev =
 	DEVICE_DT_GET_OR_NULL(DT_NODELABEL(max6639_sensor));
+
+#if BH_CHIP_COUNT == 2
+static uint8_t auto_fan_speed[BH_CHIP_COUNT] = {35, 35}; /* per–chip */
+#else
+static uint8_t auto_fan_speed[BH_CHIP_COUNT] = {35}; /* per–chip */
+#endif
+static uint8_t forced_fan_speed; /* 0-100 % */
 
 int update_fw(void)
 {
@@ -130,8 +137,25 @@ void process_cm2dm_message(struct bh_chip *chip)
 				uint8_t fan_speed_percentage = (uint8_t)message.data & 0xFF;
 				uint8_t fan_speed = (uint8_t)DIV_ROUND_UP(
 					fan_speed_percentage * UINT8_MAX, 100);
+				int chip_index = message.data >> 31;
 
 				pwm_set_cycles(max6639_pwm_dev, 0, UINT8_MAX, fan_speed, 0);
+				auto_fan_speed[chip_index] = fan_speed;
+			}
+			break;
+		case kCm2DmMsgIdForcedFanSpeedUpdate:
+			if (DT_NODE_HAS_STATUS(DT_ALIAS(fan0), okay)) {
+				uint8_t fan_speed_percentage = (uint8_t)message.data & 0xFF;
+				uint8_t fan_speed = (uint8_t)DIV_ROUND_UP(
+					fan_speed_percentage * UINT8_MAX, 100);
+				forced_fan_speed = fan_speed;
+
+				/* Broadcast forced speed to all CMFWs for telemetry */
+				for (int i = 0; i < BH_CHIP_COUNT; i++) {
+					bharc_smbus_word_data_write(&BH_CHIPS[i].config.arc,
+								    CMFW_SMBUS_FAN_SPEED,
+								    fan_speed_percentage);
+				}
 			}
 			break;
 		case kCm2DmMsgIdReady:
@@ -438,8 +462,7 @@ int main(void)
 				/* Read PC from ARC and record it */
 				jtag_setup(chip->config.jtag);
 				jtag_reset(chip->config.jtag);
-				jtag_axi_read32(chip->config.jtag,
-						RESET_UNIT_ARC_PC_CORE_0,
+				jtag_axi_read32(chip->config.jtag, RESET_UNIT_ARC_PC_CORE_0,
 						&chip->data.arc_hang_pc);
 				jtag_teardown(chip->config.jtag);
 				/* Clear watchdog state */
@@ -520,6 +543,17 @@ int main(void)
 
 			ARRAY_FOR_EACH_PTR(BH_CHIPS, chip) {
 				bh_chip_set_fan_rpm(chip, rpm);
+			}
+
+			if (forced_fan_speed != 0) {
+				pwm_set_cycles(max6639_pwm_dev, 0, UINT8_MAX, forced_fan_speed, 0);
+			} else {
+				uint8_t max_fan_speed = auto_fan_speed[0];
+
+				if (BH_CHIP_COUNT == 2) {
+					max_fan_speed = MAX(auto_fan_speed[0], auto_fan_speed[1]);
+				}
+				pwm_set_cycles(max6639_pwm_dev, 0, UINT8_MAX, max_fan_speed, 0);
 			}
 		}
 

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300A_L/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300A_L/fw_table.txt
@@ -24,7 +24,7 @@ feature_enable {
   aiclk_ppm_en: false
   watchdog_en: false
   smbus_en: false
-  fan_ctrl_en: false
+  fan_ctrl_en: true
   harvesting_en: true
 }
 

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300A_R/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300A_R/fw_table.txt
@@ -24,7 +24,7 @@ feature_enable {
   aiclk_ppm_en: false
   watchdog_en: false
   smbus_en: false
-  fan_ctrl_en: false
+  fan_ctrl_en: true
   harvesting_en: true
 }
 

--- a/boards/tenstorrent/tt_blackhole/tt_blackhole_tt_blackhole_dmc_p300a.yaml
+++ b/boards/tenstorrent/tt_blackhole/tt_blackhole_tt_blackhole_dmc_p300a.yaml
@@ -17,4 +17,6 @@ supported:
   - adc
   - i2c
   - dma
+  - mfd
+  - sensor
 vendor: tenstorrent

--- a/include/tenstorrent/bh_arc.h
+++ b/include/tenstorrent/bh_arc.h
@@ -20,6 +20,7 @@ typedef enum {
 	kCm2DmMsgIdReady = 4,
 	kCm2DmMsgIdAutoResetTimeoutUpdate = 5,
 	kCm2DmMsgTelemHeartbeatUpdate = 6,
+	kCm2DmMsgIdForcedFanSpeedUpdate = 7,
 	kCm2DmMsgCount
 } Cm2DmMsgId;
 

--- a/include/tenstorrent/tt_smbus_regs.h
+++ b/include/tenstorrent/tt_smbus_regs.h
@@ -24,8 +24,13 @@ enum CMFWSMBusReg {
 	CMFW_SMBUS_DM_STATIC_INFO = 0x20,
 	/* WO, 16 bits. Write with 0xA5A5 to respond to CMFW request `kCm2DmMsgIdPing` */
 	CMFW_SMBUS_PING = 0x21,
+	/* WO, 16 bits. Write with target fan speed percentage (0-100). Used by DMFW to broadcast
+	 * forced fan speed to every CMFW so that each chip's telemetry reflects the board-level
+	 * setting.
+	 */
+	CMFW_SMBUS_FAN_SPEED = 0x22,
 	/* WO, 16 bits. Write with fan speed to responsd to CMFW request
-	 * `kCm2DmMsgIdFanSpeedUpdate`
+	 * `kCm2DmMsgIdFanSpeedUpdate` or `kCm2DmMsgIdForcedFanSpeedUpdate`
 	 */
 	CMFW_SMBUS_FAN_RPM = 0x23,
 	/* WO, 16 bits. Write with input power limit for board */

--- a/lib/tenstorrent/bh_arc/cm2dm_msg.c
+++ b/lib/tenstorrent/bh_arc/cm2dm_msg.c
@@ -12,6 +12,7 @@
 
 #include <string.h>
 #include <zephyr/kernel.h>
+#include <zephyr/drivers/misc/bh_fwtable.h>
 #include <zephyr/drivers/watchdog.h>
 #include <zephyr/sys/byteorder.h>
 #include <tenstorrent/msg_type.h>
@@ -133,7 +134,16 @@ void ChipResetRequest(void *arg)
 
 void UpdateFanSpeedRequest(uint32_t fan_speed)
 {
-	PostCm2DmMsg(kCm2DmMsgIdFanSpeedUpdate, fan_speed);
+	uint32_t left_chip = tt_bh_fwtable_is_p300_left_chip();
+
+	PostCm2DmMsg(kCm2DmMsgIdFanSpeedUpdate, left_chip * BIT(31) + fan_speed);
+}
+
+void UpdateForcedFanSpeedRequest(uint32_t fan_speed)
+{
+	uint32_t left_chip = tt_bh_fwtable_is_p300_left_chip();
+
+	PostCm2DmMsg(kCm2DmMsgIdForcedFanSpeedUpdate, left_chip * BIT(31) + fan_speed);
 }
 
 void Dm2CmReadyRequest(void)

--- a/lib/tenstorrent/bh_arc/cm2dm_msg.h
+++ b/lib/tenstorrent/bh_arc/cm2dm_msg.h
@@ -16,6 +16,7 @@ int32_t Cm2DmMsgAckSmbusHandler(const uint8_t *data, uint8_t size);
 
 void ChipResetRequest(void *arg);
 void UpdateFanSpeedRequest(uint32_t fan_speed);
+void UpdateForcedFanSpeedRequest(uint32_t fan_speed);
 void Dm2CmReadyRequest(void);
 void UpdateAutoResetTimeoutRequest(uint32_t timeout);
 void UpdateTelemHeartbeatRequest(uint32_t heartbeat);

--- a/lib/tenstorrent/bh_arc/fan_ctrl.c
+++ b/lib/tenstorrent/bh_arc/fan_ctrl.c
@@ -132,18 +132,46 @@ void init_fan_ctrl(void)
 static uint8_t force_fan_speed(uint32_t msg_code, const struct request *request,
 			       struct response *response)
 {
-	if (tt_bh_fwtable_get_fw_table(fwtable_dev)->feature_enable.fan_ctrl_en) {
-		if (request->data[1] == 0xFFFFFFFF) { /* unforce */
-			k_timer_start(&fan_ctrl_update_timer, K_MSEC(fan_ctrl_update_interval),
-				      K_MSEC(fan_ctrl_update_interval));
-		} else { /* force */
-			k_timer_stop(&fan_ctrl_update_timer);
-			fan_speed = request->data[1];
-			UpdateFanSpeedRequest(fan_speed);
-		}
-		return 0;
+	if (!tt_bh_fwtable_get_fw_table(fwtable_dev)->feature_enable.fan_ctrl_en) {
+		return 1;
 	}
 
-	return 1;
+	uint32_t raw_speed = request->data[1];
+	uint32_t speed_percentage = (raw_speed == 0xFFFFFFFF) ? 0 : raw_speed;
+
+	/* Re-use common helper so behaviour stays identical. We ask it to notify the DMFW because
+	 * this path originated from a host command.
+	 */
+	FanCtrlApplyBoardForcedSpeed(speed_percentage);
+
+	/* The helper does NOT send the update back, so we do it here for the host path. */
+	if (speed_percentage == 0) {
+		UpdateForcedFanSpeedRequest(0);
+	} else {
+		UpdateForcedFanSpeedRequest(speed_percentage);
+	}
+
+	return 0;
 }
 REGISTER_MESSAGE(MSG_TYPE_FORCE_FAN_SPEED, force_fan_speed);
+
+/*
+ * Board-level broadcast from the DMFW arrives via SMBus. We must update local state and telemetry
+ * but MUST NOT send another ForcedFanSpeedUpdate back to the DMFW (would cause an echo).
+ */
+void FanCtrlApplyBoardForcedSpeed(uint32_t speed_percentage)
+{
+	if (!tt_bh_fwtable_get_fw_table(fwtable_dev)->feature_enable.fan_ctrl_en) {
+		return;
+	}
+
+	if (speed_percentage == 0) {
+		/* Unforce – return to automatic control */
+		k_timer_start(&fan_ctrl_update_timer, K_MSEC(fan_ctrl_update_interval),
+			      K_MSEC(fan_ctrl_update_interval));
+	} else {
+		/* Force – stop automatic updates and lock the speed */
+		k_timer_stop(&fan_ctrl_update_timer);
+		fan_speed = speed_percentage;
+	}
+}

--- a/lib/tenstorrent/bh_arc/fan_ctrl.h
+++ b/lib/tenstorrent/bh_arc/fan_ctrl.h
@@ -13,4 +13,10 @@ uint32_t GetFanSpeed(void);
 uint16_t GetFanRPM(void);
 void SetFanRPM(uint16_t rpm);
 
+/*
+ * Apply a board-level forced fan speed coming from the DMFW. The value is a percentage in the
+ * range 0-100. A value of 0 means "unforce" (return to automatic control).
+ */
+void FanCtrlApplyBoardForcedSpeed(uint32_t speed_percentage);
+
 #endif


### PR DESCRIPTION
Depends on https://github.com/tenstorrent/tt-zephyr-platforms/pull/413

This branch includes changes to senable fan control on the P300A.

**Fan controller test output:**

Initial read from the fan controller:
```
Target fan speed: 36%
Actual fan RPM: 2274 RPM
```

After forcing the fan speed to 50% and reading back:
```
(my-env) xiaoruli@yyz-syseng-36:~/work/syseng/src/t6ifc/t6py$ python packages/tenstorrent/scripts/tensix_sm/fan/fan_control.py --read --interface pci:1
Target fan speed: 50%
Actual fan RPM: 3018 RPM
```