### PR TITLE
lib: tenstorrent: log_ringbuf: support direct buffer access

### DIFF
--- a/include/tenstorrent/log_backend_ringbuf.h
+++ b/include/tenstorrent/log_backend_ringbuf.h
@@ -12,12 +12,21 @@ extern "C" {
 #endif
 
 /**
- * Read data from the Ring buffer log backend.
- * @param data Pointer to buffer to fill with data
- * @param length Length of buffer
- * @return Number of bytes read, or negative error code
+ * Get address of ring buffer log backend buffer.
+ * internally calls `ring_buf_get_claim()` on the logging ring buffer.
+ * @param data Pointer to address. Will be set to location within ring buffer
+ * @param length Requested length of data to claim
+ * @return Number of valid bytes claimed. May be less than requested length.
  */
-int log_backend_ringbuf_get_data(uint8_t *data, size_t length);
+int log_backend_ringbuf_get_claim(uint8_t **data, size_t length);
+
+/**
+ * Finish claiming data from the ring buffer log backend.
+ * internally calls `ring_buf_get_finish()` on the logging ring buffer.
+ * @param length Number of bytes read from the buffer.
+ * @return 0 on success, negative error code on failure.
+ */
+int log_backend_ringbuf_finish_claim(size_t length);
 
 /**
  * Clear the ring buffer log backend.

--- a/lib/tenstorrent/log_ringbuf/log_backend_ringbuf.c
+++ b/lib/tenstorrent/log_ringbuf/log_backend_ringbuf.c
@@ -26,14 +26,27 @@ static uint32_t log_format_current = CONFIG_LOG_BACKEND_RINGBUF_OUTPUT_DEFAULT;
 
 RING_BUF_DECLARE(ringbuf_output_buf, CONFIG_LOG_BACKEND_RINGBUF_BUFFER_SIZE);
 
-/*
- * This function is exported so that the application can
- * pull data from the ringbuf to stream to an external
- * consumer.
+/**
+ * Get address of ring buffer log backend buffer.
+ * internally calls `ring_buf_get_claim()` on the logging ring buffer.
+ * @param data Pointer to address. Will be set to location within ring buffer
+ * @param length Requested length of data to claim
+ * @return Number of valid bytes claimed. May be less than requested length.
  */
-int log_backend_ringbuf_get_data(uint8_t *data, size_t length)
+int log_backend_ringbuf_get_claim(uint8_t **data, size_t length)
 {
-	return ring_buf_get(&ringbuf_output_buf, data, length);
+	return ring_buf_get_claim(&ringbuf_output_buf, data, length);
+}
+
+/**
+ * Finish claiming data from the ring buffer log backend.
+ * internally calls `ring_buf_get_finish()` on the logging ring buffer.
+ * @param length Number of bytes read from the buffer.
+ * @return 0 on success, negative error code on failure.
+ */
+int log_backend_ringbuf_finish_claim(size_t length)
+{
+	return ring_buf_get_finish(&ringbuf_output_buf, length);
 }
 
 /* This function is exported so the application can reset buffer state */


### PR DESCRIPTION
Support direct buffer access within log_ringbuf, so that the ring buffer memory can be read directly without copying. This also allows us to attempt to transmit data from the ringbuffer before we actually mark it as consumed.

This fixes a bug with the DMFW logging implementation where the DMFW would stream the initial log data via SMBUS before the SMC was ready to read it. With get/finish claims, we only actually consume the log data if the SMBUS block write succeeds, so the early portion of logs aren't lost.

Thanks to @jgrowdenTT for catching this