### PR TITLE
patches: Fix smbus PEC correction patch

### DIFF
--- a/zephyr/patches.yml
+++ b/zephyr/patches.yml
@@ -177,7 +177,7 @@ patches:
 
       Implementations are included for STM32 I2C and SMBus.
   - path: zephyr/smbus_stm32-pec.patch
-    sha256sum: 4e3f00df96e7e9536553f1230262ee4e28efea8e537b07885a7cb314427bd819
+    sha256sum: b4fe073932487fc5b4ca1502688e101624b98f9010e1273266c7dd8529988bfd
     module: zephyr
     author: Andrew Lewycky
     email: alewycky@tenstorrent.com

--- a/zephyr/patches/zephyr/smbus_stm32-pec.patch
+++ b/zephyr/patches/zephyr/smbus_stm32-pec.patch
@@ -11,7 +11,7 @@ index a81b239e444..f07bcb72718 100644
  	  Enable STM32 SMBus driver.
  
 diff --git a/drivers/smbus/smbus_stm32.c b/drivers/smbus/smbus_stm32.c
-index 590db91f54c..cf6472b146a 100644
+index 590db91f54c..b74d94cdc9d 100644
 --- a/drivers/smbus/smbus_stm32.c
 +++ b/drivers/smbus/smbus_stm32.c
 @@ -10,7 +10,7 @@
@@ -212,7 +212,7 @@ index 590db91f54c..cf6472b146a 100644
  }
  
  static int smbus_stm32_byte_data_read(const struct device *dev, uint16_t periph_addr,
-@@ -181,56 +313,145 @@ static int smbus_stm32_byte_data_read(const struct device *dev, uint16_t periph_
+@@ -181,56 +313,140 @@ static int smbus_stm32_byte_data_read(const struct device *dev, uint16_t periph_
  {
  	const struct smbus_stm32_config *config = dev->config;
  
@@ -255,8 +255,7 @@ index 590db91f54c..cf6472b146a 100644
 -	buffer[0] = command;
 -	sys_put_le16(word, buffer + 1);
 +	uint8_t pec;
- 
--	return i2c_write(config->i2c_dev, buffer, ARRAY_SIZE(buffer), periph_addr);
++
 +	struct i2c_msg messages[] = {
 +		{
 +			.buf = &command,
@@ -276,7 +275,8 @@ index 590db91f54c..cf6472b146a 100644
 +	};
 +
 +	uint8_t num_msgs = prepare_write_pec(dev, periph_addr, messages, ARRAY_SIZE(messages));
-+
+ 
+-	return i2c_write(config->i2c_dev, buffer, ARRAY_SIZE(buffer), periph_addr);
 +	return i2c_transfer(config->i2c_dev, messages, num_msgs, periph_addr);
  }
  
@@ -327,16 +327,8 @@ index 590db91f54c..cf6472b146a 100644
 -	buffer[0] = command;
 -	sys_put_le16(send_word, buffer + 1);
 +	uint8_t received_pec;
- 
--	result = i2c_write_read(config->i2c_dev, periph_addr, buffer, ARRAY_SIZE(buffer), recv_word,
--			      sizeof(*recv_word));
--	*recv_word = sys_le16_to_cpu(*recv_word);
++
 +	struct i2c_msg messages[] = {
-+		{
-+			.buf = &command,
-+			.len = sizeof(command),
-+			.flags = I2C_MSG_WRITE,
-+		},
 +		{
 +			.buf = &command,
 +			.len = sizeof(command),
@@ -361,10 +353,13 @@ index 590db91f54c..cf6472b146a 100644
 +
 +	uint8_t num_msgs = prepare_read_pec(dev, messages, ARRAY_SIZE(messages));
  
--	return result;
+-	result = i2c_write_read(config->i2c_dev, periph_addr, buffer, ARRAY_SIZE(buffer), recv_word,
+-			      sizeof(*recv_word));
+-	*recv_word = sys_le16_to_cpu(*recv_word);
 +	int res = i2c_transfer(config->i2c_dev, messages, num_msgs, periph_addr);
 +	if (res != 0) return res;
-+
+ 
+-	return result;
 +	return check_read_pec(dev, periph_addr, messages, ARRAY_SIZE(messages));
  }
  
@@ -378,7 +373,7 @@ index 590db91f54c..cf6472b146a 100644
  	struct i2c_msg messages[] = {
  		{
  			.buf = &command,
-@@ -246,10 +467,17 @@ static int smbus_stm32_block_write(const struct device *dev, uint16_t periph_add
+@@ -246,10 +462,17 @@ static int smbus_stm32_block_write(const struct device *dev, uint16_t periph_add
  			.buf = buf,
  			.len = count,
  			.flags = I2C_MSG_WRITE,
@@ -397,7 +392,7 @@ index 590db91f54c..cf6472b146a 100644
  }
  
  static int smbus_stm32_block_read(const struct device *dev, uint16_t periph_addr, uint8_t command,
-@@ -257,6 +485,8 @@ static int smbus_stm32_block_read(const struct device *dev, uint16_t periph_addr
+@@ -257,6 +480,8 @@ static int smbus_stm32_block_read(const struct device *dev, uint16_t periph_addr
  {
  	const struct smbus_stm32_config *config = dev->config;
  
@@ -406,7 +401,7 @@ index 590db91f54c..cf6472b146a 100644
  	struct i2c_msg messages[] = {
  		{
  			.buf = &command,
-@@ -272,6 +502,11 @@ static int smbus_stm32_block_read(const struct device *dev, uint16_t periph_addr
+@@ -272,6 +497,11 @@ static int smbus_stm32_block_read(const struct device *dev, uint16_t periph_addr
  			.buf = buf,
  			.len = 0,	/* written by previous message! */
  			.flags = I2C_MSG_READ,
@@ -418,7 +413,7 @@ index 590db91f54c..cf6472b146a 100644
  		}
  	};
  
-@@ -281,11 +516,15 @@ static int smbus_stm32_block_read(const struct device *dev, uint16_t periph_addr
+@@ -281,11 +511,15 @@ static int smbus_stm32_block_read(const struct device *dev, uint16_t periph_addr
  	 */
  	messages[1].buf = (uint8_t*)&messages[2].len;
  


### PR DESCRIPTION
The smbus PEC correction patch double sends the command byte. We need to only send it once according to spec.