### PR TITLE
app: pytest: e2e_smoke: rework harness setup

### DIFF
--- a/.github/workflows/hardware-smoke.yml
+++ b/.github/workflows/hardware-smoke.yml
@@ -246,6 +246,12 @@ jobs:
             echo "ASIC_ID=0" >> "$GITHUB_ENV"
           fi
 
+      - name: build-tt-smc_console
+        working-directory: tt-zephyr-platforms/scripts/tooling
+        run: |
+          # Build tt-console
+          make
+
       - name: run-e2e-tests
         working-directory: zephyr
         run: |

--- a/app/smc/pytest/e2e_smoke.py
+++ b/app/smc/pytest/e2e_smoke.py
@@ -37,6 +37,7 @@ BOOT_STATUS = 0x80030408
 PCIE_INIT_CPL_TIME_REG_ADDR = 0x80030438
 CMFW_START_TIME_REG_ADDR = 0x8003043C
 ARC_START_TIME_REG_ADDR = 0x80030440
+ARC_HANG_PC_REG_ADDR = 0x80030454
 
 # ARC messages
 ARC_MSG_TYPE_REINIT_TENSIX = 0x20
@@ -48,24 +49,37 @@ ARC_MSG_TYPE_PING_DM = 0xC0
 ARC_MSG_TYPE_SET_WDT = 0xC1
 
 
-def get_arc_chip(unlaunched_dut: DeviceAdapter, asic_id):
+@pytest.fixture(scope="session")
+def launched_arc_dut(unlaunched_dut: DeviceAdapter):
     """
-    Validates the ARC firmware is alive and booted, since this required
-    for any test to run
+    This fixture launches the Zephyr DUT once per test session, and returns
+    a reference to the launched DUT. This is used by tests that need to
+    flash the DUT once, and then run multiple tests against it.
     """
-    logger.info(f"Getting ASIC ID {asic_id}")
-    # Try to flash the DUT
+    logger.info("Flashing ARC DUT")
     try:
         unlaunched_dut.launch()
     except TwisterHarnessException:
         pytest.exit("Failed to flash DUT")
     except TwisterHarnessTimeoutException:
         pytest.exit("DUT flash timed out")
-    time.sleep(1)
+    time.sleep(1)  # Wait for ARC to start
+    return unlaunched_dut
+
+
+@pytest.fixture()
+def arc_chip_dut(launched_arc_dut, asic_id):
+    """
+    This fixture returns the Zephyr DUT once the ARC chip is ready. Otherwise, it
+    raises a runtime error.
+
+    We use this approach rather than providing a reference to the pyluwen
+    chip directly because tests may need to delete chip objects after they
+    reset the ARC chip to induce pyluwen to close open file descriptors
+    """
     start = time.time()
     # Attempt to detect the ARC chip for 15 seconds
     timeout = 15
-    chips = []
     while True:
         try:
             chips = pyluwen.detect_chips()
@@ -73,7 +87,12 @@ def get_arc_chip(unlaunched_dut: DeviceAdapter, asic_id):
                 logger.info("Detected ARC chip")
                 break
         except Exception:
-            print("Warning- SMC firmware requires a reset. Rescanning PCIe bus")
+            logger.warning("SMC firmware requires a reset. Rescanning PCIe bus")
+        except BaseException as e:
+            # We will continue through these exceptions, since pyluwen
+            # sometimes throws rust exceptions when the chip is resetting.
+            # log them with a higher severity so we can track them
+            logger.error(f"Base exception error while detecting chips: {e}")
         time.sleep(0.5)
         if time.time() - start > timeout:
             # Dump the SMC state for debugging
@@ -85,25 +104,25 @@ def get_arc_chip(unlaunched_dut: DeviceAdapter, asic_id):
     try:
         status = chip.axi_read32(ARC_STATUS)
     except Exception:
-        print("Warning- SMC firmware requires a reset. Rescanning PCIe bus")
+        logger.warning("SMC firmware requires a reset. Rescanning PCIe bus")
         rescan_pcie()
         status = chip.axi_read32(ARC_STATUS)
     assert (status & 0xFFFF0000) == 0xC0DE0000, "SMC firmware postcode is invalid"
     # Check post code status of firmware
     assert (status & 0xFFFF) >= 0x1D, "SMC firmware boot failed"
-    return chip
+    # Remove references to chip objects so pyluwen will close file descriptors.
+    # Otherwise these may become stale when SMC resets.
+    del chips
+    del chip
+    return launched_arc_dut
 
 
-@pytest.fixture(scope="session")
-def arc_chip(unlaunched_dut: DeviceAdapter, asic_id):
-    return get_arc_chip(unlaunched_dut, asic_id)
-
-
-def test_arc_msg(arc_chip):
+def test_arc_msg(arc_chip_dut, asic_id):
     """
     Runs a smoke test to verify that the ARC firmware can receive ARC messages
     """
     # Send a test message. We expect response to be incremented by 1
+    arc_chip = pyluwen.detect_chips()[asic_id]
     response = arc_chip.arc_msg(ARC_MSG_TYPE_TEST, True, False, 20, 0, 1000)
     assert response[0] == 21, "SMC did not respond to test message"
     assert response[1] == 0, "SMC response invalid"
@@ -113,41 +132,44 @@ def test_arc_msg(arc_chip):
     assert status == 0xC0DE003F, "SMC firmware has incorrect status"
 
 
-def test_dmc_msg(arc_chip):
+def test_dmc_msg(arc_chip_dut, asic_id):
     """
     Validates the DMC firmware is alive and responding to pings
     """
     # Send an ARC message to ping the DMC, and validate that it is online
+    arc_chip = pyluwen.detect_chips()[asic_id]
     response = arc_chip.arc_msg(ARC_MSG_TYPE_PING_DM, True, False, 0, 0, 1000)
     assert response[0] == 1, "DMC did not respond to ping from SMC"
     assert response[1] == 0, "SMC response invalid"
     logger.info('DMC ping message response "%d"', response[0])
 
 
-def test_boot_status(arc_chip):
+def test_boot_status(arc_chip_dut, asic_id):
     """
     Validates the boot status of the ARC firmware
     """
     # Read the boot status register and validate that it is correct
+    arc_chip = pyluwen.detect_chips()[asic_id]
     status = arc_chip.axi_read32(BOOT_STATUS)
     assert (status >> 1) & 0x3 == 0x2, "SMC HW boot status is not valid"
     logger.info('SMC boot status "%d"', status)
 
 
-def test_smbus_status(arc_chip):
+def test_smbus_status(arc_chip_dut, asic_id):
     """
     Validates that the SMBUS tests run from the DMC firmware passed
     """
     # We have limited visibility into the DMC firmware, so we read
     # the ARC scratch register the DMC should have set within SMBUS
     # tests to check that they passed
+    arc_chip = pyluwen.detect_chips()[asic_id]
     ARC_SCRATCH_63 = 0x80030400 + (63 * 4)
     status = arc_chip.axi_read32(ARC_SCRATCH_63)
     assert status == 0xFEEDFACE, "SMC firmware did not pass SMBUS tests"
     logger.info('SMC SMBUS status: "0x%x"', status)
 
 
-def test_flash_write(arc_chip):
+def test_flash_write(arc_chip_dut, asic_id):
     """
     Validates that flash read/write works via pyluwen,
     since this is the same interface used by tt-flash
@@ -159,6 +181,7 @@ def test_flash_write(arc_chip):
     WRITE_SIZE = 0x8000
     NUM_ITERATIONS = 5
 
+    arc_chip = pyluwen.detect_chips()[asic_id]
     # Read the SPI RX training region and validate that it is correct
     data = bytes(4)
     check_data = SPI_RX_TRAIN_DATA.to_bytes(4, byteorder="little")
@@ -219,11 +242,12 @@ def get_int_version_from_file(filename) -> int:
     return version_int
 
 
-def arc_watchdog_test(arc_chip):
+def arc_watchdog_test(asic_id):
     """
     Helper to run ARC watchdog test. Returns True on pass, or False on
     failure
     """
+    arc_chip = pyluwen.detect_chips()[asic_id]
     wdt_timeout = 1000
     # Setup ARC watchdog for a 1000ms timeout
     arc_chip.arc_msg(ARC_MSG_TYPE_SET_WDT, True, False, wdt_timeout, 0, 1000)
@@ -236,34 +260,62 @@ def arc_watchdog_test(arc_chip):
     if response[1] != 0:
         logger.warning("SMC response invalid")
         return False
+    # Clear the ARC hang register- this should be set during a watchdog reset
+    arc_chip.axi_write32(ARC_HANG_PC_REG_ADDR, 0)
     # Halt the ARC cores.
     arc_chip.axi_write32(ARC_MISC_CTRL, 0xF0)
     # Make sure we can still detect ARC core after 500 ms
     time.sleep(0.5)
-    arc_chip = pyluwen.detect_chips()[0]
+    try:
+        arc_chip = pyluwen.detect_chips()[asic_id]
+        hang_pc = arc_chip.axi_read32(ARC_HANG_PC_REG_ADDR)
+        if hang_pc != 0:
+            logger.error(
+                "DMC reset too early (hang PC set), ARC should still be online"
+            )
+            return False
+    except Exception:
+        # Ideally we would catch a more specific exception here, but pyluwen
+        # does not currently have specific exception types
+        logger.error("DMC reset too early, ARC should still be online")
+        return False
     # Delay 600 more ms. Make sure the ARC has been reset.
     time.sleep(0.6)
-    # Ideally we would catch a more narrow exception, but this is what pyluwen raises
+    # Delete arc chip object, to make sure pyluwen drops open file descriptors
+    del arc_chip
     try:
-        # This should fail, since the ARC should have been reset
-        arc_chip = pyluwen.detect_chips()[0]
-        logger.warning("DMC did not reset ARC core. Still able to detect ARC chip")
-        # tt-kmd sets its own 10000ms timer, which sometimes can race our own
-        # timer and override it. To handle this case, delay 10 more seconds
-        # to allow the ARC to reset
-        logger.warning("Waiting 10 additional seconds to see if ARC core resets")
-        time.sleep(10)
-        arc_chip = pyluwen.detect_chips()[0]
-        logger.error("ARC core was not reset after 10 seconds")
-        return False
+        arc_chip = pyluwen.detect_chips()[asic_id]
+        hang_pc = arc_chip.axi_read32(ARC_HANG_PC_REG_ADDR)
+        # If the ARC chip was reset, the hang program counter should have been set
+        if hang_pc == 0:
+            logger.warning(
+                "ARC did not reset, waiting 10 additional seconds to see if ARC core resets"
+            )
+            time.sleep(10)
+            rescan_pcie()
+            arc_chip = pyluwen.detect_chips()[asic_id]
+            hang_pc = arc_chip.axi_read32(ARC_HANG_PC_REG_ADDR)
+            if hang_pc == 0:
+                logger.error("ARC core was not reset after ten seconds")
+                return False
     except Exception:
-        # Expected behavior, since the ARC should have been reset.
-        # Unfortunately, pyluwen does not throw a specific exception
+        # We expect an exception here since the ARC should be resetting
         pass
+    except BaseException as e:
+        # We will continue through these exceptions, since pyluwen
+        # sometimes throws rust exceptions when the chip is resetting.
+        # log them with a higher severity so we can track them
+        logger.error(f"Base exception error while detecting chips: {e}")
+    # Delay a bit, then rescan PCIe
     time.sleep(1.0)
+    # Rescan PCIe, and see if ARC chip has been reset
     rescan_pcie()
-    # ARC should now be back online
-    arc_chip = pyluwen.detect_chips()[0]
+    arc_chip = pyluwen.detect_chips()[asic_id]
+    hang_pc = arc_chip.axi_read32(ARC_HANG_PC_REG_ADDR)
+    if hang_pc == 0:
+        logger.error("ARC core was not reset, but PCIe device re-enumerated?")
+        return False
+    logger.info(f"ARC was reset, hang PC 0x{hang_pc:08X}")
     # Make sure ARC can still ping the DMC
     response = arc_chip.arc_msg(ARC_MSG_TYPE_PING_DM, True, False, 0, 0, 1000)
     if response[0] != 1:
@@ -277,22 +329,19 @@ def arc_watchdog_test(arc_chip):
 
 
 @pytest.mark.flash
-@pytest.mark.skipif(
-    os.environ.get("CONSOLE_DEV") == "/dev/tenstorrent/1",
-    reason="Test unreliable on p300a board",
-)
-def test_arc_watchdog(arc_chip):
+def test_arc_watchdog(arc_chip_dut, asic_id):
     """
     Validates that the DMC firmware watchdog for the ARC will correctly
     reset the chip
     """
-    assert arc_watchdog_test(arc_chip), "ARC watchdog test failed"
+    assert arc_watchdog_test(asic_id), "ARC watchdog test failed"
 
 
-def pcie_fw_load_time_test(arc_chip):
+def pcie_fw_load_time_test(asic_id):
     """
     Helper to run PCIe FW load time test. Returns True if passed, False if failed
     """
+    arc_chip = pyluwen.detect_chips()[asic_id]
     duration_deadline = 40  # 40 ms.
     pcie_init_cpl_time = arc_chip.axi_read32(PCIE_INIT_CPL_TIME_REG_ADDR)
     cmfw_start_time = arc_chip.axi_read32(CMFW_START_TIME_REG_ADDR)
@@ -327,19 +376,20 @@ def pcie_fw_load_time_test(arc_chip):
 
 
 @pytest.mark.flash
-def test_pcie_fw_load_time(arc_chip):
+def test_pcie_fw_load_time(arc_chip_dut, asic_id):
     """
     Checks PCIe firmware load time is within 40ms.
     This test needs to be run after production reset.
     """
-    assert pcie_fw_load_time_test(arc_chip), "PCIe firmware load time test failed"
+    assert pcie_fw_load_time_test(asic_id), "PCIe firmware load time test failed"
 
 
 @pytest.mark.flash
-def test_fw_bundle_version(arc_chip):
+def test_fw_bundle_version(arc_chip_dut, asic_id):
     """
     Checks that the fw bundle version in telemetry matches the repo
     """
+    arc_chip = pyluwen.detect_chips()[asic_id]
     telemetry = arc_chip.get_telemetry()
 
     exp_bundle_version = get_int_version_from_file(SCRIPT_DIR.parents[2] / "VERSION")
@@ -365,7 +415,7 @@ def smi_reset_test(asic_id):
 
 
 @pytest.mark.flash
-def test_smi_reset(arc_chip, asic_id):
+def test_smi_reset(arc_chip_dut, asic_id):
     """
     Checks that tt-smi resets are working successfully
     """
@@ -412,10 +462,6 @@ def dirty_reset_test():
 
 
 @pytest.mark.flash
-@pytest.mark.skipif(
-    os.environ.get("CONSOLE_DEV") == "/dev/tenstorrent/1",
-    reason="Test unreliable on p300a board",
-)
 def test_dirty_reset():
     """
     Checks that the SMC comes up correctly after a "dirty" reset, where the
@@ -469,12 +515,13 @@ def tensix_reset_sequence(arc_chip):
     arc_chip.arc_msg(ARC_MSG_TYPE_FORCE_AICLK, arg0=0, arg1=0)
 
 
-def test_tensix_reset(arc_chip):
+def test_tensix_reset(arc_chip_dut, asic_id):
     """
     Validates the Tensix reset sequence
     """
     # Unused register in Tensix. Use bit 0 as a scratch bit
     # "PREFECTH" is a typo carried over from the register name in the RTL
+    arc_chip = pyluwen.detect_chips()[asic_id]
     ETH_RISC_PREFECTH_CTRL_ADDR = 0xFFB120B8
     # This Tensix coordinate (1-2) should be available in all current harvesting configs
     scratch_set = arc_chip.noc_read32(
@@ -502,7 +549,8 @@ def test_tensix_reset(arc_chip):
         logger.info(f"Tensix reset test iteration {i} passed")
 
 
-def test_aiclk(arc_chip):
+def test_aiclk(arc_chip_dut, asic_id):
+    arc_chip = pyluwen.detect_chips()[asic_id]
     TARGET_AICLKS = [
         1350,  # Max value we rise to with GO_BUSY
         800,  # Value we settle to with GO_IDLE_LONG

--- a/app/smc/pytest/e2e_stress.py
+++ b/app/smc/pytest/e2e_stress.py
@@ -10,16 +10,17 @@ import subprocess
 from pathlib import Path
 
 import pyluwen
-import pytest
-from twister_harness import DeviceAdapter
 
 from e2e_smoke import (
     dirty_reset_test,
     smi_reset_test,
     arc_watchdog_test,
     pcie_fw_load_time_test,
-    get_arc_chip,
 )
+
+# Needed to keep ruff from complaining about this "unused import"
+# ruff: noqa: F811
+from e2e_smoke import arc_chip_dut, launched_arc_dut  # noqa: F401
 
 logger = logging.getLogger(__name__)
 
@@ -45,11 +46,6 @@ def report_results(test_name, fail_count, total_tries):
     logger.info(f"{test_name} completed. Failed {fail_count}/{total_tries} times.")
 
 
-@pytest.fixture(scope="session")
-def arc_chip(unlaunched_dut: DeviceAdapter, asic_id):
-    return get_arc_chip(unlaunched_dut, asic_id)
-
-
 def tt_smi_reset():
     """
     Resets the SMC using tt-smi
@@ -61,7 +57,7 @@ def tt_smi_reset():
     return smi_reset_result
 
 
-def test_arc_watchdog(arc_chip):
+def test_arc_watchdog(arc_chip_dut, asic_id):
     """
     Validates that the DMC firmware watchdog for the ARC will correctly
     reset the chip
@@ -76,7 +72,7 @@ def test_arc_watchdog(arc_chip):
         if i % 10 == 0:
             logger.info(f"{test_name} iteration {i}/{total_tries}")
 
-        result = arc_watchdog_test(arc_chip)
+        result = arc_watchdog_test(asic_id)
         if not result:
             logger.warning(f"{test_name} failed on iteration {i}")
             fail_count += 1
@@ -87,7 +83,7 @@ def test_arc_watchdog(arc_chip):
     )
 
 
-def test_pcie_fw_load_time(arc_chip):
+def test_pcie_fw_load_time(arc_chip_dut, asic_id):
     """
     Checks PCIe firmware load time is within 40ms.
     This test needs to be run after production reset.
@@ -107,7 +103,7 @@ def test_pcie_fw_load_time(arc_chip):
             logger.warning(f"tt-smi reset failed on iteration {i}")
             fail_count += 1
             continue
-        result = pcie_fw_load_time_test(arc_chip)
+        result = pcie_fw_load_time_test(asic_id)
         if not result:
             logger.warning(f"PCIe firmware load time test failed on iteration {i}")
             fail_count += 1
@@ -118,7 +114,7 @@ def test_pcie_fw_load_time(arc_chip):
     )
 
 
-def test_smi_reset(arc_chip, asic_id):
+def test_smi_reset(arc_chip_dut, asic_id):
     """
     Checks that tt-smi resets are working successfully
     """
@@ -140,7 +136,7 @@ def test_smi_reset(arc_chip, asic_id):
             fail_count += 1
             continue
 
-        arc_chip = pyluwen.detect_chips()[0]
+        arc_chip = pyluwen.detect_chips()[asic_id]
         response = arc_chip.arc_msg(ARC_MSG_TYPE_PING_DM, True, False, 0, 0, 1000)
         if response[0] != 1 or response[1] != 0:
             logger.warning(f"Ping failed on iteration {i}")
@@ -191,13 +187,14 @@ def test_dirty_reset():
     )
 
 
-def test_dmc_ping(arc_chip):
+def test_dmc_ping(arc_chip_dut, asic_id):
     """
     Repeatedly pings the DMC from the SMC to see what the average response time
     is. Ping statistics are printed to the log. These statistics are gathered
     without resetting the SMC. The `smi_reset` test will gather statistics
     for the SMC reset case.
     """
+    arc_chip = pyluwen.detect_chips()[asic_id]
     total_tries = min(MAX_TEST_ITERATIONS, 1000)
     fail_count = 0
     dmfw_ping_avg = 0

--- a/app/smc/pytest/vuart.py
+++ b/app/smc/pytest/vuart.py
@@ -1,15 +1,9 @@
 # Copyright (c) 2025 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
 
-from e2e_smoke import get_arc_chip
-from twister_harness import DeviceAdapter
-import pytest
-
-
-@pytest.fixture(scope="session")
-def arc_chip_dut(unlaunched_dut: DeviceAdapter, asic_id):
-    get_arc_chip(unlaunched_dut, asic_id)
-    return unlaunched_dut
+# Needed to keep ruff from complaining about this "unused import"
+# ruff: noqa: F811
+from e2e_smoke import arc_chip_dut, launched_arc_dut  # noqa: F401
 
 
 def test_boot_banner(arc_chip_dut):


### PR DESCRIPTION
Rework the harness setup for the e2e smoke test. This is required because with tt-kmd versions >2.4.0, applications using a "stale FD" referring to the tenstorrent device before a reset will be unable to access it.

We therefore need to modify our harness setup to never hold a reference to the chip detected by pyluwen across a reset, otherwise python won't induce closure of the underlying file descriptors.