### PR TITLE
SYS-2023 Fix boot hang due to using disabled tensix to wipe L1s

### DIFF
--- a/include/tenstorrent/sys_init_defines.h
+++ b/include/tenstorrent/sys_init_defines.h
@@ -24,7 +24,7 @@
 #define DeassertRiscvResets_PRIO              11
 #define InitAiclkPPM_PRIO                     12
 #define pcie_init_PRIO                        13
-#define tensix_cg_init_PRIO                   14
+#define tensix_init_PRIO                      14
 #define InitMrisc_PRIO                        15
 #define eth_init_PRIO                         16
 #define InitSmbusTarget_PRIO                  17

--- a/lib/tenstorrent/bh_arc/CMakeLists.txt
+++ b/lib/tenstorrent/bh_arc/CMakeLists.txt
@@ -26,7 +26,7 @@ zephyr_library_sources_ifndef(
   serdes_eth.c
   telemetry.c
   telemetry_internal.c
-  tensix_cg.c
+  tensix_init.c
   throttler.c
   vf_curve.c
   voltage.c

--- a/lib/tenstorrent/bh_arc/eth.c
+++ b/lib/tenstorrent/bh_arc/eth.c
@@ -10,6 +10,7 @@
 #include "init.h"
 #include "noc.h"
 #include "noc_dma.h"
+#include "noc_init.h"
 #include "noc2axi.h"
 #include "reg.h"
 #include "serdes_eth.h"
@@ -351,8 +352,9 @@ static void wipe_l1(void)
 {
 	uint8_t noc_id = 0;
 	uint64_t addr = 0;
-	uint8_t tensix_x = 1;
-	uint8_t tensix_y = 2;
+	uint8_t tensix_x, tensix_y;
+
+	GetEnabledTensix(&tensix_x, &tensix_y);
 
 	for (uint8_t eth_inst = 0; eth_inst < MAX_ETH_INSTANCES; eth_inst++) {
 		if (tile_enable.eth_enabled & BIT(eth_inst)) {

--- a/lib/tenstorrent/bh_arc/gddr.c
+++ b/lib/tenstorrent/bh_arc/gddr.c
@@ -10,6 +10,7 @@
 #include "init.h"
 #include "noc.h"
 #include "noc_dma.h"
+#include "noc_init.h"
 #include "noc2axi.h"
 #include "reg.h"
 
@@ -257,8 +258,9 @@ static void wipe_l1(void)
 	uint8_t noc_id = 0;
 	uint64_t addr = 0;
 	uint32_t dram_mask = GetDramMask();
-	uint8_t tensix_x = 1;
-	uint8_t tensix_y = 2;
+	uint8_t tensix_x, tensix_y;
+
+	GetEnabledTensix(&tensix_x, &tensix_y);
 
 	for (uint32_t gddr_inst = 0; gddr_inst < NUM_GDDR; gddr_inst++) {
 		if (IS_BIT_SET(dram_mask, gddr_inst)) {

--- a/lib/tenstorrent/bh_arc/noc_init.h
+++ b/lib/tenstorrent/bh_arc/noc_init.h
@@ -16,4 +16,9 @@ void InitNocTranslation(unsigned int pcie_instance, uint16_t bad_tensix_cols, ui
 int InitNocTranslationFromHarvesting(void);
 void ClearNocTranslation(void);
 
+/* Returns NOC 0 coordinates of an enabled, unharvested tensix core.
+ * It's guaranteed to be the same core until translation is enabled, disabled or modified.
+ */
+void GetEnabledTensix(uint8_t *x, uint8_t *y);
+
 #endif

--- a/lib/tenstorrent/bh_arc/reset.c
+++ b/lib/tenstorrent/bh_arc/reset.c
@@ -15,7 +15,7 @@
 #include "noc2axi.h"
 #include "reg.h"
 #include "status_reg.h"
-#include "tensix_cg.h"
+#include "tensix_init.h"
 
 #include <stdint.h>
 
@@ -177,9 +177,7 @@ static __maybe_unused uint8_t ReinitTensix(uint32_t msg_code, const struct reque
 	 * but it's simpler to reuse the same functions to re-program all of it.
 	 */
 	NocInit();
-	if (tt_bh_fwtable_get_fw_table(fwtable_dev)->feature_enable.cg_en) {
-		EnableTensixCG();
-	}
+	TensixInit();
 	if (tt_bh_fwtable_get_fw_table(fwtable_dev)->feature_enable.noc_translation_en) {
 		InitNocTranslationFromHarvesting();
 	}

--- a/lib/tenstorrent/bh_arc/tensix_init.c
+++ b/lib/tenstorrent/bh_arc/tensix_init.c
@@ -6,6 +6,7 @@
 
 #include "noc2axi.h"
 #include "noc_dma.h"
+#include "noc_init.h"
 
 #include <stdint.h>
 
@@ -75,9 +76,10 @@ static void EnableTensixCG(void)
 static void wipe_l1(void)
 {
 	uint64_t addr = 0;
-	uint8_t tensix_x = 1;
-	uint8_t tensix_y = 2;
+	uint8_t tensix_x, tensix_y;
 	uint8_t sram_buffer[CONFIG_TT_BH_ARC_SCRATCHPAD_SIZE] __aligned(4);
+
+	GetEnabledTensix(&tensix_x, &tensix_y);
 
 	/* wipe SCRATCHPAD_SIZE of the chosen tensix */
 	memset(sram_buffer, 0, sizeof(sram_buffer));

--- a/lib/tenstorrent/bh_arc/tensix_init.h
+++ b/lib/tenstorrent/bh_arc/tensix_init.h
@@ -3,4 +3,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-void EnableTensixCG(void);
+void TensixInit(void);


### PR DESCRIPTION
We use a tensix as the source of zeroes, and to run NOC DMAs. Because wiping happens before translation is enabled, we can't count on known-good tensixes at certain NOC coordinates. Instead we need to find the coordinates of an enabled tensix.
