### PR TITLE
ci: fixes for e2e-stress tests

### DIFF
--- a/.github/workflows/hardware-long.yml
+++ b/.github/workflows/hardware-long.yml
@@ -122,15 +122,17 @@ jobs:
           # - board: p100
           #  runs-on:
           #    - p100-jtag
+          # disabled until #https://github.com/tenstorrent/tt-metal/issues/19837
+          # is resolved- P300 support for metal is currently WIP
+          # - board: p300a
+          #   runs-on:
+          #     - p300a-jtag
           - board: p100a
             runs-on:
               - p100a-jtag
           - board: p150a
             runs-on:
               - p150a-jtag
-          - board: p300a
-            runs-on:
-              - p300a-jtag
     runs-on: ${{ matrix.config.runs-on }}
     container:
       image: ghcr.io/tenstorrent/tt-metal/upstream-tests-bh:v0.61.0-30-g3a3d9d704e

--- a/.github/workflows/hardware-long.yml
+++ b/.github/workflows/hardware-long.yml
@@ -70,20 +70,8 @@ jobs:
       - name: run-e2e-stress-test
         working-directory: zephyr
         run: |
-          # TODO: ideally we would use one twister command to build and
-          # flash DMC and SMC firmware, but since each chip uses a separate
-          # debug adapter this doesn't work. For now, just flash DMC
-          # then run twister with SMC firmware
-          ./scripts/twister -i \
-            --tag e2e \
-            -p $DMC_BOARD --device-testing \
-            --device-serial-pty ../tt-zephyr-platforms/scripts/dmc_rtt.py \
-            --flash-before \
-            --west-flash \
-            -T ../tt-zephyr-platforms/app \
-            --outdir twister-dmc-e2e
-          # Rescan PCIe before we run tt-flash
-          sudo ../tt-zephyr-platforms/scripts/rescan-pcie.sh
+          # Reset the card first. If this fails tt-flash won't work either
+          tt-smi -r
           # Run a full stress test, using tt-flash as the runner
           ./scripts/twister -i -p $SMC_BOARD \
             --tag e2e-stress -T ../tt-zephyr-platforms/app \

--- a/.github/workflows/hardware-long.yml
+++ b/.github/workflows/hardware-long.yml
@@ -90,6 +90,7 @@ jobs:
             --west-flash="--force" \
             --west-runner tt_flash \
             --device-testing -c \
+            --device-flash-timeout 120 \
             --device-serial-pty ../tt-zephyr-platforms/scripts/smc_console.py \
             --flash-before \
             --outdir twister-e2e-stress

--- a/app/smc/pytest/e2e_smoke.py
+++ b/app/smc/pytest/e2e_smoke.py
@@ -240,9 +240,14 @@ def arc_watchdog_test(arc_chip):
     try:
         # This should fail, since the ARC should have been reset
         arc_chip = pyluwen.detect_chips()[0]
-        logger.warning(
-            "SMC did not reset ARC core on iteration still able to detect ARC chip"
-        )
+        logger.warning("DMC did not reset ARC core. Still able to detect ARC chip")
+        # tt-kmd sets its own 10000ms timer, which sometimes can race our own
+        # timer and override it. To handle this case, delay 10 more seconds
+        # to allow the ARC to reset
+        logger.warning("Waiting 10 additional seconds to see if ARC core resets")
+        time.sleep(10)
+        arc_chip = pyluwen.detect_chips()[0]
+        logger.error("ARC core was not reset after 10 seconds")
         return False
     except Exception:
         # Expected behavior, since the ARC should have been reset.

--- a/app/smc/pytest/e2e_smoke.py
+++ b/app/smc/pytest/e2e_smoke.py
@@ -281,6 +281,17 @@ def pcie_fw_load_time_test(arc_chip):
     pcie_init_cpl_time = arc_chip.axi_read32(PCIE_INIT_CPL_TIME_REG_ADDR)
     cmfw_start_time = arc_chip.axi_read32(CMFW_START_TIME_REG_ADDR)
     arc_start_time = arc_chip.axi_read32(ARC_START_TIME_REG_ADDR)
+    # Wait up to 5 seconds for DMC to boot and sync with ARC
+    timeout = time.time() + 5
+    while arc_start_time == 0 and time.time() < timeout:
+        # Wait for the DMC to report the ARC start time
+        logger.info("Waiting for ARC start time to be set...")
+        time.sleep(0.1)
+        arc_start_time = arc_chip.axi_read32(ARC_START_TIME_REG_ADDR)
+
+    if arc_start_time == 0:
+        logger.warning("DMC never reported ARC start time")
+        return False
 
     duration_in_ms = (pcie_init_cpl_time - arc_start_time) / REFCLK_HZ * 1000
 

--- a/app/smc/pytest/e2e_stress.py
+++ b/app/smc/pytest/e2e_stress.py
@@ -5,6 +5,7 @@
 
 import logging
 import os
+import time
 import subprocess
 from pathlib import Path
 
@@ -157,6 +158,10 @@ def test_dirty_reset():
             fail_count += 1
         else:
             logger.info(f"dirty reset passed on iteration {i}")
+            # Delay a moment before next run. Without this, tests seem to fail
+            # TODO- would be best to determine why rapidly resetting like this
+            # breaks enumeration.
+            time.sleep(0.5)
 
     report_results("Dirty reset test", fail_count, total_tries)
     assert fail_count == 0, "Dirty reset failed a non-zero number of times."

--- a/app/smc/sample.yaml
+++ b/app/smc/sample.yaml
@@ -85,6 +85,8 @@ tests:
     tags: e2e-stress
     harness: pytest
     sysbuild: true
+    extra_args:
+      - dmc_CONFIG_DMC_RUN_SMBUS_TESTS=y
     harness_config:
       pytest_root:
         - pytest/e2e_stress.py

--- a/scripts/dmc_reset.py
+++ b/scripts/dmc_reset.py
@@ -216,6 +216,8 @@ def wait_for_smc_boot(timeout):
             chips = pyluwen.detect_chips()
             print("SMC init complete")
             chip = chips[0]
+            # Wait for chip to populate telemetry
+            telemetry = chip.get_telemetry()
             break
         except Exception:
             # Just decrement timeout, which we do below
@@ -227,7 +229,7 @@ def wait_for_smc_boot(timeout):
             print(f"Card did not reappear after {timeout} seconds)")
             return os.EX_UNAVAILABLE
     # Check if the SMC ping will work
-    if chip.get_telemetry().m3_app_fw_version < 0x40000:
+    if telemetry.m3_app_fw_version < 0x40000:
         print("Warning: DMC firmware is too old, no support for SMC ping")
         return os.EX_OK
     # Try to verify that the SMC can ping the DMC

--- a/scripts/rtt_helper.py
+++ b/scripts/rtt_helper.py
@@ -72,6 +72,12 @@ class OpenOCDServer:
             "-c",
             "init",
             "-c",
+            "halt",
+            "-c",
+            "reg pc",
+            "-c",
+            "resume",
+            "-c",
             f'rtt setup {search_base} {search_range} "SEGGER RTT"',
             "-c",
             "rtt start",
@@ -88,6 +94,9 @@ class OpenOCDServer:
             while self._proc.poll() is None:
                 line = self._proc.stderr.readline().decode().strip()
                 logger.debug("Openocd Output: %s", line)
+                if "pc (/32)" in line:
+                    # Print openocd's read of the program counter
+                    print(f"System PC:{line.split(':')[1]}")
                 if f"Listening on port {rtt_port} for rtt connections" in line:
                     break
         except subprocess.CalledProcessError as e:


### PR DESCRIPTION
Fix a few issues affecting the reliability of the E2E stress test, notably:

> In some CI tests the DMC flash prior to running tt-flash will leave the
    card in a state where a PCIe rescan is required. Add a pcie rescan step to
    the tt-flash runner in order to improve CI reliability, and automate
    this rescan for developers.

> In 3e74f74 (app: smc: improve code reuse in E2E stress test,
    2025-08-15), code that waited for the DMC to set the PCIe init time
    after booting the SMC was mistakenly dropped. This has caused the E2E
    stress test to fail in the PCIe init phase.

> tt-kmd sets a 10000ms watchdog timer on the ARC after reset. In some
cases this overrides our watchdog timer. To work around this, delay an
additional 10 seconds if the SMC initially fails to reset, and log a
warning. Only fail the test if the SMC doesn't reset within 10 seconds.


See individual commits for specific details- this PR essentially amounts to a variety of reliability improvements needed to get the e2e-stress tests functional again.

~This PR also adds a temporary commit to run e2e tests on the PR itself, so we can verify things are passing~