### PR TITLE
sys_init: centralize sys_init prio

### DIFF
--- a/app/smc/src/main.c
+++ b/app/smc/src/main.c
@@ -18,6 +18,7 @@
 #include <app_version.h>
 #include <tenstorrent/msgqueue.h>
 #include <tenstorrent/post_code.h>
+#include <tenstorrent/sys_init_defines.h>
 #include <zephyr/init.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
@@ -118,7 +119,7 @@ static int bh_arc_init_start(void)
 
 	return 0;
 }
-SYS_INIT(bh_arc_init_start, APPLICATION, 3);
+SYS_INIT_APP(bh_arc_init_start);
 
 int tt_init_status;
 
@@ -140,4 +141,4 @@ static int bh_arc_init_end(void)
 
 	return 0;
 }
-SYS_INIT(bh_arc_init_end, APPLICATION, 22);
+SYS_INIT_APP(bh_arc_init_end);

--- a/include/tenstorrent/sys_init_defines.h
+++ b/include/tenstorrent/sys_init_defines.h
@@ -10,30 +10,30 @@
 #include <zephyr/init.h>
 
 /* SYS_INIT APPLICATION defines */
-#define register_interrupt_handlers_PRIO       0
-#define arc_dma_init_PRIO                      1
-#define InitSpiFS_PRIO                         2
-#define bh_arc_init_start_PRIO                 3
-#define CATEarlyInit_PRIO                      4
-#define CalculateHarvesting_PRIO               5
-#define DeassertTileResets_PRIO                6
-#define PLLInit_PRIO                           7
-#define PVTInit_PRIO                           8
-#define NocInit_PRIO                           9
-#define AssertSoftResets_PRIO                  10
-#define DeassertRiscvResets_PRIO               11
-#define InitAiclkPPM_PRIO                      12
-#define pcie_init_PRIO                         13
-#define InitMrisc_PRIO                         14
-#define eth_init_PRIO                          15
-#define InitSmbusTarget_PRIO                   16
-#define regulator_init_PRIO                    16
-#define avs_init_PRIO                          17
-#define tensix_cg_init_PRIO                    18
-#define InitNocTranslationFromHarvesting_PRIO  19
-#define gddr_training_PRIO                     20
-#define CATInit_PRIO                           20
-#define bh_arc_init_end_PRIO                   21
+#define register_interrupt_handlers_PRIO      0
+#define arc_dma_init_PRIO                     1
+#define InitSpiFS_PRIO                        2
+#define bh_arc_init_start_PRIO                3
+#define CATEarlyInit_PRIO                     4
+#define CalculateHarvesting_PRIO              5
+#define DeassertTileResets_PRIO               6
+#define PLLInit_PRIO                          7
+#define PVTInit_PRIO                          8
+#define NocInit_PRIO                          9
+#define AssertSoftResets_PRIO                 10
+#define DeassertRiscvResets_PRIO              11
+#define InitAiclkPPM_PRIO                     12
+#define pcie_init_PRIO                        13
+#define InitMrisc_PRIO                        14
+#define eth_init_PRIO                         15
+#define InitSmbusTarget_PRIO                  16
+#define regulator_init_PRIO                   17
+#define avs_init_PRIO                         18
+#define tensix_cg_init_PRIO                   19
+#define InitNocTranslationFromHarvesting_PRIO 20
+#define gddr_training_PRIO                    21
+#define CATInit_PRIO                          22
+#define bh_arc_init_end_PRIO                  23
 
 #define SYS_INIT_APP(func) SYS_INIT(func, APPLICATION, func##_PRIO)
 

--- a/include/tenstorrent/sys_init_defines.h
+++ b/include/tenstorrent/sys_init_defines.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2024 Tenstorrent AI ULC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef TENSTORRENT_SYS_INIT_DEFINES_H_
+#define TENSTORRENT_SYS_INIT_DEFINES_H_
+
+#include <zephyr/init.h>
+
+/* SYS_INIT APPLICATION defines */
+#define register_interrupt_handlers_PRIO       0
+#define arc_dma_init_PRIO                      1
+#define InitSpiFS_PRIO                         2
+#define bh_arc_init_start_PRIO                 3
+#define CATEarlyInit_PRIO                      4
+#define CalculateHarvesting_PRIO               5
+#define DeassertTileResets_PRIO                6
+#define PLLInit_PRIO                           7
+#define PVTInit_PRIO                           8
+#define NocInit_PRIO                           9
+#define AssertSoftResets_PRIO                  10
+#define DeassertRiscvResets_PRIO               11
+#define InitAiclkPPM_PRIO                      12
+#define pcie_init_PRIO                         13
+#define InitMrisc_PRIO                         14
+#define eth_init_PRIO                          15
+#define InitSmbusTarget_PRIO                   16
+#define regulator_init_PRIO                    16
+#define avs_init_PRIO                          17
+#define tensix_cg_init_PRIO                    18
+#define InitNocTranslationFromHarvesting_PRIO  19
+#define gddr_training_PRIO                     20
+#define CATInit_PRIO                           20
+#define bh_arc_init_end_PRIO                   21
+
+#define SYS_INIT_APP(func) SYS_INIT(func, APPLICATION, func##_PRIO)
+
+#endif

--- a/lib/tenstorrent/bh_arc/aiclk_ppm.c
+++ b/lib/tenstorrent/bh_arc/aiclk_ppm.c
@@ -13,6 +13,7 @@
 
 #include <tenstorrent/msg_type.h>
 #include <tenstorrent/msgqueue.h>
+#include <tenstorrent/sys_init_defines.h>
 #include <zephyr/init.h>
 #include <zephyr/drivers/misc/bh_fwtable.h>
 #include <zephyr/sys/util.h>
@@ -189,7 +190,7 @@ static int InitAiclkPPM(void)
 
 	return 0;
 }
-SYS_INIT(InitAiclkPPM, APPLICATION, 12);
+SYS_INIT_APP(InitAiclkPPM);
 
 uint8_t ForceAiclk(uint32_t freq)
 {

--- a/lib/tenstorrent/bh_arc/arc_dma.c
+++ b/lib/tenstorrent/bh_arc/arc_dma.c
@@ -8,6 +8,7 @@
 #include "arc.h"
 #include "timer.h"
 
+#include <tenstorrent/sys_init_defines.h>
 #include <zephyr/init.h>
 
 void ArcDmaConfig(void)
@@ -99,4 +100,4 @@ static int arc_dma_init(void)
 	ArcDmaInitCh(0, 0, 15);
 	return 0;
 }
-SYS_INIT(arc_dma_init, APPLICATION, 1);
+SYS_INIT_APP(arc_dma_init);

--- a/lib/tenstorrent/bh_arc/avs.c
+++ b/lib/tenstorrent/bh_arc/avs.c
@@ -7,6 +7,7 @@
 #include "avs.h"
 #include "regulator.h"
 
+#include <tenstorrent/sys_init_defines.h>
 #include <zephyr/init.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/device.h>
@@ -312,4 +313,4 @@ static int avs_init(void)
 
 	return 0;
 }
-SYS_INIT(avs_init, APPLICATION, 17);
+SYS_INIT_APP(avs_init);

--- a/lib/tenstorrent/bh_arc/cat.c
+++ b/lib/tenstorrent/bh_arc/cat.c
@@ -12,6 +12,7 @@
 #include <stdbool.h>
 
 #include <tenstorrent/post_code.h>
+#include <tenstorrent/sys_init_defines.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/init.h>
@@ -107,7 +108,7 @@ static int CATEarlyInit(void)
 	EnableCAT(TempToTrimCode(CAT_EARLY_TRIP_TEMP), true);
 	return 0;
 }
-SYS_INIT(CATEarlyInit, APPLICATION, 4);
+SYS_INIT_APP(CATEarlyInit);
 
 #ifndef CONFIG_TT_SMC_RECOVERY
 /* Calibrate catmon against thermal sensors by looping over the
@@ -167,5 +168,5 @@ static int CATInit(void)
 	EnableCAT(TempToTrimCode(T_J_SHUTDOWN + catmon_error), true);
 	return 0;
 }
-SYS_INIT(CATInit, APPLICATION, 20);
+SYS_INIT_APP(CATInit);
 #endif

--- a/lib/tenstorrent/bh_arc/eth.c
+++ b/lib/tenstorrent/bh_arc/eth.c
@@ -14,6 +14,7 @@
 #include "serdes_eth.h"
 
 #include <tenstorrent/post_code.h>
+#include <tenstorrent/sys_init_defines.h>
 #include <tenstorrent/tt_boot_fs.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
@@ -371,4 +372,4 @@ static int eth_init(void)
 
 	return 0;
 }
-SYS_INIT(eth_init, APPLICATION, 15);
+SYS_INIT_APP(eth_init);

--- a/lib/tenstorrent/bh_arc/gddr.c
+++ b/lib/tenstorrent/bh_arc/gddr.c
@@ -13,6 +13,7 @@
 #include "reg.h"
 
 #include <tenstorrent/post_code.h>
+#include <tenstorrent/sys_init_defines.h>
 #include <tenstorrent/tt_boot_fs.h>
 #include <zephyr/drivers/misc/bh_fwtable.h>
 #include <zephyr/init.h>
@@ -305,7 +306,7 @@ static int InitMrisc(void)
 
 	return 0;
 }
-SYS_INIT(InitMrisc, APPLICATION, 14);
+SYS_INIT_APP(InitMrisc);
 
 static int CheckGddrTraining(uint8_t gddr_inst, k_timepoint_t timeout)
 {
@@ -408,4 +409,4 @@ static int gddr_training(void)
 
 	return 0;
 }
-SYS_INIT(gddr_training, APPLICATION, 20);
+SYS_INIT_APP(gddr_training);

--- a/lib/tenstorrent/bh_arc/harvesting.c
+++ b/lib/tenstorrent/bh_arc/harvesting.c
@@ -8,6 +8,7 @@
 #include "harvesting.h"
 #include "noc.h"
 
+#include <tenstorrent/sys_init_defines.h>
 #include <zephyr/drivers/misc/bh_fwtable.h>
 #include <zephyr/init.h>
 #include <zephyr/sys/util.h>
@@ -262,4 +263,4 @@ static int CalculateHarvesting(void)
 
 	return 0;
 }
-SYS_INIT(CalculateHarvesting, APPLICATION, 5);
+SYS_INIT_APP(CalculateHarvesting);

--- a/lib/tenstorrent/bh_arc/msgqueue.c
+++ b/lib/tenstorrent/bh_arc/msgqueue.c
@@ -12,8 +12,9 @@
 #include <zephyr/kernel.h>
 
 #include <tenstorrent/msgqueue.h>
-#include <tenstorrent/post_code.h>
 #include <tenstorrent/msg_type.h>
+#include <tenstorrent/post_code.h>
+#include <tenstorrent/sys_init_defines.h>
 #include "status_reg.h"
 #include "reg.h"
 #include "irqnum.h"
@@ -374,7 +375,7 @@ static int register_interrupt_handlers(void)
 	return 0;
 }
 
-SYS_INIT(register_interrupt_handlers, APPLICATION, 0);
+SYS_INIT_APP(register_interrupt_handlers);
 #endif
 
 #ifdef CONFIG_BOARD_TT_BLACKHOLE

--- a/lib/tenstorrent/bh_arc/noc_init.c
+++ b/lib/tenstorrent/bh_arc/noc_init.c
@@ -17,6 +17,7 @@
 
 #include <tenstorrent/msgqueue.h>
 #include <tenstorrent/msg_type.h>
+#include <tenstorrent/sys_init_defines.h>
 #include <zephyr/drivers/misc/bh_fwtable.h>
 #include <zephyr/init.h>
 #include <zephyr/kernel.h>
@@ -222,7 +223,7 @@ int NocInit(void)
 
 	return 0;
 }
-SYS_INIT(NocInit, APPLICATION, 9);
+SYS_INIT_APP(NocInit);
 
 #define PRE_TRANSLATION_SIZE 32
 
@@ -594,7 +595,7 @@ int InitNocTranslationFromHarvesting(void)
 
 	return 0;
 }
-SYS_INIT(InitNocTranslationFromHarvesting, APPLICATION, 19);
+SYS_INIT_APP(InitNocTranslationFromHarvesting);
 
 static void DisableArcNocTranslation(void)
 {

--- a/lib/tenstorrent/bh_arc/pcie.c
+++ b/lib/tenstorrent/bh_arc/pcie.c
@@ -17,6 +17,7 @@
 #include <stdbool.h>
 
 #include <tenstorrent/post_code.h>
+#include <tenstorrent/sys_init_defines.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/misc/bh_fwtable.h>
 #include <zephyr/init.h>
@@ -412,4 +413,4 @@ static int pcie_init(void)
 
 	return 0;
 }
-SYS_INIT(pcie_init, APPLICATION, 13);
+SYS_INIT_APP(pcie_init);

--- a/lib/tenstorrent/bh_arc/pll.c
+++ b/lib/tenstorrent/bh_arc/pll.c
@@ -11,6 +11,7 @@
 #include <stdbool.h>
 
 #include <tenstorrent/post_code.h>
+#include <tenstorrent/sys_init_defines.h>
 #include <zephyr/init.h>
 #include <zephyr/sys/util.h>
 
@@ -408,7 +409,7 @@ int PLLInit(void)
 
 	return 0;
 }
-SYS_INIT(PLLInit, APPLICATION, 7);
+SYS_INIT_APP(PLLInit);
 
 uint32_t GetExtPostdiv(uint8_t postdiv_index, PLL_CNTL_PLL_CNTL_5_reg_u pll_cntl_5,
 		       PLL_CNTL_USE_POSTDIV_reg_u use_postdiv)

--- a/lib/tenstorrent/bh_arc/pvt.c
+++ b/lib/tenstorrent/bh_arc/pvt.c
@@ -11,11 +11,12 @@
 
 #include <float.h> /* for FLT_MAX */
 
-#include <zephyr/init.h>
-#include <zephyr/kernel.h>
 #include <tenstorrent/msg_type.h>
 #include <tenstorrent/msgqueue.h>
 #include <tenstorrent/post_code.h>
+#include <tenstorrent/sys_init_defines.h>
+#include <zephyr/init.h>
+#include <zephyr/kernel.h>
 #include <zephyr/device.h>
 #include <zephyr/devicetree.h>
 #include <zephyr/drivers/clock_control/clock_control_tt_bh.h>
@@ -449,7 +450,7 @@ static int PVTInit(void)
 
 	return 0;
 }
-SYS_INIT(PVTInit, APPLICATION, 8);
+SYS_INIT_APP(PVTInit);
 
 static uint32_t get_pvt_addr(PvtType type, uint32_t id, uint32_t base_addr)
 {

--- a/lib/tenstorrent/bh_arc/regulator.c
+++ b/lib/tenstorrent/bh_arc/regulator.c
@@ -18,6 +18,7 @@
 #include <tenstorrent/msg_type.h>
 #include <tenstorrent/msgqueue.h>
 #include <tenstorrent/post_code.h>
+#include <tenstorrent/sys_init_defines.h>
 #include <zephyr/init.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
@@ -353,4 +354,4 @@ static int regulator_init(void)
 
 	return 0;
 }
-SYS_INIT(regulator_init, APPLICATION, 16);
+SYS_INIT_APP(regulator_init);

--- a/lib/tenstorrent/bh_arc/reset.c
+++ b/lib/tenstorrent/bh_arc/reset.c
@@ -22,6 +22,7 @@
 #include <tenstorrent/msgqueue.h>
 #include <tenstorrent/msg_type.h>
 #include <tenstorrent/post_code.h>
+#include <tenstorrent/sys_init_defines.h>
 #include <tenstorrent/tt_boot_fs.h>
 #include <zephyr/drivers/misc/bh_fwtable.h>
 #include <zephyr/init.h>
@@ -96,7 +97,7 @@ static int AssertSoftResets(void)
 
 	return 0;
 }
-SYS_INIT(AssertSoftResets, APPLICATION, 10);
+SYS_INIT_APP(AssertSoftResets);
 
 /* Deassert RISC reset from reset_unit for all RISC-V cores */
 /* L2CPU is skipped due to JIRA issues BH-25 and BH-28 */
@@ -139,7 +140,7 @@ static int DeassertRiscvResets(void)
 
 	return 0;
 }
-SYS_INIT(DeassertRiscvResets, APPLICATION, 11);
+SYS_INIT_APP(DeassertRiscvResets);
 
 static __maybe_unused uint8_t ToggleTensixReset(uint32_t msg_code, const struct request *req,
 						struct response *rsp)
@@ -237,4 +238,4 @@ static int DeassertTileResets(void)
 
 	return 0;
 }
-SYS_INIT(DeassertTileResets, APPLICATION, 6);
+SYS_INIT_APP(DeassertTileResets);

--- a/lib/tenstorrent/bh_arc/smbus_target.c
+++ b/lib/tenstorrent/bh_arc/smbus_target.c
@@ -16,6 +16,7 @@
 #include <stdint.h>
 
 #include <tenstorrent/post_code.h>
+#include <tenstorrent/sys_init_defines.h>
 #include <tenstorrent/tt_smbus_regs.h>
 #include <zephyr/kernel.h>
 #include <zephyr/init.h>
@@ -532,7 +533,7 @@ static int InitSmbusTarget(void)
 	i2c_target_register(i2c0_dev, &i2c_target_config_impl);
 	return 0;
 }
-SYS_INIT(InitSmbusTarget, APPLICATION, 16);
+SYS_INIT_APP(InitSmbusTarget);
 
 void PollSmbusTarget(void)
 {

--- a/lib/tenstorrent/bh_arc/spi_eeprom.c
+++ b/lib/tenstorrent/bh_arc/spi_eeprom.c
@@ -13,6 +13,7 @@
 
 #include <tenstorrent/msg_type.h>
 #include <tenstorrent/msgqueue.h>
+#include <tenstorrent/sys_init_defines.h>
 #include <tenstorrent/tt_boot_fs.h>
 #include <zephyr/drivers/mspi.h>
 #include <zephyr/drivers/flash.h>
@@ -217,4 +218,4 @@ static int InitSpiFS(void)
 	tt_boot_fs_mount(&boot_fs_data, SpiReadWrap, NULL, NULL);
 	return 0;
 }
-SYS_INIT(InitSpiFS, APPLICATION, 2);
+SYS_INIT_APP(InitSpiFS);

--- a/lib/tenstorrent/bh_arc/tensix_cg.c
+++ b/lib/tenstorrent/bh_arc/tensix_cg.c
@@ -9,6 +9,7 @@
 #include <stdint.h>
 
 #include <tenstorrent/post_code.h>
+#include <tenstorrent/sys_init_defines.h>
 #include <zephyr/drivers/misc/bh_fwtable.h>
 #include <zephyr/init.h>
 
@@ -78,4 +79,4 @@ static int tensix_cg_init(void)
 
 	return 0;
 }
-SYS_INIT(tensix_cg_init, APPLICATION, 18);
+SYS_INIT_APP(tensix_cg_init);


### PR DESCRIPTION
It is painful currently to insert a SYS_INIT step between two steps, it requires manually editing all the files that does SYS_INIT. Centralizing SYS_INIT priorities so that only one file edit is needed.