### PR TITLE
drivers: sensor: tenstorrent: pvt: tt_bh: namespace helper functions

### DIFF
--- a/drivers/sensor/tenstorrent/pvt_tt_bh_decoder.c
+++ b/drivers/sensor/tenstorrent/pvt_tt_bh_decoder.c
@@ -13,14 +13,14 @@ LOG_MODULE_DECLARE(pvt_tt_bh);
 
 #define VM_VREF 1.2207f
 
-float raw_to_temp(uint16_t raw)
+float pvt_tt_bh_raw_to_temp(uint16_t raw)
 {
 	float eqbs = raw / 4096.0 - 0.5;
 	/* TODO: slope and offset need to be replaced with fused values */
 	return 83.09f + 262.5f * eqbs;
 }
 
-uint16_t temp_to_raw(const struct sensor_value *value)
+uint16_t pvt_tt_bh_temp_to_raw(const struct sensor_value *value)
 {
 	float temp = sensor_value_to_float(value);
 
@@ -39,7 +39,7 @@ uint16_t temp_to_raw(const struct sensor_value *value)
 	return (uint16_t)(raw_f + 0.5f);
 }
 
-float raw_to_volt(uint16_t raw)
+float pvt_tt_bh_raw_to_volt(uint16_t raw)
 {
 	float k1 = VM_VREF * 6 / (5 * 16384);
 	float offset = VM_VREF / 5 * (3 / 256 + 1);
@@ -47,7 +47,7 @@ float raw_to_volt(uint16_t raw)
 	return k1 * raw - offset;
 }
 
-uint16_t volt_to_raw(const struct sensor_value *value)
+uint16_t pvt_tt_bh_volt_to_raw(const struct sensor_value *value)
 {
 	float volt = sensor_value_to_float(value);
 
@@ -66,7 +66,7 @@ uint16_t volt_to_raw(const struct sensor_value *value)
 	return (uint16_t)(raw_f + 0.5f);
 }
 
-float raw_to_freq(uint16_t raw)
+float pvt_tt_bh_raw_to_freq(uint16_t raw)
 {
 	float a = 4.0;
 	float b = 1.0;
@@ -76,7 +76,7 @@ float raw_to_freq(uint16_t raw)
 	return raw * a * b * fclk / w;
 }
 
-uint16_t freq_to_raw(const struct sensor_value *value)
+uint16_t pvt_tt_bh_freq_to_raw(const struct sensor_value *value)
 {
 	float freq = sensor_value_to_float(value);
 
@@ -97,7 +97,7 @@ uint16_t freq_to_raw(const struct sensor_value *value)
 	return (uint16_t)(raw_f + 0.5f);
 }
 
-void float_to_sensor_value(float data, struct sensor_value *val)
+void pvt_tt_bh_float_to_sensor_value(float data, struct sensor_value *val)
 {
 	val->val1 = (int32_t)data;
 	val->val2 = (int32_t)roundf((data - (float)val->val1) * 1000000.0f);
@@ -128,16 +128,16 @@ static int pvt_tt_bh_decode_sample(const uint8_t *buf, struct sensor_chan_spec c
 
 		switch (chan_spec.chan_type) {
 		case SENSOR_CHAN_PVT_TT_BH_PD: {
-			data_converted = raw_to_freq(data->raw);
+			data_converted = pvt_tt_bh_raw_to_freq(data->raw);
 			break;
 		}
 		case SENSOR_CHAN_PVT_TT_BH_VM: {
-			data_converted = raw_to_volt(data->raw);
+			data_converted = pvt_tt_bh_raw_to_volt(data->raw);
 			break;
 		}
 		case SENSOR_CHAN_PVT_TT_BH_TS:
 		case SENSOR_CHAN_PVT_TT_BH_TS_AVG: {
-			data_converted = raw_to_temp(data->raw);
+			data_converted = pvt_tt_bh_raw_to_temp(data->raw);
 			break;
 		}
 		default:
@@ -147,7 +147,7 @@ static int pvt_tt_bh_decode_sample(const uint8_t *buf, struct sensor_chan_spec c
 		break;
 	}
 
-	float_to_sensor_value(data_converted, out);
+	pvt_tt_bh_float_to_sensor_value(data_converted, out);
 	return 0;
 }
 

--- a/include/zephyr/drivers/sensor/tenstorrent/pvt_tt_bh.h
+++ b/include/zephyr/drivers/sensor/tenstorrent/pvt_tt_bh.h
@@ -54,37 +54,37 @@ struct pvt_tt_bh_rtio_data {
 /*
  * Convert raw temperature sensor data to celcius.
  */
-float raw_to_temp(uint16_t raw);
+float pvt_tt_bh_raw_to_temp(uint16_t raw);
 
 /*
  * Convert celcius into raw temperature sensor data.
  */
-uint16_t temp_to_raw(const struct sensor_value *value);
+uint16_t pvt_tt_bh_temp_to_raw(const struct sensor_value *value);
 
 /*
  * Convert raw voltage monitor data to volts.
  */
-float raw_to_volt(uint16_t raw);
+float pvt_tt_bh_raw_to_volt(uint16_t raw);
 
 /*
  * Convert voltage insto raw voltage monitor data;
  */
-uint16_t volt_to_raw(const struct sensor_value *value);
+uint16_t pvt_tt_bh_volt_to_raw(const struct sensor_value *value);
 
 /*
  * Convert raw process detector data to MHz.
  */
-float raw_to_freq(uint16_t raw);
+float pvt_tt_bh_raw_to_freq(uint16_t raw);
 
 /*
  * Convert frequency into raw process detector data.
  */
-uint16_t freq_to_raw(const struct sensor_value *value);
+uint16_t pvt_tt_bh_freq_to_raw(const struct sensor_value *value);
 
 /*
  * Represent float data as two integers in struct sensor_value.
  */
-void float_to_sensor_value(float data, struct sensor_value *val);
+void pvt_tt_bh_float_to_sensor_value(float data, struct sensor_value *val);
 
 int pvt_tt_bh_get_decoder(const struct device *dev, const struct sensor_decoder_api **api);
 

--- a/lib/tenstorrent/bh_arc/pvt.c
+++ b/lib/tenstorrent/bh_arc/pvt.c
@@ -70,7 +70,7 @@ static uint8_t read_ts_handler(uint32_t msg_code, const struct request *request,
 	decoder->decode(buf, (struct sensor_chan_spec){SENSOR_CHAN_PVT_TT_BH_TS, id}, NULL, 8,
 			&celcius);
 
-	response->data[1] = temp_to_raw(&celcius);
+	response->data[1] = pvt_tt_bh_temp_to_raw(&celcius);
 	response->data[2] = ConvertFloatToTelemetry(sensor_value_to_float(&celcius));
 
 	return ret;
@@ -96,7 +96,7 @@ static uint8_t read_pd_handler(uint32_t msg_code, const struct request *request,
 	decoder->decode(buf, (struct sensor_chan_spec){SENSOR_CHAN_PVT_TT_BH_PD, id}, NULL, 8,
 			&freq);
 
-	response->data[1] = freq_to_raw(&freq);
+	response->data[1] = pvt_tt_bh_freq_to_raw(&freq);
 	response->data[2] = ConvertFloatToTelemetry(sensor_value_to_float(&freq));
 
 	return ret;
@@ -118,7 +118,7 @@ static uint8_t read_vm_handler(uint32_t msg_code, const struct request *request,
 	decoder->decode(buf, (struct sensor_chan_spec){SENSOR_CHAN_PVT_TT_BH_VM, id}, NULL, 8,
 			&volts);
 
-	response->data[1] = volt_to_raw(&volts);
+	response->data[1] = pvt_tt_bh_volt_to_raw(&volts);
 	response->data[2] = (uint16_t)sensor_value_to_float(&volts) * 1000;
 
 	return ret;

--- a/tests/boards/tenstorrent/tt_blackhole/sensor/pvt/src/main.c
+++ b/tests/boards/tenstorrent/tt_blackhole/sensor/pvt/src/main.c
@@ -87,9 +87,9 @@ ZTEST(pvt_tt_bh_tests, test_read_decode_pd)
 	for (int i = 0; i < NUM_READS; i++) {
 		const struct pvt_tt_bh_rtio_data *raw_freq =
 			&(((const struct pvt_tt_bh_rtio_data *)test_buf)[i]);
-		float converted_freq = raw_to_freq(raw_freq->raw);
+		float converted_freq = pvt_tt_bh_raw_to_freq(raw_freq->raw);
 
-		float_to_sensor_value(converted_freq, &freq_from_manual);
+		pvt_tt_bh_float_to_sensor_value(converted_freq, &freq_from_manual);
 
 		/* Get celcius value from decoder */
 		decoder->decode(test_buf, (struct sensor_chan_spec){SENSOR_CHAN_PVT_TT_BH_PD, i},
@@ -135,9 +135,9 @@ ZTEST(pvt_tt_bh_tests, test_read_decode_vm)
 	for (int i = 0; i < NUM_READS; i++) {
 		const struct pvt_tt_bh_rtio_data *raw_volt =
 			&(((const struct pvt_tt_bh_rtio_data *)test_buf)[i]);
-		float converted_volt = raw_to_volt(raw_volt->raw);
+		float converted_volt = pvt_tt_bh_raw_to_volt(raw_volt->raw);
 
-		float_to_sensor_value(converted_volt, &volt_from_manual);
+		pvt_tt_bh_float_to_sensor_value(converted_volt, &volt_from_manual);
 
 		/* Get celcius value from decoder */
 		decoder->decode(test_buf, (struct sensor_chan_spec){SENSOR_CHAN_PVT_TT_BH_VM, i},
@@ -182,9 +182,9 @@ ZTEST(pvt_tt_bh_tests, test_read_decode_ts)
 
 		const struct pvt_tt_bh_rtio_data *raw_temp =
 			&(((const struct pvt_tt_bh_rtio_data *)test_buf)[i]);
-		float converted_temp = raw_to_temp(raw_temp->raw);
+		float converted_temp = pvt_tt_bh_raw_to_temp(raw_temp->raw);
 
-		float_to_sensor_value(converted_temp, &celcius_from_manual);
+		pvt_tt_bh_float_to_sensor_value(converted_temp, &celcius_from_manual);
 
 		/* Get celcius value from decoder */
 		decoder->decode(test_buf, (struct sensor_chan_spec){SENSOR_CHAN_PVT_TT_BH_TS, i},
@@ -232,7 +232,7 @@ ZTEST(pvt_tt_bh_tests, test_read_decode_ts_avg)
 	}
 
 	avg_tmp /= 8;
-	float_to_sensor_value(avg_tmp, &celcius_from_manual_avg);
+	pvt_tt_bh_float_to_sensor_value(avg_tmp, &celcius_from_manual_avg);
 
 	/* Get celcius value from average channel decoder */
 	decoder->decode(test_buf, (struct sensor_chan_spec){SENSOR_CHAN_PVT_TT_BH_TS_AVG, 0}, NULL,
@@ -271,9 +271,9 @@ ZTEST(pvt_tt_bh_tests, test_read_decode_all)
 	/* Test PD (Process Detector) - index 0 */
 	const struct pvt_tt_bh_rtio_data *raw_freq =
 		&(((const struct pvt_tt_bh_rtio_data *)test_buf)[0]);
-	float converted_freq = raw_to_freq(raw_freq->raw);
+	float converted_freq = pvt_tt_bh_raw_to_freq(raw_freq->raw);
 
-	float_to_sensor_value(converted_freq, &from_manual);
+	pvt_tt_bh_float_to_sensor_value(converted_freq, &from_manual);
 	LOG_DBG("PD freq from manual: %d.%d", from_manual.val1, from_manual.val2);
 
 	/* Get frequency value from decoder */
@@ -295,9 +295,9 @@ ZTEST(pvt_tt_bh_tests, test_read_decode_all)
 	/* Test VM (Voltage Monitor) - index 1 */
 	const struct pvt_tt_bh_rtio_data *raw_volt =
 		&(((const struct pvt_tt_bh_rtio_data *)test_buf)[1]);
-	float converted_volt = raw_to_volt(raw_volt->raw);
+	float converted_volt = pvt_tt_bh_raw_to_volt(raw_volt->raw);
 
-	float_to_sensor_value(converted_volt, &from_manual);
+	pvt_tt_bh_float_to_sensor_value(converted_volt, &from_manual);
 	LOG_DBG("VM volt from manual: %d.%d", from_manual.val1, from_manual.val2);
 
 	/* Get voltage value from decoder */
@@ -319,9 +319,9 @@ ZTEST(pvt_tt_bh_tests, test_read_decode_all)
 	/* Test TS (Temperature Sensor) - index 2 */
 	const struct pvt_tt_bh_rtio_data *raw_temp =
 		&(((const struct pvt_tt_bh_rtio_data *)test_buf)[2]);
-	float converted_temp = raw_to_temp(raw_temp->raw);
+	float converted_temp = pvt_tt_bh_raw_to_temp(raw_temp->raw);
 
-	float_to_sensor_value(converted_temp, &from_manual);
+	pvt_tt_bh_float_to_sensor_value(converted_temp, &from_manual);
 	LOG_DBG("TS celsius from manual: %d.%d", from_manual.val1, from_manual.val2);
 
 	/* Get temperature value from decoder */


### PR DESCRIPTION
Namespace helper functions that convert between data types with pvt_tt_bh as they are in the global namespace. It is not possible to make them private/static as they are used by multiple files.