### PR TITLE
bh_arc: throttler: be less verbose

### DIFF
--- a/lib/tenstorrent/bh_arc/throttler.c
+++ b/lib/tenstorrent/bh_arc/throttler.c
@@ -147,7 +147,8 @@ static void SetThrottlerLimit(ThrottlerId id, float limit)
 	float clamped_limit =
 		CLAMP(limit, throttler_limit_ranges[id].min, throttler_limit_ranges[id].max);
 
-	LOG_INF("Throttler %d limit set to %d", id, (uint32_t)clamped_limit);
+	/* FIXME: switch to LOG_INF_RATELIMIT() after zephyr 4.3.0 bump */
+	LOG_DBG("Throttler %d limit set to %d", id, (uint32_t)clamped_limit);
 	throttler[id].limit = clamped_limit;
 }
 
@@ -213,7 +214,8 @@ int32_t Dm2CmSetBoardPowerLimit(const uint8_t *data, uint8_t size)
 
 	uint32_t power_limit = sys_get_le16(data);
 
-	LOG_INF("Cable Power Limit: %u", power_limit);
+	/* FIXME: switch to LOG_INF_RATELIMIT() after zephyr 4.3.0 bump */
+	LOG_DBG("Cable Power Limit: %u", power_limit);
 	power_limit = MIN(power_limit,
 			  tt_bh_fwtable_get_fw_table(fwtable_dev)->chip_limits.board_power_limit);
 


### PR DESCRIPTION
Upon starting `tt-console`, all that was visible was Throttler and Cable power limit log messages at `LOG_LEVEL_INF`.

Ideally, we want to make the console a bit more usable, especially with the shell enabled, so convert those messages to `LOG_DBG()` until the `LOG_INF_RATELIMIT()` [API](https://docs.zephyrproject.org/latest/services/logging/index.html#rate-limited-logging) is available (4.3.0).

What is of course important is that the code executes. Not so much that the event is logged.

Before:
```shell
// much more log messages
...
uart:~$ 
[00:00:07.568,000] <inf> throttler: Throttler 4 limit set to 50
[00:00:07.591,000] <inf> throttler: Cable Power Limit: 300
[00:00:07.591,000] <inf> throttler: Throttler 4 limit set to 50
[00:00:07.614,000] <inf> throttler: Cable Power Limit: 300
[00:00:07.614,000] <inf> throttler: Throttler 4 limit set to 50
[00:00:07.637,000] <inf> throttler: Cable Power Limit: 300
[00:00:07.637,000] <inf> throttler: Throttler 4 limit set to 50
[00:00:07.660,000] <inf> throttler: Cable Power Limit: 300
[00:00:07.660,000] <inf> throttler: Throttler 4 limit set to 50
[00:00:07.682,000] <inf> throttler: Cable Power Limit: 300
--- 9999 messages dropped ---
[00:00:07.682,000] <inf> throttler: Throttler 4 limit set to 50
--- 1 messages dropped ---
[00:00:07.706,000] <inf> throttler: Cable Power Limit: 300
--- 2 messages dropped ---
[00:00:07.706,000] <inf> throttler: Throttler 4 limit set to 50
--- 2 messages dropped ---
[00:00:07.728,000] <inf> throttler: Cable Power Limit: 300
[00:00:07.728,000] <inf> throttler: Throttler 4 limit set to 50
[00:00:07.751,000] <inf> throttler: Cable Power Limit: 300
[00:00:07.751,000] <inf> throttler: Throttler 4 limit set to 50
--- 1 messages dropped ---
[00:00:07.774,000] <inf> throttler: Cable Power Limit: 300
--- 2 messages dropped ---
[00:00:07.774,000] <inf> throttler: Throttler 4 limit set to 50
--- 1 messages dropped ---
[00:00:07.797,000] <inf> throttler: Cable Power Limit: 300
[00:00:07.797,000] <inf> throttler: Throttler 4 limit set to 50
--- 1 messages dropped ---
[00:00:07.820,000] <inf> throttler: Cable Power Limit: 300
--- 2 messages dropped ---
[00:00:07.820,000] <inf> throttler: Throttler 4 limit set to 50
[00:00:07.842,000] <inf> throttler: Cable Power Limit: 300
[00:00:07.842,000] <inf> throttler: Throttler 4 limit set to 50
--- 2 messages dropped ---
[00:07:11.173,000] <inf> throttler: Throttler 4 limit set to 50
[00:07:11.219,000] <inf> throttler: Cable Power Limit: 300
[00:07:11.242,000] <inf> throttler: Cable Power Limit: 300
[00:07:11.265,000] <inf> throttler: Throttler 4 limit set to 50
// much more log messages
```

After:
```shell
$ /tmp/tt-console
Press Ctrl-a,x to quit

Tenstorrent Blackhole CMFW 0.18.99
uart:~$ 
```