### PR TITLE
drivers: smbus: target: always use variable block sizes

### DIFF
--- a/include/tenstorrent/smbus_target.h
+++ b/include/tenstorrent/smbus_target.h
@@ -36,16 +36,13 @@ typedef int32_t (*SmbusRcvHandler)(const uint8_t *data, uint8_t size);
  *          application to send to the I2C controller. SMBUS send handlers shall
  *          return 0 on success, and any other value on failure.
  */
-typedef int32_t (*SmbusSendHandler)(uint8_t *data, uint8_t size);
+typedef int32_t (*SmbusSendHandler)(uint8_t *data, uint8_t *size);
 
 typedef struct {
 	SmbusTransType trans_type;
 	SmbusRcvHandler rcv_handler;
 	SmbusSendHandler send_handler;
-	uint8_t expected_blocksize_r; /* Only used for block r commands */
-	uint8_t expected_blocksize_w; /* Only used for block w commands */
 	uint8_t pec: 1;
-	uint8_t variable_blocksize: 1; /* If set, block size can be <= expected */
 } SmbusCmdDef;
 
 /**

--- a/lib/tenstorrent/bh_arc/cm2dm_msg.c
+++ b/lib/tenstorrent/bh_arc/cm2dm_msg.c
@@ -68,13 +68,11 @@ static Cm2DmMsgId next_id_rr(uint32_t pending_messages)
 	return (Cm2DmMsgId)next_message_id;
 }
 
-int32_t Cm2DmMsgReqSmbusHandler(uint8_t *data, uint8_t size)
+int32_t Cm2DmMsgReqSmbusHandler(uint8_t *data, uint8_t *size)
 {
 	BUILD_ASSERT(sizeof(cm2dm_msg_state.curr_msg) == 6,
 		     "Unexpected size of cm2dm_msg_state.curr_msg");
-	if (size != sizeof(cm2dm_msg_state.curr_msg)) {
-		return -1;
-	}
+	*size = sizeof(cm2dm_msg_state.curr_msg);
 
 	if (!cm2dm_msg_state.curr_msg_valid) {
 		atomic_val_t pending_messages = atomic_get(&cm2dm_msg_state.pending_messages);
@@ -325,13 +323,11 @@ int32_t SMBusTelemRegHandler(const uint8_t *data, uint8_t size)
 	return 0;
 }
 
-int32_t SMBusTelemDataHandler(uint8_t *data, uint8_t size)
+int32_t SMBusTelemDataHandler(uint8_t *data, uint8_t *size)
 {
 	uint32_t telemetry_data;
 
-	if (size != 7U) {
-		return -1;
-	}
+	*size = 7U;
 	data[0] = GetTelemetryTagValid(telemetry_reg) ? 0U : 1U;
 	data[1] = 0U;
 	data[2] = 0U;
@@ -361,12 +357,10 @@ int32_t Dm2CmWriteTelemetry(const uint8_t *data, uint8_t size)
 	return 0;
 }
 
-int32_t Dm2CmReadControlData(uint8_t *data, uint8_t size)
+int32_t Dm2CmReadControlData(uint8_t *data, uint8_t *size)
 {
-	if (size != 20) {
-		return -1;
-	}
-	(void)memset(data, 0U, size);
+	*size = 20U;
+	(void)memset(data, 0U, *size);
 
 	struct {
 		uint32_t pcie_index: 8;
@@ -390,8 +384,8 @@ int32_t Dm2CmReadControlData(uint8_t *data, uint8_t size)
 	 */
 	uint8_t pec = 0U;
 
-	pec = crc8(&size, 1, 0x7, 0U, false);
-	pec = crc8(data, size - 1, 0x7, pec, false);
+	pec = crc8(size, 1, 0x7, 0U, false);
+	pec = crc8(data, *size - 1, 0x7, pec, false);
 	data[19] = pec;
 	return 0;
 }

--- a/lib/tenstorrent/bh_arc/cm2dm_msg.h
+++ b/lib/tenstorrent/bh_arc/cm2dm_msg.h
@@ -11,7 +11,7 @@
 #include <tenstorrent/bh_arc.h>
 
 void PostCm2DmMsg(Cm2DmMsgId msg_id, uint32_t data);
-int32_t Cm2DmMsgReqSmbusHandler(uint8_t *data, uint8_t size);
+int32_t Cm2DmMsgReqSmbusHandler(uint8_t *data, uint8_t *size);
 int32_t Cm2DmMsgAckSmbusHandler(const uint8_t *data, uint8_t size);
 
 void ChipResetRequest(void *arg);
@@ -29,9 +29,9 @@ int32_t GetInputCurrent(void);
 uint16_t GetInputPower(void);
 int32_t Dm2CmSendFanRPMHandler(const uint8_t *data, uint8_t size);
 int32_t SMBusTelemRegHandler(const uint8_t *data, uint8_t size);
-int32_t SMBusTelemDataHandler(uint8_t *data, uint8_t size);
+int32_t SMBusTelemDataHandler(uint8_t *data, uint8_t *size);
 int32_t Dm2CmSendThermTripCountHandler(const uint8_t *data, uint8_t size);
 int32_t Dm2CmWriteTelemetry(const uint8_t *data, uint8_t size);
-int32_t Dm2CmReadControlData(uint8_t *data, uint8_t size);
+int32_t Dm2CmReadControlData(uint8_t *data, uint8_t *size);
 int32_t Dm2CmDMCLogHandler(const uint8_t *data, uint8_t size);
 #endif

--- a/lib/tenstorrent/bh_arc/smbus_target.c
+++ b/lib/tenstorrent/bh_arc/smbus_target.c
@@ -48,18 +48,15 @@ static int32_t Dm2CmSendFanSpeedHandler(const uint8_t *data, uint8_t size)
 	return -1;
 }
 
-int32_t ReadByteTest(uint8_t *data, uint8_t size)
+static int32_t ReadByteTest(uint8_t *data, uint8_t *size)
 {
-	if (size != 1) {
-		return -1;
-	}
-
+	*size = 1;
 	data[0] = ReadReg(STATUS_FW_SCRATCH_REG_ADDR) & 0xFF;
 
 	return 0;
 }
 
-int32_t WriteByteTest(const uint8_t *data, uint8_t size)
+static int32_t WriteByteTest(const uint8_t *data, uint8_t size)
 {
 	if (size != 1) {
 		return -1;
@@ -68,11 +65,9 @@ int32_t WriteByteTest(const uint8_t *data, uint8_t size)
 	return 0;
 }
 
-int32_t ReadWordTest(uint8_t *data, uint8_t size)
+static int32_t ReadWordTest(uint8_t *data, uint8_t *size)
 {
-	if (size != 2) {
-		return -1;
-	}
+	*size = 2U;
 
 	uint32_t tmp = ReadReg(STATUS_FW_SCRATCH_REG_ADDR);
 
@@ -82,7 +77,7 @@ int32_t ReadWordTest(uint8_t *data, uint8_t size)
 	return 0;
 }
 
-int32_t WriteWordTest(const uint8_t *data, uint8_t size)
+static int32_t WriteWordTest(const uint8_t *data, uint8_t size)
 {
 	if (size != 2) {
 		return -1;
@@ -91,11 +86,9 @@ int32_t WriteWordTest(const uint8_t *data, uint8_t size)
 	return 0;
 }
 
-int32_t BlockReadTest(uint8_t *data, uint8_t size)
+static int32_t BlockReadTest(uint8_t *data, uint8_t *size)
 {
-	if (size != 4) {
-		return -1;
-	}
+	*size = 4;
 	uint32_t tmp = ReadReg(STATUS_FW_SCRATCH_REG_ADDR);
 
 	memcpy(data, &tmp, 4);
@@ -131,7 +124,6 @@ int32_t UpdateArcStateHandler(const uint8_t *data, uint8_t size)
 
 static const SmbusCmdDef smbus_req_cmd_def = {.pec = 1U,
 					      .trans_type = kSmbusTransBlockRead,
-					      .expected_blocksize_r = 6,
 					      .send_handler = &Cm2DmMsgReqSmbusHandler};
 
 static const SmbusCmdDef smbus_ack_cmd_def = {
@@ -139,13 +131,10 @@ static const SmbusCmdDef smbus_ack_cmd_def = {
 
 static const SmbusCmdDef smbus_update_arc_state_cmd_def = {.pec = 0U,
 							   .trans_type = kSmbusTransBlockWrite,
-							   .expected_blocksize_w = 3,
 							   .rcv_handler = &UpdateArcStateHandler};
 
 static const SmbusCmdDef smbus_dm_static_info_cmd_def = {.pec = 1U,
 							 .trans_type = kSmbusTransBlockWrite,
-							 .expected_blocksize_w =
-								 sizeof(dmStaticInfo),
 							 .rcv_handler = &Dm2CmSendDataHandler};
 
 static const SmbusCmdDef smbus_ping_cmd_def = {
@@ -160,15 +149,11 @@ static const SmbusCmdDef smbus_fan_rpm_cmd_def = {
 #ifndef CONFIG_TT_SMC_RECOVERY
 static const SmbusCmdDef smbus_telem_read_cmd_def = {.pec = 0U,
 						     .trans_type = kSmbusTransBlockWriteBlockRead,
-						     .expected_blocksize_w = 1,
-						     .expected_blocksize_r = 7,
 						     .rcv_handler = SMBusTelemRegHandler,
 						     .send_handler = SMBusTelemDataHandler};
 
 static const SmbusCmdDef smbus_telem_write_cmd_def = {.pec = 0U,
 						      .trans_type = kSmbusTransBlockWriteBlockRead,
-						      .expected_blocksize_w = 33,
-						      .expected_blocksize_r = 20,
 						      .rcv_handler = Dm2CmWriteTelemetry,
 						      .send_handler = Dm2CmReadControlData};
 
@@ -183,7 +168,6 @@ static const SmbusCmdDef smbus_telem_reg_cmd_def = {
 
 static const SmbusCmdDef smbus_telem_data_cmd_def = {.pec = 1U,
 						     .trans_type = kSmbusTransBlockRead,
-						     .expected_blocksize_r = 7U,
 						     .send_handler = &SMBusTelemDataHandler};
 
 static const SmbusCmdDef smbus_therm_trip_count_cmd_def = {.pec = 1U,
@@ -193,7 +177,6 @@ static const SmbusCmdDef smbus_therm_trip_count_cmd_def = {.pec = 1U,
 
 #endif /*CONFIG_TT_SMC_RECOVERY*/
 static const SmbusCmdDef smbus_dmc_log_cmd_def = {.pec = 1U,
-						  .variable_blocksize = 1U,
 						  .trans_type = kSmbusTransBlockWrite,
 						  .rcv_handler = &Dm2CmDMCLogHandler};
 
@@ -212,19 +195,15 @@ static const SmbusCmdDef smbus_test_write_word_cmd_def = {
 static const SmbusCmdDef smbus_block_write_block_read_test = {
 	.pec = 1U,
 	.trans_type = kSmbusTransBlockWriteBlockRead,
-	.expected_blocksize_r = 4,
-	.expected_blocksize_w = 4,
 	.rcv_handler = &BlockWriteTest,
 	.send_handler = BlockReadTest};
 
 static const SmbusCmdDef smbus_test_read_block_cmd_def = {.pec = 1U,
 							  .trans_type = kSmbusTransBlockRead,
-							  .expected_blocksize_r = 4,
 							  .send_handler = &BlockReadTest};
 
 static const SmbusCmdDef smbus_test_write_block_cmd_def = {.pec = 1U,
 							   .trans_type = kSmbusTransBlockWrite,
-							   .expected_blocksize_w = 4,
 							   .rcv_handler = &BlockWriteTest};
 
 static int InitSmbusTarget(void)

--- a/tests/lib/tenstorrent/bh_arc/src/smbus_target.c
+++ b/tests/lib/tenstorrent/bh_arc/src/smbus_target.c
@@ -75,7 +75,7 @@ ZTEST(smbus_target, test_unsolicited_read_received)
 
 ZTEST(smbus_target, test_write_received_bad_blocksize)
 {
-	uint8_t write_data[] = {CMFW_SMBUS_TEST_WRITE_BLOCK, 5U};
+	uint8_t write_data[] = {CMFW_SMBUS_TEST_WRITE_BLOCK, 5U, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 54U};
 
 	/* WRITE_BLOCK is a valid command */
 	zassert_equal(-1, i2c_write(i2c0_dev, write_data, sizeof(write_data), tt_i2c_addr));
@@ -206,7 +206,7 @@ ZTEST(smbus_target, test_update_arc_test_state_0)
 
 ZTEST(smbus_target, test_telem_read_bad_w_blocksize)
 {
-	uint8_t write_data[] = {CMFW_SMBUS_TELEMETRY_READ, 0x3};
+	uint8_t write_data[] = {CMFW_SMBUS_TELEMETRY_READ, 0x3, 0xAA, 0xBB, 0xCC};
 
 	zassert_equal(-1, i2c_write(i2c0_dev, write_data, sizeof(write_data), tt_i2c_addr));
 }


### PR DESCRIPTION
Block sizes for the reads from SMC can be provided by the callback 
Block sizes for the writes to SMC can be checked by the callback.

This means we can now support variable sized read commands implicitly.