### PR TITLE
lib: tenstorrent: bh_arc: Fix BWBR PEC

### DIFF
--- a/include/tenstorrent/tt_smbus_regs.h
+++ b/include/tenstorrent/tt_smbus_regs.h
@@ -55,6 +55,8 @@ enum CMFWSMBusReg {
 	CMFW_SMBUS_TEST_READ_BLOCK = 0xDC,
 	/* WO, 32 bits. Write to CMFW scratch register */
 	CMFW_SMBUS_TEST_WRITE_BLOCK = 0xDD,
+	/* WR, 32 bits I/O. Write to CMFW scratch register and read it back. */
+	CMFW_SMBUS_TEST_WRITE_BLOCK_READ_BLOCK = 0xDE,
 	CMFW_SMBUS_MSG_MAX,
 };
 

--- a/tests/lib/tenstorrent/bh_arc/src/smbus_target.c
+++ b/tests/lib/tenstorrent/bh_arc/src/smbus_target.c
@@ -231,4 +231,14 @@ ZTEST(smbus_target, test_telem_write_no_reset)
 	zexpect_equal(0U, ctl);
 }
 
+ZTEST(smbus_target, test_block_write_block_read_with_pec)
+{
+	uint8_t write_data[] = {0xDE, 4, 0xde, 0xad, 0xbe, 0xef};
+	uint8_t read_data[6];
+
+	zassert_equal(0, i2c_write_read(i2c0_dev, tt_i2c_addr, write_data, sizeof(write_data),
+					read_data, sizeof(read_data)));
+	zexpect_equal(4, read_data[0]);
+}
+
 ZTEST_SUITE(smbus_target, NULL, NULL, NULL, tear_down_tc, NULL);


### PR DESCRIPTION
SMBUS spec indicates that, for block-write-block-read transactions, the PEC is only present on the end of the read phase (and covers all of the transaction.) The bug before was that we were also expecting a PEC byte during the write phase, which is incorrect.

Add a test command to cover this case and a testcase in native_sim.

Note this doesn't affect our ODM because all their commands have PEC = 0.