### PR TITLE
scripts: tooling: vuart: report error if card reads as 0xffff_ffff

### DIFF
--- a/scripts/tooling/vuart.c
+++ b/scripts/tooling/vuart.c
@@ -495,6 +495,10 @@ int vuart_start(struct vuart_data *data)
 		}
 		data->vuart_addr = ret;
 		D(2, "discovery address: 0x%08x", data->vuart_addr);
+		if (data->vuart_addr == 0xffffffff) {
+			D(1, "Read 0xffffffff from ARC. Please reset the card and try again.");
+			return -ENOENT;
+		}
 
 		uint64_t adjust;
 


### PR DESCRIPTION
During reset, a card may read as 0xffff_ffff until the card re-enumerates over pcie. In this case, return an error so the vuart tooling will rescan pcie.