### PR TITLE
ci: doc: deploy to github pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,6 +28,12 @@ jobs:
       - name: Build
         run: |
           cd doc
+
+          # IMPORTANT: symlink directories here that are needed during the sphinx build
+          # There may be a better way to do this, but this seems to be simplest at the moment.
+          # It's required because symlinks trip check_compliance.py.
+          ln -sf ../boards .
+
           rm -f zephyr.tag
           wget https://docs.zephyrproject.org/latest/doxygen/html/zephyr.tag -O /tmp/zephyr.tag
           doxygen

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,10 @@
 
 name: Documentation
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request: {}
 
 env:
   DOXYGEN_VERSION: 1.9.6
@@ -34,7 +37,6 @@ jobs:
           mkdir deploy
           mv _build_doxygen/html deploy/doxygen
           mv _build_sphinx/html/* deploy
-          mv deploy/genindex.html deploy/index.html
           rm -rf _build_doxygen _build_sphinx
 
       - name: Setup pages
@@ -53,13 +55,17 @@ jobs:
         with:
           path: doc/deploy
 
-#   deploy:
-#     runs-on: ubuntu-22.04
-#     needs: build
-#     if: github.event_name != 'pull_request'
-#     permissions:
-#       pages: write
-#       id-token: write
-#     steps:
-#       - name: Deploy to GitHub Pages
-#         uses: actions/deploy-pages@v4
+  deploy:
+    runs-on: ubuntu-22.04
+    needs: build
+    if: github.event_name != 'pull_request'
+    permissions:
+      pages: write
+      id-token: write
+    # Deploy to the github-pages environment
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@v4

--- a/boards/index.rst
+++ b/boards/index.rst
@@ -3,11 +3,11 @@
 Supported Boards
 ################
 
-If you are looking to add Zephyr support for a new board, please start with the
-:ref:`board_porting_guide`.
-
 .. toctree::
    :maxdepth: 2
    :glob:
 
    tenstorrent/*/doc/index
+
+.. note::
+       New boards should follow the :ref:`board_porting_guide`.

--- a/boards/tenstorrent/tt_blackhole/doc/index.rst
+++ b/boards/tenstorrent/tt_blackhole/doc/index.rst
@@ -15,15 +15,21 @@ PCIe AI accelerator card that is also a
 
 Own your Silicon Future.
 
-Supported Boards
-****************
+Product Family
+**************
 
-Boards in the Blackhole product family that are officially supported by this repository include:
+The Blackhole product family officially supported by this repository include the following
+revisions:
 
 * Blackhole P100 (aka "Scrappy" - an internal development board)
 * Blackhole P100A
 * Blackhole P150A
 * Blackhole P150B
+* Blackhole P150C
+* Blackhole P300A
+* Blackhole P300B
+* Blackhole P300C
+* Blackhole Galaxy
 
 Additional boards in the Blackhole product family may be added in the future as they are
 announced.

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -5,7 +5,7 @@
 # from the environment for the first two.
 SPHINXOPTS    ?= -W --conf-dir .
 SPHINXBUILD   ?= sphinx-build
-SOURCEDIR     = ..
+SOURCEDIR     = .
 BUILDDIR      = _build_sphinx
 
 # Put it first so that "make" without argument is like "make help".

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 TTZP = Path(__file__).parent.parent
 
-root_doc = "doc/index"
+root_doc = "index"
 project = "TT Zephyr Platforms"
 copyright = "2025, Tenstorrent AI ULC"
 author = "Tenstorrent AI ULC"

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -5,7 +5,6 @@ from pathlib import Path
 
 TTZP = Path(__file__).parent.parent
 
-root_doc = "index"
 project = "TT Zephyr Platforms"
 copyright = "2025, Tenstorrent AI ULC"
 author = "Tenstorrent AI ULC"

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -5,7 +5,7 @@ Welcome to TT Zephyr Platforms!
    :maxdepth: 2
    :caption: Contents
 
-   ../boards/index.rst
+   boards/index
    zephyr
 
 Indices and tables


### PR DESCRIPTION
Deploy doc to github pages when pushed to main branch

For examples of this deployment, see
* https://danieldegrasse.github.io/tt-zephyr-platforms/
* https://cfriedt.github.io/tt-zephyr-platforms/ (minor corrections)