### PR TITLE
ci: workflows: hardware-long: update container, run p300 metal tests

### DIFF
--- a/.github/workflows/hardware-long.yml
+++ b/.github/workflows/hardware-long.yml
@@ -122,11 +122,9 @@ jobs:
           # - board: p100
           #  runs-on:
           #    - p100-jtag
-          # disabled until #https://github.com/tenstorrent/tt-metal/issues/19837
-          # is resolved- P300 support for metal is currently WIP
-          # - board: p300a
-          #   runs-on:
-          #     - p300a-jtag
+          - board: p300a
+            runs-on:
+              - p300a-jtag
           - board: p100a
             runs-on:
               - p100a-jtag
@@ -135,7 +133,7 @@ jobs:
               - p150a-jtag
     runs-on: ${{ matrix.config.runs-on }}
     container:
-      image: ghcr.io/tenstorrent/tt-metal/upstream-tests-bh:v0.61.0-30-g3a3d9d704e
+      image: ghcr.io/tenstorrent/tt-metal/upstream-tests-bh:v0.62.0-rc33-466-gf3b2c1316e
       volumes:
         - /dev/hugepages-1G:/dev/hugepages-1G
         - /dev/hugepages:/dev/hugepages


### PR DESCRIPTION
Update container to latest metal revision, and enable metal tests on
P300a now that UMD should be updated to support metal

Signed-off-by: Daniel DeGrasse <ddegrasse@tenstorrent.com>