### PR TITLE
app: smc: fix tracing build

### DIFF
--- a/app/smc/tracing.conf
+++ b/app/smc/tracing.conf
@@ -1,13 +1,3 @@
-# console
-CONFIG_CONSOLE=y
-CONFIG_SERIAL=y
-CONFIG_UART_CONSOLE=y
-CONFIG_RAM_CONSOLE=n
-
-# disable RTT console so that we can use vuart
-CONFIG_USE_SEGGER_RTT=n
-CONFIG_RTT_CONSOLE=n
-
 # tracing
 CONFIG_TRACING=y
 CONFIG_TRACING_CTF=y


### PR DESCRIPTION
Fix tracing build- we no longer need to disable RTT, as RTT logging is always enabled.