### PR TITLE
doc: migration: 18.8: bump pyluwen to >= 0.7.11

### DIFF
--- a/doc/release/migration-guide-18.8.md
+++ b/doc/release/migration-guide-18.8.md
@@ -6,7 +6,7 @@ This document lists recommended and required changes for those migrating from th
 
 [comment]: <> (UL by area, indented as necessary)
 
-* Update `luwen`, `tt-smi` and `tt-flash` to support more firmware telemetry values being added.
-  * `luwen` >= 0.7.2
+* Update `pyluwen`, `tt-smi` and `tt-flash` to support more firmware telemetry values being added.
+  * `pyluwen` >= 0.7.11
   * `tt-smi` >= v3.0.22
   * `tt-flash` >= v3.3.4


### PR DESCRIPTION
Our CI requires that we [manually install a version of pyluwen that is explicitly > 0.7.9](https://github.com/tenstorrent/tt-zephyr-platforms/blob/7b1c0886df959cb26af514262de777faf19478aa/.github/workflows/prepare-zephyr/action.yml#L92).

The exact revision is `d20b8d6f64c0`, which is sometime after 0.7.9 according to [Cargo.toml](https://github.com/tenstorrent/luwen/blob/d20b8d6f64c06fe01f0734d1dd5c0a669f4fa29a/crates/pyluwen/Cargo.toml).

To be sure that we communicate to end users what the required minimum version of pyluwen is, suggest [the latest version available from pypi.org which is 0.7.11](https://pypi.org/project/pyluwen/0.7.11/).