### PR TITLE
boards: tenstorrent: blackhole: define a fixed partition layout

### DIFF
--- a/boards/tenstorrent/tt_blackhole/tt_blackhole_fixed_partitions.dtsi
+++ b/boards/tenstorrent/tt_blackhole/tt_blackhole_fixed_partitions.dtsi
@@ -18,69 +18,63 @@ partitions {
 		label = "cmfwcfg";
 		reg = <0x14000 DT_SIZE_K(4)>;
 		binary-path = "$BUILD_DIR/smc/generated_board_cfg/$BOARD_REV/fw_table.bin";
-		read-only;
 	};
 
 	origcfg: partition@15000 {
 		label = "origcfg";
 		reg = <0x15000 DT_SIZE_K(4)>;
 		binary-path = "$BUILD_DIR/smc/generated_board_cfg/$BOARD_REV/fw_table.bin";
-		read-only;
 	};
 
 	cmfw: partition@10000000 {
 		label = "cmfw";
 		reg = <0x10000000 DT_SIZE_K(106)>;
+		offset = <0x10000000>;
 		binary-path = "$BUILD_DIR/smc/zephyr/zephyr.bin";
+		executable;
 	};
 
 	ethfwcfg: partition@30000 {
 		label = "ethfwcfg";
 		reg = <0x30000 DT_SIZE_K(4)>;
 		binary-path = "$BLOBS_DIR/tt_blackhole_erisc_params.bin";
-		read-only;
 	};
 
 	ethfw: partition@31000 {
 		label = "ethfw";
 		reg = <0x31000 DT_SIZE_K(36)>;
 		binary-path = "$BLOBS_DIR/tt_blackhole_erisc.bin";
-		read-only;
 	};
 
 	memfwcfg: partition@3a000 {
 		label = "memfwcfg";
 		reg = <0x3a000 DT_SIZE_K(4)>;
-		binary-path = "$BLOBS_DIR/tt_blackhole_gddr_params_$BOARD_REV.bin";
-		read-only;
+		binary-path = "$BLOBS_DIR/tt_blackhole_gddr_params_$PROD_NAME.bin";
 	};
 
 	memfw: partition@3b000 {
 		label = "memfw";
 		reg = <0x3b000 DT_SIZE_K(16)>;
 		binary-path = "$BLOBS_DIR/tt_blackhole_gddr_init.bin";
-		read-only;
 	};
 
 	ethsdreg: partition@3f000 {
 		label = "ethsdreg";
 		reg = <0x3f000 DT_SIZE_K(4)>;
 		binary-path = "$BLOBS_DIR/tt_blackhole_serdes_eth_fwreg.bin";
-		read-only;
 	};
 
 	ethsdfw: partition@40000 {
 		label = "ethsdfw";
 		reg = <0x40000 DT_SIZE_K(20)>;
 		binary-path = "$BLOBS_DIR/tt_blackhole_serdes_eth_fw.bin";
-		read-only;
 	};
 
 	bmfw: partition@45000 {
 		label = "bmfw";
 		reg = <0x45000 DT_SIZE_K(52)>;
+		padto = <DT_SIZE_K(52)>;
 		binary-path = "$BUILD_DIR/dmc/zephyr/zephyr.signed.bin";
-		read-only;
 	};
 
 	flshinfo: partition@52000 {
@@ -88,13 +82,14 @@ partitions {
 		reg = <0x52000 DT_SIZE_K(4)>;
 		binary-path =
 			"$BUILD_DIR/smc/generated_board_cfg/$BOARD_REV/flash_info.bin";
-		read-only;
 	};
 
 	boardcfg: partition@53000 {
 		label = "boardcfg";
 		reg = <0x53000 DT_SIZE_K(4)>;
 		binary-path = "$BUILD_DIR/smc/generated_board_cfg/$BOARD_REV/read_only.bin";
+		source = "$END - 0x1000";
+		provisioning-only;
 		read-only;
 	};
 
@@ -108,7 +103,7 @@ partitions {
 	failover: failover_partition@10000000 {
 		label = "failover";
 		reg = <0x10000000 DT_SIZE_K(76)>;
+		offset = <0x10000000>;
 		binary-path = "$BUILD_DIR/recovery/zephyr/zephyr.bin";
-		read-only;
 	};
 };

--- a/boards/tenstorrent/tt_blackhole/tt_blackhole_fixed_partitions.dtsi
+++ b/boards/tenstorrent/tt_blackhole/tt_blackhole_fixed_partitions.dtsi
@@ -26,84 +26,78 @@ partitions {
 		binary-path = "$BUILD_DIR/smc/generated_board_cfg/$BOARD_REV/fw_table.bin";
 	};
 
-	cmfw: partition@10000000 {
+	ethfwcfg: partition@16000 {
+		label = "ethfwcfg";
+		reg = <0x16000 DT_SIZE_K(4)>;
+		binary-path = "$BLOBS_DIR/tt_blackhole_erisc_params.bin";
+	};
+
+	ethfw: partition@17000 {
+		label = "ethfw";
+		reg = <0x17000 DT_SIZE_K(36)>;
+		binary-path = "$BLOBS_DIR/tt_blackhole_erisc.bin";
+	};
+
+	memfwcfg: partition@20000 {
+		label = "memfwcfg";
+		reg = <0x20000 DT_SIZE_K(4)>;
+		binary-path = "$BLOBS_DIR/tt_blackhole_gddr_params_$PROD_NAME.bin";
+	};
+
+	memfw: partition@21000 {
+		label = "memfw";
+		reg = <0x21000 DT_SIZE_K(16)>;
+		binary-path = "$BLOBS_DIR/tt_blackhole_gddr_init.bin";
+	};
+
+	ethsdreg: partition@25000 {
+		label = "ethsdreg";
+		reg = <0x25000 DT_SIZE_K(4)>;
+		binary-path = "$BLOBS_DIR/tt_blackhole_serdes_eth_fwreg.bin";
+	};
+
+	ethsdfw: partition@26000 {
+		label = "ethsdfw";
+		reg = <0x26000 DT_SIZE_K(20)>;
+		binary-path = "$BLOBS_DIR/tt_blackhole_serdes_eth_fw.bin";
+	};
+
+	flshinfo: partition@2b000 {
+		label = "flshinfo";
+		reg = <0x2b000 DT_SIZE_K(4)>;
+		binary-path =
+			"$BUILD_DIR/smc/generated_board_cfg/$BOARD_REV/flash_info.bin";
+	};
+
+	cmfw: partition@2c000 {
 		label = "cmfw";
-		reg = <0x10000000 DT_SIZE_K(106)>;
+		reg = <0x2c000 DT_SIZE_K(512)>;
 		offset = <0x10000000>;
 		binary-path = "$BUILD_DIR/smc/zephyr/zephyr.bin";
 		executable;
 	};
 
-	ethfwcfg: partition@30000 {
-		label = "ethfwcfg";
-		reg = <0x30000 DT_SIZE_K(4)>;
-		binary-path = "$BLOBS_DIR/tt_blackhole_erisc_params.bin";
+	failover: failover_partition@ac000 {
+		label = "failover";
+		reg = <0xac000 DT_SIZE_K(512)>;
+		offset = <0x10000000>;
+		binary-path = "$BUILD_DIR/recovery/zephyr/zephyr.bin";
 	};
 
-	ethfw: partition@31000 {
-		label = "ethfw";
-		reg = <0x31000 DT_SIZE_K(36)>;
-		binary-path = "$BLOBS_DIR/tt_blackhole_erisc.bin";
-	};
-
-	memfwcfg: partition@3a000 {
-		label = "memfwcfg";
-		reg = <0x3a000 DT_SIZE_K(4)>;
-		binary-path = "$BLOBS_DIR/tt_blackhole_gddr_params_$PROD_NAME.bin";
-	};
-
-	memfw: partition@3b000 {
-		label = "memfw";
-		reg = <0x3b000 DT_SIZE_K(16)>;
-		binary-path = "$BLOBS_DIR/tt_blackhole_gddr_init.bin";
-	};
-
-	ethsdreg: partition@3f000 {
-		label = "ethsdreg";
-		reg = <0x3f000 DT_SIZE_K(4)>;
-		binary-path = "$BLOBS_DIR/tt_blackhole_serdes_eth_fwreg.bin";
-	};
-
-	ethsdfw: partition@40000 {
-		label = "ethsdfw";
-		reg = <0x40000 DT_SIZE_K(20)>;
-		binary-path = "$BLOBS_DIR/tt_blackhole_serdes_eth_fw.bin";
-	};
-
-	bmfw: partition@45000 {
+	bmfw: partition@12c000 {
 		label = "bmfw";
-		reg = <0x45000 DT_SIZE_K(52)>;
+		reg = <0x12c000 DT_SIZE_K(512)>;
 		padto = <DT_SIZE_K(52)>;
 		binary-path = "$BUILD_DIR/dmc/zephyr/zephyr.signed.bin";
 	};
 
-	flshinfo: partition@52000 {
-		label = "flshinfo";
-		reg = <0x52000 DT_SIZE_K(4)>;
-		binary-path =
-			"$BUILD_DIR/smc/generated_board_cfg/$BOARD_REV/flash_info.bin";
-	};
-
-	boardcfg: partition@53000 {
+	boardcfg: partition@3fff000 {
 		label = "boardcfg";
-		reg = <0x53000 DT_SIZE_K(4)>;
+		reg = <0x3fff000 DT_SIZE_K(4)>;
 		binary-path = "$BUILD_DIR/smc/generated_board_cfg/$BOARD_REV/read_only.bin";
+		/* Always placed 4KB from end of flash */
 		source = "$END - 0x1000";
 		provisioning-only;
 		read-only;
-	};
-
-	/*
-	 * FIXME: The address of this node triggers a warning that we should try to fix:
-	 * Warning (unique_unit_address_if_enabled):
-	 *  /soc/spi@80070000/eeprom@0/partitions/partition@10000000
-	 * duplicate unit-address (also used in node
-	 *   /soc/spi@80070000/eeprom@0/partitions/failover_partition@10000000)
-	 */
-	failover: failover_partition@10000000 {
-		label = "failover";
-		reg = <0x10000000 DT_SIZE_K(76)>;
-		offset = <0x10000000>;
-		binary-path = "$BUILD_DIR/recovery/zephyr/zephyr.bin";
 	};
 };

--- a/dts/bindings/mtd/tenstorrent,tt-boot-fs.yaml
+++ b/dts/bindings/mtd/tenstorrent,tt-boot-fs.yaml
@@ -28,7 +28,8 @@ child-binding:
       type: string
       description: |
         Where to place the binary in flash memory. Can be an absolute address,
-        or relative to end of flash by referencing $END.
+        or relative to end of flash by referencing $END. If absent, the register
+        address is used to determine where the binary is placed in flash.
     padto:
       type: int
       description: |

--- a/dts/bindings/mtd/tenstorrent,tt-boot-fs.yaml
+++ b/dts/bindings/mtd/tenstorrent,tt-boot-fs.yaml
@@ -20,3 +20,26 @@ child-binding:
     binary-path:
       type: string
       required: true
+    provisioning-only:
+      type: boolean
+      description: |
+        Set to indicate the partition is only provisioned during manufacturing
+    source:
+      type: string
+      description: |
+        Where to place the binary in flash memory. Can be an absolute address,
+        or relative to end of flash by referencing $END.
+    padto:
+      type: int
+      description: |
+        Pad the region the binary occupies to support fixed size tt_boot_fs entries.
+    executable:
+      type: boolean
+      description: |
+        Set to indicate the partition is executable. This is used to determine
+        whether the partition should be loaded into memory and executed by the
+        bootloader.
+    offset:
+      type: int
+      description: |
+        Address where the bootloader should load an executable binary within memory.

--- a/scripts/tt_boot_fs.py
+++ b/scripts/tt_boot_fs.py
@@ -680,7 +680,12 @@ class FileImage:
             if image.tag not in tag_order:
                 tag_order.append(image.tag)
 
-        failover_spi_addr = tracker.find_gap_of_size(len(self.failover.binary))[0]
+        if self.failover.spi_addr is not None:
+            # Respect the "source" value set for the failover image
+            failover_spi_addr = self.failover.spi_addr
+        else:
+            # Find a gap for the failover image
+            failover_spi_addr = tracker.find_gap_of_size(len(self.failover.binary))[0]
 
         return BootFs(
             tag_order,

--- a/scripts/tt_boot_fs.py
+++ b/scripts/tt_boot_fs.py
@@ -909,49 +909,20 @@ def _generate_bootfs_yaml(
             continue
 
         label = partition.label
-        offset, size = partition.props["reg"].val
         path = partition.props["binary-path"].val
-        path = path.replace(
-            "$BOARD_REV",
-            gen_name if partition.label != "memfwcfg" else prod_name,
-        )
+        path = path.replace("$PROD_NAME", prod_name)
+        path = path.replace("$BOARD_REV", gen_name)
         path = path.replace("$BUILD_DIR", str(args.build_dir))
         path = path.replace("$BLOBS_DIR", str(args.blobs_dir))
-        read_only = partition.read_only
 
-        # Right now tt_boot_fs expects a very specific format, so that's why
-        # the YAML generation is done in a more manual way below.
-        if label == "cmfw":
-            image_entry = {
-                "name": label,
-                "offset": offset,
-                "binary": path,
-                "executable": not read_only,
-            }
-        elif label == "bmfw":
-            image_entry = {
-                "name": label,
-                "padto": size,
-                "binary": path,
-            }
-        elif label == "boardcfg":
-            image_entry = {
-                "name": label,
-                "binary": path,
-                "provisioning_only": True,
-                "source": "$END - 0x1000",
-            }
-        elif label == "failover":
-            image_entry = {
-                "name": label,
-                "offset": offset,
-                "binary": path,
-            }
-        else:
-            image_entry = {
-                "name": label,
-                "binary": path,
-            }
+        image_entry = {
+            "name": label,
+            "binary": path,
+        }
+        # Build image entry based on which fields the partition actually had
+        for prop in ["offset", "padto", "source", "executable", "provisioning-only"]:
+            if prop in partition.props:
+                image_entry[prop.replace("-", "_")] = partition.props[prop].val
 
         if label == "failover":
             partitions_yml["fail_over_image"] = image_entry

--- a/scripts/tt_boot_fs.py
+++ b/scripts/tt_boot_fs.py
@@ -925,9 +925,14 @@ def _generate_bootfs_yaml(
             "binary": path,
         }
         # Build image entry based on which fields the partition actually had
-        for prop in ["offset", "padto", "source", "executable", "provisioning-only"]:
+        for prop in ["offset", "padto", "executable", "provisioning-only"]:
             if prop in partition.props:
                 image_entry[prop.replace("-", "_")] = partition.props[prop].val
+        if "source" in partition.props:
+            image_entry["source"] = partition.props["source"].val
+        else:
+            # Use register address to set source
+            image_entry["source"] = str(partition.props["reg"].val[0])
 
         if label == "failover":
             partitions_yml["fail_over_image"] = image_entry


### PR DESCRIPTION
Define a fixed partition layout for the tt-boot-fs within blackhole boards. This shouldn't be merged as is, we need to get tt-boot-fs to support hex formatted images first. Mostly opening this for review of the partition layout.