### PR TITLE
doc: release: rename 19.0 to 18.9 and adjust versions

### DIFF
--- a/doc/release/migration-guide-18.9.md
+++ b/doc/release/migration-guide-18.9.md
@@ -1,0 +1,7 @@
+# Migration Guide: TT-Zephyr-Platforms v18.9.0
+
+> [!NOTE]
+> This is a working draft for the up-coming v18.9.0 release.
+This document lists recommended and required changes for those migrating from the previous v18.8.0 firmware release to the new v18.9.0 firmware release.
+
+[comment]: <> (UL by area, indented as necessary)

--- a/doc/release/migration-guide-19.0.md
+++ b/doc/release/migration-guide-19.0.md
@@ -1,7 +1,0 @@
-# Migration Guide: TT-Zephyr-Platforms v19.0.0
-
-> [!NOTE]
-> This is a working draft for the up-coming v19.0.0 release.
-This document lists recommended and required changes for those migrating from the previous v18.8.0 firmware release to the new v19.0.0 firmware release.
-
-[comment]: <> (UL by area, indented as necessary)

--- a/doc/release/release-notes-18.9.md
+++ b/doc/release/release-notes-18.9.md
@@ -1,9 +1,9 @@
-# TT-Zephyr-Platforms v19.0.0
+# TT-Zephyr-Platforms v18.9.0
 
 > [!NOTE]
-> This is a working draft for the up-coming v19.0.0 release.
+> This is a working draft for the up-coming v18.9.0 release.
 
-[comment]: <> (We are pleased to announce the release of TT Zephyr Platforms firmware version 19.0.0 🥳🎉.)
+[comment]: <> (We are pleased to announce the release of TT Zephyr Platforms firmware version 18.9.0 🥳🎉.)
 
 Major enhancements with this release include:
 
@@ -61,10 +61,10 @@ Major enhancements with this release include:
 
 ## Migration guide
 
-An overview of required and recommended changes to make when migrating from the previous v18.8.0 release can be found in [v19.0 Migration Guide](https://github.com/tenstorrent/tt-zephyr-platforms/tree/main/doc/release/migration-guide-19.0.md).
+An overview of required and recommended changes to make when migrating from the previous v18.8.0 release can be found in [v18.9 Migration Guide](https://github.com/tenstorrent/tt-zephyr-platforms/tree/main/doc/release/migration-guide-18.9.md).
 
 ## Full ChangeLog
 
 The full ChangeLog from the previous v18.8.0 release can be found at the link below.
 
-https://github.com/tenstorrent/tt-zephyr-platforms/compare/v18.8.0...v19.0.0
+https://github.com/tenstorrent/tt-zephyr-platforms/compare/v18.8.0...v18.9.0


### PR DESCRIPTION
Change release notes back to a minor version bump per the next planned version release.