### PR TITLE
tdp_limit & tdc_limit change

### DIFF
--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P150C/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P150C/fw_table.txt
@@ -7,10 +7,10 @@ chip_limits {
   vdd_max: 900
   vdd_min: 700
   voltage_margin: 50
-  tdp_limit: 150
-  tdc_limit: 200
+  tdp_limit: 500
+  tdc_limit: 500
   thm_limit: 90
-  tdc_fast_limit: 220
+  tdc_fast_limit: 400
   therm_trip_l1_limit: 0
   bus_peak_limit: 0
   frequency_margin: 0


### PR DESCRIPTION
These limits were preventing tt-burnin from allow max power to be achieved. Discovered when performing thermal testing for p150c qual.