### PR TITLE
boards: tenstorrent: define all DMC board revisions

### DIFF
--- a/app/smc/Kconfig.sysbuild
+++ b/app/smc/Kconfig.sysbuild
@@ -6,7 +6,11 @@ source "share/sysbuild/Kconfig"
 
 config DMC_BOARD
 	string "DMC Board"
-	default "tt_blackhole@p150a/tt_blackhole/dmc" if $(BOARD_REVISION) = "p150a" || $(BOARD_REVISION) = "p150b" || $(BOARD_REVISION) = "p150c"
+	default "tt_blackhole@p150a/tt_blackhole/dmc" if $(BOARD_REVISION) = "p150a"
+	default "tt_blackhole@p150b/tt_blackhole/dmc" if $(BOARD_REVISION) = "p150b"
+	default "tt_blackhole@p150c/tt_blackhole/dmc" if $(BOARD_REVISION) = "p150c"
 	default "tt_blackhole@p100a/tt_blackhole/dmc" if $(BOARD_REVISION) = "p100a"
 	default "tt_blackhole@p100/tt_blackhole/dmc" if $(BOARD_REVISION) = "p100"
-	default "tt_blackhole@p300a/tt_blackhole/dmc" if $(BOARD_REVISION) = "p300a" || $(BOARD_REVISION) = "p300b" || $(BOARD_REVISION) = "p300c"
+	default "tt_blackhole@p300a/tt_blackhole/dmc" if $(BOARD_REVISION) = "p300a"
+	default "tt_blackhole@p300b/tt_blackhole/dmc" if $(BOARD_REVISION) = "p300b"
+	default "tt_blackhole@p300c/tt_blackhole/dmc" if $(BOARD_REVISION) = "p300c"

--- a/boards/tenstorrent/tt_blackhole/tt_blackhole_tt_blackhole_dmc_p150b.yaml
+++ b/boards/tenstorrent/tt_blackhole/tt_blackhole_tt_blackhole_dmc_p150b.yaml
@@ -1,0 +1,22 @@
+identifier: tt_blackhole@p150b/tt_blackhole/dmc
+name: Tenstorrent Blackhole P150B board (DMC)
+type: mcu
+arch: arm
+toolchain:
+  - zephyr
+  - gnuarmemb
+  - xtools
+sysbuild: true
+ram: 144
+flash: 512
+supported:
+  - gpio
+  - counter
+  - watchdog
+  - pwm
+  - adc
+  - i2c
+  - dma
+  - mfd
+  - sensor
+vendor: tenstorrent

--- a/boards/tenstorrent/tt_blackhole/tt_blackhole_tt_blackhole_dmc_p150c.yaml
+++ b/boards/tenstorrent/tt_blackhole/tt_blackhole_tt_blackhole_dmc_p150c.yaml
@@ -1,0 +1,22 @@
+identifier: tt_blackhole@p150c/tt_blackhole/dmc
+name: Tenstorrent Blackhole P150C board (DMC)
+type: mcu
+arch: arm
+toolchain:
+  - zephyr
+  - gnuarmemb
+  - xtools
+sysbuild: true
+ram: 144
+flash: 512
+supported:
+  - gpio
+  - counter
+  - watchdog
+  - pwm
+  - adc
+  - i2c
+  - dma
+  - mfd
+  - sensor
+vendor: tenstorrent

--- a/boards/tenstorrent/tt_blackhole/tt_blackhole_tt_blackhole_dmc_p300b.overlay
+++ b/boards/tenstorrent/tt_blackhole/tt_blackhole_tt_blackhole_dmc_p300b.overlay
@@ -1,0 +1,6 @@
+/*
+ * Copyright (c) 2025 Tenstorrent AI ULC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include "tt_blackhole_tt_blackhole_dmc_p300a.overlay"

--- a/boards/tenstorrent/tt_blackhole/tt_blackhole_tt_blackhole_dmc_p300b.yaml
+++ b/boards/tenstorrent/tt_blackhole/tt_blackhole_tt_blackhole_dmc_p300b.yaml
@@ -1,0 +1,22 @@
+identifier: tt_blackhole@p300b/tt_blackhole/dmc
+name: Tenstorrent Blackhole P300 board (DMC)
+type: mcu
+arch: arm
+toolchain:
+  - zephyr
+  - gnuarmemb
+  - xtools
+sysbuild: true
+ram: 144
+flash: 512
+supported:
+  - gpio
+  - counter
+  - watchdog
+  - pwm
+  - adc
+  - i2c
+  - dma
+  - mfd
+  - sensor
+vendor: tenstorrent

--- a/boards/tenstorrent/tt_blackhole/tt_blackhole_tt_blackhole_dmc_p300c.overlay
+++ b/boards/tenstorrent/tt_blackhole/tt_blackhole_tt_blackhole_dmc_p300c.overlay
@@ -1,0 +1,6 @@
+/*
+ * Copyright (c) 2025 Tenstorrent AI ULC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include "tt_blackhole_tt_blackhole_dmc_p300a.overlay"

--- a/boards/tenstorrent/tt_blackhole/tt_blackhole_tt_blackhole_dmc_p300c.yaml
+++ b/boards/tenstorrent/tt_blackhole/tt_blackhole_tt_blackhole_dmc_p300c.yaml
@@ -1,0 +1,22 @@
+identifier: tt_blackhole@p300c/tt_blackhole/dmc
+name: Tenstorrent Blackhole P300 board (DMC)
+type: mcu
+arch: arm
+toolchain:
+  - zephyr
+  - gnuarmemb
+  - xtools
+sysbuild: true
+ram: 144
+flash: 512
+supported:
+  - gpio
+  - counter
+  - watchdog
+  - pwm
+  - adc
+  - i2c
+  - dma
+  - mfd
+  - sensor
+vendor: tenstorrent


### PR DESCRIPTION
Define all DMC board revisions, so that the DMFW can be built targeting P150A/B/C (or equivalent for P300)