### PR TITLE
fw_table: enable aiclk ppm for p300x

### DIFF
--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300A_L/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300A_L/fw_table.txt
@@ -7,21 +7,22 @@ chip_limits {
   vdd_max: 900
   vdd_min: 700
   voltage_margin: 50
-  tdp_limit: 150
-  tdc_limit: 200
+  tdp_limit: 500
+  tdc_limit: 500
   thm_limit: 90
-  tdc_fast_limit: 220
+  tdc_fast_limit: 320
   therm_trip_l1_limit: 0
   bus_peak_limit: 0
   frequency_margin: 0
   gddr_thm_limit: 85
+  board_power_limit: 450
 }
 
 feature_enable {
   cg_en: true
   noc_translation_en: true
   ddr_train_en: true
-  aiclk_ppm_en: false
+  aiclk_ppm_en: true
   watchdog_en: false
   smbus_en: false
   fan_ctrl_en: true

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300A_R/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300A_R/fw_table.txt
@@ -7,21 +7,22 @@ chip_limits {
   vdd_max: 900
   vdd_min: 700
   voltage_margin: 50
-  tdp_limit: 150
-  tdc_limit: 200
+  tdp_limit: 500
+  tdc_limit: 500
   thm_limit: 90
-  tdc_fast_limit: 220
+  tdc_fast_limit: 320
   therm_trip_l1_limit: 0
   bus_peak_limit: 0
   frequency_margin: 0
   gddr_thm_limit: 85
+  board_power_limit: 450
 }
 
 feature_enable {
   cg_en: true
   noc_translation_en: true
   ddr_train_en: true
-  aiclk_ppm_en: false
+  aiclk_ppm_en: true
   watchdog_en: false
   smbus_en: false
   fan_ctrl_en: true

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300B_L/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300B_L/fw_table.txt
@@ -7,21 +7,22 @@ chip_limits {
   vdd_max: 900
   vdd_min: 700
   voltage_margin: 50
-  tdp_limit: 150
-  tdc_limit: 200
+  tdp_limit: 500
+  tdc_limit: 500
   thm_limit: 90
-  tdc_fast_limit: 220
+  tdc_fast_limit: 320
   therm_trip_l1_limit: 0
   bus_peak_limit: 0
   frequency_margin: 0
   gddr_thm_limit: 85
+  board_power_limit: 450
 }
 
 feature_enable {
   cg_en: true
   noc_translation_en: true
   ddr_train_en: true
-  aiclk_ppm_en: false
+  aiclk_ppm_en: true
   watchdog_en: false
   smbus_en: false
   fan_ctrl_en: false

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300B_R/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300B_R/fw_table.txt
@@ -7,21 +7,22 @@ chip_limits {
   vdd_max: 900
   vdd_min: 700
   voltage_margin: 50
-  tdp_limit: 150
-  tdc_limit: 200
+  tdp_limit: 500
+  tdc_limit: 500
   thm_limit: 90
-  tdc_fast_limit: 220
+  tdc_fast_limit: 320
   therm_trip_l1_limit: 0
   bus_peak_limit: 0
   frequency_margin: 0
   gddr_thm_limit: 85
+  board_power_limit: 450
 }
 
 feature_enable {
   cg_en: true
   noc_translation_en: true
   ddr_train_en: true
-  aiclk_ppm_en: false
+  aiclk_ppm_en: true
   watchdog_en: false
   smbus_en: false
   fan_ctrl_en: false

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300C_L/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300C_L/fw_table.txt
@@ -7,21 +7,22 @@ chip_limits {
   vdd_max: 900
   vdd_min: 700
   voltage_margin: 50
-  tdp_limit: 150
-  tdc_limit: 200
+  tdp_limit: 500
+  tdc_limit: 500
   thm_limit: 90
-  tdc_fast_limit: 220
+  tdc_fast_limit: 320
   therm_trip_l1_limit: 0
   bus_peak_limit: 0
   frequency_margin: 0
   gddr_thm_limit: 85
+  board_power_limit: 600
 }
 
 feature_enable {
   cg_en: true
   noc_translation_en: true
   ddr_train_en: true
-  aiclk_ppm_en: false
+  aiclk_ppm_en: true
   watchdog_en: false
   smbus_en: false
   fan_ctrl_en: false

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300C_R/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300C_R/fw_table.txt
@@ -7,21 +7,22 @@ chip_limits {
   vdd_max: 900
   vdd_min: 700
   voltage_margin: 50
-  tdp_limit: 150
-  tdc_limit: 200
+  tdp_limit: 500
+  tdc_limit: 500
   thm_limit: 90
-  tdc_fast_limit: 220
+  tdc_fast_limit: 320
   therm_trip_l1_limit: 0
   bus_peak_limit: 0
   frequency_margin: 0
   gddr_thm_limit: 85
+  board_power_limit: 600
 }
 
 feature_enable {
   cg_en: true
   noc_translation_en: true
   ddr_train_en: true
-  aiclk_ppm_en: false
+  aiclk_ppm_en: true
   watchdog_en: false
   smbus_en: false
   fan_ctrl_en: false


### PR DESCRIPTION
Set appropriate limits for p300x boards to enable AICLK PPM. This allows AICLK > 800 MHz.

Board power limits:
- p300a = 450 W
- p300b = 450 W
- p300c = 600 W

Move TDP, and slow TDC throttlers out of the way. Set Fast TDC to 320 A.