### PR TITLE
Revert "app: pytest: rework pytest harness setup"

### DIFF
--- a/.github/workflows/hardware-smoke.yml
+++ b/.github/workflows/hardware-smoke.yml
@@ -209,17 +209,11 @@ jobs:
           DMC_BOARD="$(./scripts/rev2board.sh "${{ matrix.config.board }}" dmc)"
           echo "DMC_BOARD=$DMC_BOARD" >> "$GITHUB_ENV"
 
-          if [ ${{ matrix.config.board }} = 'p300a' ]; then
+          if [ ${{matrix.board}} = 'p300a' ]; then
             echo "CONSOLE_DEV=/dev/tenstorrent/1" >> "$GITHUB_ENV"
           else
             echo "CONSOLE_DEV=/dev/tenstorrent/0" >> "$GITHUB_ENV"
           fi
-
-      - name: build-tt-smc_console
-        working-directory: tt-zephyr-platforms/scripts/tooling
-        run: |
-          # Build tt-console
-          make
 
       - name: run-e2e-tests
         working-directory: zephyr

--- a/app/smc/pytest/e2e_stress.py
+++ b/app/smc/pytest/e2e_stress.py
@@ -10,17 +10,16 @@ import subprocess
 from pathlib import Path
 
 import pyluwen
+import pytest
+from twister_harness import DeviceAdapter
 
 from e2e_smoke import (
     dirty_reset_test,
     smi_reset_test,
     arc_watchdog_test,
     pcie_fw_load_time_test,
+    get_arc_chip,
 )
-
-# Needed to keep ruff from complaining about this "unused import"
-# ruff: noqa: F811
-from e2e_smoke import arc_chip_dut  # noqa: F401
 
 logger = logging.getLogger(__name__)
 
@@ -35,7 +34,7 @@ ARC_MSG_TYPE_PING_DM = 0xC0
 ARC_MSG_TYPE_SET_WDT = 0xC1
 
 # Lower this number if testing local changes, so that tests run faster.
-MAX_TEST_ITERATIONS = 10
+MAX_TEST_ITERATIONS = 1000
 
 
 def report_results(test_name, fail_count, total_tries):
@@ -44,6 +43,11 @@ def report_results(test_name, fail_count, total_tries):
     consistent format so that twister can parse the results
     """
     logger.info(f"{test_name} completed. Failed {fail_count}/{total_tries} times.")
+
+
+@pytest.fixture(scope="session")
+def arc_chip(unlaunched_dut: DeviceAdapter, asic_id):
+    return get_arc_chip(unlaunched_dut, asic_id)
 
 
 def tt_smi_reset():
@@ -57,7 +61,7 @@ def tt_smi_reset():
     return smi_reset_result
 
 
-def test_arc_watchdog(arc_chip_dut, asic_id):
+def test_arc_watchdog(arc_chip):
     """
     Validates that the DMC firmware watchdog for the ARC will correctly
     reset the chip
@@ -66,7 +70,7 @@ def test_arc_watchdog(arc_chip_dut, asic_id):
     fail_count = 0
     for i in range(total_tries):
         logger.info(f"Starting ARC watchdog test iteration {i}/{total_tries}")
-        result = arc_watchdog_test(asic_id)
+        result = arc_watchdog_test(arc_chip)
         if not result:
             logger.warning(f"ARC watchdog test failed on iteration {i}")
             fail_count += 1
@@ -75,7 +79,7 @@ def test_arc_watchdog(arc_chip_dut, asic_id):
     assert fail_count == 0, "ARC watchdog test failed a non-zero number of times."
 
 
-def test_pcie_fw_load_time(arc_chip_dut, asic_id):
+def test_pcie_fw_load_time(arc_chip):
     """
     Checks PCIe firmware load time is within 40ms.
     This test needs to be run after production reset.
@@ -91,7 +95,7 @@ def test_pcie_fw_load_time(arc_chip_dut, asic_id):
             logger.warning(f"tt-smi reset failed on iteration {i}")
             fail_count += 1
             continue
-        result = pcie_fw_load_time_test(asic_id)
+        result = pcie_fw_load_time_test(arc_chip)
         if not result:
             logger.warning(f"PCIe firmware load time test failed on iteration {i}")
             fail_count += 1
@@ -102,7 +106,7 @@ def test_pcie_fw_load_time(arc_chip_dut, asic_id):
     )
 
 
-def test_smi_reset(asic_id):
+def test_smi_reset():
     """
     Checks that tt-smi resets are working successfully
     """
@@ -119,7 +123,7 @@ def test_smi_reset(asic_id):
             fail_count += 1
             continue
 
-        arc_chip = pyluwen.detect_chips()[asic_id]
+        arc_chip = pyluwen.detect_chips()[0]
         response = arc_chip.arc_msg(ARC_MSG_TYPE_PING_DM, True, False, 0, 0, 1000)
         if response[0] != 1 or response[1] != 0:
             logger.warning(f"Ping failed on iteration {i}")
@@ -163,14 +167,13 @@ def test_dirty_reset():
     assert fail_count == 0, "Dirty reset failed a non-zero number of times."
 
 
-def test_dmc_ping(arc_chip_dut, asic_id):
+def test_dmc_ping(arc_chip):
     """
     Repeatedly pings the DMC from the SMC to see what the average response time
     is. Ping statistics are printed to the log. These statistics are gathered
     without resetting the SMC. The `smi_reset` test will gather statistics
     for the SMC reset case.
     """
-    arc_chip = pyluwen.detect_chips()[asic_id]
     total_tries = min(MAX_TEST_ITERATIONS, 1000)
     fail_count = 0
     dmfw_ping_avg = 0

--- a/app/smc/pytest/vuart.py
+++ b/app/smc/pytest/vuart.py
@@ -1,20 +1,49 @@
 # Copyright (c) 2025 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
 
-# Needed to keep ruff from complaining about this "unused import"
-# ruff: noqa: F811
-from e2e_smoke import arc_chip_dut  # noqa: F401
+import os
+import pytest
+import subprocess
+
+from pathlib import Path
+
+from e2e_smoke import ARC_STATUS, get_arc_chip
+from twister_harness import DeviceAdapter
+
+SCRIPT_ROOT = Path(__file__)
+MODULE_ROOT = SCRIPT_ROOT.parents[3]
+SCRIPT_DIR = MODULE_ROOT / "scripts" / "tooling"
 
 
-def test_boot_banner(arc_chip_dut):
-    """
-    Validates that the boot banner is printed correctly. This should run before
-    any tests that reset the chip.
-    """
-    # Wait 3 seconds for console output
-    output = arc_chip_dut.readlines_until(
-        "Booting tt_blackhole with Zephyr OS", timeout=3000
-    )
-    out_str = "\n".join(output)
-    assert "Booting tt_blackhole with Zephyr OS" in out_str
-    print(f"\nconsole output successfully captured:\n{out_str}")
+@pytest.fixture(scope="session")
+def tt_console(tmp_path_factory: Path):
+    tt_console_exe = tmp_path_factory.getbasetemp() / "tt-console"
+    cmd = "make tt-console"
+    subprocess.run(cmd.split(), capture_output=True, check=True, cwd=SCRIPT_DIR)
+    cmd = f"cp {SCRIPT_DIR / 'tt-console'} {tt_console_exe}"
+    subprocess.run(cmd.split(), capture_output=True, check=True)
+    return tt_console_exe
+
+
+@pytest.fixture(scope="session")
+def arc_chip(unlaunched_dut: DeviceAdapter, asic_id):
+    return get_arc_chip(unlaunched_dut, asic_id)
+
+
+def test_compile_tt_console(tt_console: Path):
+    assert os.access(tt_console, os.X_OK)
+
+
+def test_boot_banner(tt_console: Path, arc_chip, asic_id):
+    arc_chip.axi_read32(ARC_STATUS)
+
+    # run 'tt-console' in quiet mode, and timeout after 3 s
+    cmd = f"{tt_console} -d /dev/tenstorrent/{asic_id} -q -w 3000"
+    proc = subprocess.run(cmd.split(), capture_output=True, check=True)
+
+    out = proc.stdout.decode("utf-8")
+
+    # check that the boot banner is seen on the console
+    assert "Booting tt_blackhole with Zephyr OS" in out
+
+    print(f"\nconsole output successfully captured:\n{out}")


### PR DESCRIPTION
This reverts commit b09a5dca412af68c83dfd66807ea1482e7e9cc1c. This test rework wasn't fully stable, and should not have been merged in its current state.

#589 will properly implement the rework and test it fully prior to merging