### PR TITLE
lib: tenstorrent: bh_arc: lower scratchpad size

### DIFF
--- a/lib/tenstorrent/bh_arc/Kconfig
+++ b/lib/tenstorrent/bh_arc/Kconfig
@@ -61,7 +61,7 @@ config TT_BH_ARC_WDT_FEED_INTERVAL
 	  Interval to feed watchdog within firmware
 
 config TT_BH_ARC_SCRATCHPAD_SIZE
-	hex "Size of scratchpad memory in bytes"
+	int "Size of scratchpad memory in bytes"
 	default 512
 	help
 	  Size of scratchpad memory in bytes. This is mainly used as a temporary buffer for


### PR DESCRIPTION
Change TT_BH_ARC_SCRATCHPAD_SIZE Kconfig to int instead of hex type, reducing the scratchpad size from 0x512 (1298) to 512.

This seems to have been causing eth FW loading issues on cold boot.