### PR TITLE
ci: release: ensure build artifacts for all board revisions are in zip

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,6 +99,7 @@ jobs:
           name: tt-zephyr-platforms-${{ steps.set_vars.outputs.VERSION }}.spdx
 
       - name: Package firmware artifacts
+        shell: bash
         run: |
           BOARD_REVS=(${{ needs.prepare-release.outputs.boards }})
 
@@ -107,7 +108,7 @@ jobs:
             mv $REV/update.fwbundle $REV.fwbundle
           done
 
-          zip -r -9 tt-zephyr-platforms-${{ steps.set_vars.outputs.VERSION }}.zip $BOARD_REVS
+          zip -r -9 tt-zephyr-platforms-${{ steps.set_vars.outputs.VERSION }}.zip ${BOARD_REVS[@]}
 
       - name: Create Release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
Since 49aacf6a3cb660f252a003b38a88296d9c1c4e03, the `tt-zephyr-platforms-<version>.zip` file that is created as a published release artifact, that contains build and debug information for all platforms, has only included a subdirectory for `p100`.

This is because the local variable was changed to a bash array `BOARD_REVS=(...)` but in the invocation of `zip`, the variable was evaluated as a normal variable rather than as a bash array.

Use `${BOARD_REVS[@]}` instead of `$BOARD_REVS` to have the variable evaluate to e.g. `p100 p100a p150a p150b p150c p300a p300b p300c galaxy` instead of only `p100`.

See [SYS-2054](https://tenstorrent.atlassian.net/browse/SYS-2054) for more information.