### PR TITLE
lib: tenstorrent: bh_arc: support running NOC code in native_sim

### DIFF
--- a/lib/tenstorrent/bh_arc/noc2axi.c
+++ b/lib/tenstorrent/bh_arc/noc2axi.c
@@ -7,8 +7,6 @@
 #include "noc.h"
 #include "noc2axi.h"
 
-#define NIU_0_A_REG_MAP_BASE_ADDR 0x80050000
-
 typedef struct {
 	uint32_t passthrough_bits: 24;
 	uint32_t lower_addr_bits: 8;
@@ -62,6 +60,15 @@ typedef union {
 #define NOC2AXI_NUM_TLB_PER_RING 16
 #define RING0_TLB_REG_OFFSET     0x1000
 #define AXI2NOC_RING_SEL_BIT     15
+
+#ifdef CONFIG_BOARD_NATIVE_SIM
+#define NIU0_A_REG_SPACE_SIZE 0x10000
+/* Running within simulation. Fake out TLB register space */
+static uint8_t fake_niu_reg_space[NIU0_A_REG_SPACE_SIZE];
+#define NIU_0_A_REG_MAP_BASE_ADDR ((uintptr_t)fake_niu_reg_space)
+#else
+#define NIU_0_A_REG_MAP_BASE_ADDR 0x80050000
+#endif
 
 static inline uint32_t volatile *GetTlbRegStartAddr(const uint8_t ring)
 {

--- a/lib/tenstorrent/bh_arc/noc2axi.h
+++ b/lib/tenstorrent/bh_arc/noc2axi.h
@@ -7,9 +7,18 @@
 #define NOC2AXI_H
 
 #include <stdint.h>
+#include <zephyr/sys/util.h>
 
+#ifdef CONFIG_BOARD_NATIVE_SIM
+/* Fake out both NOC address spaces (16 MB each) */
+static uint8_t fake_noc0_window[MB(16)];
+static uint8_t fake_noc1_window[MB(16)];
+#define ARC_NOC0_BASE_ADDR ((uintptr_t)fake_noc0_window)
+#define ARC_NOC1_BASE_ADDR ((uintptr_t)fake_noc1_window)
+#else
 #define ARC_NOC0_BASE_ADDR       0xC0000000
 #define ARC_NOC1_BASE_ADDR       0xE0000000
+#endif
 #define NOC_TLB_LOG_SIZE         24
 #define NOC_TLB_WINDOW_ADDR_MASK ((1 << NOC_TLB_LOG_SIZE) - 1)
 

--- a/lib/tenstorrent/bh_arc/noc_dma.c
+++ b/lib/tenstorrent/bh_arc/noc_dma.c
@@ -78,6 +78,10 @@ static inline uint32_t read_noc_dma_config(uint32_t addr)
 
 static bool noc_wait_cmd_ready(void)
 {
+#ifdef CONFIG_BOARD_NATIVE_SIM
+	/* Fake completion */
+	return true;
+#else
 	uint32_t cmd_ctrl;
 	k_timepoint_t timeout = sys_timepoint_calc(K_MSEC(NOC_DMA_TIMEOUT_MS));
 
@@ -86,6 +90,7 @@ static bool noc_wait_cmd_ready(void)
 	} while (cmd_ctrl != 0 && !sys_timepoint_expired(timeout));
 
 	return cmd_ctrl == 0;
+#endif
 }
 
 static uint32_t get_expected_acks(uint32_t noc_cmd, uint64_t size)
@@ -108,6 +113,10 @@ static inline bool is_behind(uint32_t current, uint32_t target)
 
 static bool wait_noc_dma_done(uint32_t noc_cmd, uint32_t expected_acks)
 {
+#ifdef CONFIG_BOARD_NATIVE_SIM
+	/* Fake NOC completion */
+	return true;
+#else
 	k_timepoint_t timeout = sys_timepoint_calc(K_MSEC(NOC_DMA_TIMEOUT_MS));
 	uint32_t ack_reg_addr =
 		(noc_cmd & NOC_CMD_WR) ? NIU_MST_WR_ACK_RECEIVED : NIU_MST_RD_RESP_RECEIVED;
@@ -120,6 +129,7 @@ static bool wait_noc_dma_done(uint32_t noc_cmd, uint32_t expected_acks)
 	} while (behind && !sys_timepoint_expired(timeout));
 
 	return !behind;
+#endif
 }
 
 static uint32_t noc_dma_format_coord(uint8_t x, uint8_t y)


### PR DESCRIPTION
Commit d3cb9055 (security: wipe l1s, 2025-08-06) caused a regression by adding the NOC code in bh_arc into the bh_arc test built in simulation, since we now perform NOC access during system init.

Rather than reverting this commit, add support in the noc code for running within emulation. This support is *very* limited- we essentially create RAM buffers to fake out the NOC TLB and configuration spaces, and fake NOC completion where required. However, it is sufficient to fix the bh_arc tests.


Note that we need something like this, or need to revert d3cb9055 to fix CI