### PR TITLE
scripts: define left ASIC first for P300

### DIFF
--- a/scripts/board_metadata.yaml
+++ b/scripts/board_metadata.yaml
@@ -31,33 +31,33 @@ p150c:
 p300a:
   - upi: 0x45
     name: "P300A-1"
-    bootfs-name: "tt_boot_fs_right"
-    protobuf-name: "P300A_R"
-    pyocd-config: "pyocd_config_spi1.py"
-  - upi: 0x45
-    name: "P300A-1"
     bootfs-name: "tt_boot_fs_left"
     protobuf-name: "P300A_L"
     pyocd-config: "pyocd_config_spi_combo.py"
-p300b:
-  - upi: 0x44
-    name: "P300B-1"
+  - upi: 0x45
+    name: "P300A-1"
     bootfs-name: "tt_boot_fs_right"
-    protobuf-name: "P300B_R"
+    protobuf-name: "P300A_R"
     pyocd-config: "pyocd_config_spi1.py"
+p300b:
   - upi: 0x44
     name: "P300B-1"
     bootfs-name: "tt_boot_fs_left"
     protobuf-name: "P300B_L"
     pyocd-config: "pyocd_config_spi_combo.py"
-p300c:
-  - upi: 0x46
-    name: "P300C-1"
+  - upi: 0x44
+    name: "P300B-1"
     bootfs-name: "tt_boot_fs_right"
-    protobuf-name: "P300C_R"
+    protobuf-name: "P300B_R"
     pyocd-config: "pyocd_config_spi1.py"
+p300c:
   - upi: 0x46
     name: "P300C-1"
     bootfs-name: "tt_boot_fs_left"
     protobuf-name: "P300C_L"
     pyocd-config: "pyocd_config_spi_combo.py"
+  - upi: 0x46
+    name: "P300C-1"
+    bootfs-name: "tt_boot_fs_right"
+    protobuf-name: "P300C_R"
+    pyocd-config: "pyocd_config_spi1.py"

--- a/scripts/board_metadata.yaml
+++ b/scripts/board_metadata.yaml
@@ -30,34 +30,34 @@ p150c:
     pyocd-config: "pyocd_config_spi1.py"
 p300a:
   - upi: 0x45
-    name: "P300A-1"
+    name: "P300A-1_left"
     bootfs-name: "tt_boot_fs_left"
     protobuf-name: "P300A_L"
     pyocd-config: "pyocd_config_spi_combo.py"
   - upi: 0x45
-    name: "P300A-1"
+    name: "P300A-1_right"
     bootfs-name: "tt_boot_fs_right"
     protobuf-name: "P300A_R"
     pyocd-config: "pyocd_config_spi1.py"
 p300b:
   - upi: 0x44
-    name: "P300B-1"
+    name: "P300B-1_left"
     bootfs-name: "tt_boot_fs_left"
     protobuf-name: "P300B_L"
     pyocd-config: "pyocd_config_spi_combo.py"
   - upi: 0x44
-    name: "P300B-1"
+    name: "P300B-1_right"
     bootfs-name: "tt_boot_fs_right"
     protobuf-name: "P300B_R"
     pyocd-config: "pyocd_config_spi1.py"
 p300c:
   - upi: 0x46
-    name: "P300C-1"
+    name: "P300C-1_left"
     bootfs-name: "tt_boot_fs_left"
     protobuf-name: "P300C_L"
     pyocd-config: "pyocd_config_spi_combo.py"
   - upi: 0x46
-    name: "P300C-1"
+    name: "P300C-1_right"
     bootfs-name: "tt_boot_fs_right"
     protobuf-name: "P300C_R"
     pyocd-config: "pyocd_config_spi1.py"

--- a/scripts/tooling/blackhole_recovery/recover-blackhole.py
+++ b/scripts/tooling/blackhole_recovery/recover-blackhole.py
@@ -209,6 +209,9 @@ def main():
             # Delay a moment for ASIC boot
             time.sleep(2)
             pcie_utils.rescan_pcie()
+        # Now, check if all asics are functional
+        for idx in range(len(BOARD_ID_MAP[args.board])):
+            asic = BOARD_ID_MAP[args.board][idx]
             if not check_card_status(idx, asic):
                 raise RuntimeError(f"ASIC {idx} did not enumerate after flash")
             print(f"Successfully flashed {asic['bootfs-name']}")


### PR DESCRIPTION
Recovery scripting flashes ASICs in the order they are described, and
the left bootfs is the only one that contains the DMFW for P300 systems.
Define this asic first in metadata, so the board recovery scripting will
flash the DMFW during the initial recovery phase.

Signed-off-by: Daniel DeGrasse <ddegrasse@tenstorrent.com>