### PR TITLE
Fine-grained DMC events

### DIFF
--- a/app/dmc/src/main.c
+++ b/app/dmc/src/main.c
@@ -729,13 +729,6 @@ int main(void)
 		if (events & (TT_EVENT_LOGS_TO_SMC | TT_EVENT_WAKE)) {
 			send_logs_to_smc();
 		}
-
-		/*
-		 * Really only matters if running without security... but
-		 * cm should register that it is on the pcie bus and therefore can be an update
-		 * candidate. If chips that are on the bus see that an update has been requested
-		 * they can update?
-		 */
 	}
 
 	return EXIT_SUCCESS;

--- a/app/dmc/src/main.c
+++ b/app/dmc/src/main.c
@@ -711,8 +711,6 @@ int main(void)
 
 		handle_pgood_change();
 
-		/* TODO(drosen): Turn this into a task which will re-arm until static data is sent
-		 */
 		/* send_init_data only triggers once per chip (per reset). */
 		send_init_data();
 

--- a/app/dmc/src/main.c
+++ b/app/dmc/src/main.c
@@ -561,7 +561,7 @@ static void send_logs_to_smc(void)
 	ret = log_backend_ringbuf_get_claim(&log_data, 32);
 	if (ret > 0) {
 		/* Write log data to the first BH chip */
-		if (bh_chip_write_logs(&BH_CHIPS[0], log_data, ret) == 0) {
+		if (bh_chip_write_logs(&BH_CHIPS[BH_CHIP_PRIMARY_INDEX], log_data, ret) == 0) {
 			/* Only finish the claim if the write was successful */
 			log_backend_ringbuf_finish_claim(ret);
 		} else {

--- a/include/tenstorrent/event.h
+++ b/include/tenstorrent/event.h
@@ -23,11 +23,19 @@ extern "C" {
  * system. Multiple events may be posted and receieved simultaneously, as they form a bitmask.
  */
 enum tt_event {
-	TT_EVENT_WAKE = BIT(31), /**< @brief Wake firmware for a generic reason */
+	TT_EVENT_THERM_TRIP = BIT(0),         /**< @brief ASIC thermal trip detected */
+	TT_EVENT_WATCHDOG_EXPIRED = BIT(1),   /**< @brief Watchdog timeout expired */
+	TT_EVENT_PERST = BIT(2),              /**< @brief PERST (pcie reset) signal asserted */
+	TT_EVENT_PGOOD = BIT(3),              /**< @brief PGOOD (power good) state change */
+	TT_EVENT_BOARD_POWER_TO_SMC = BIT(4), /**< @brief 20ms: board power sense & send to smc */
+	TT_EVENT_FAN_RPM_TO_SMC = BIT(5),     /**< @brief 20ms: fan RPM sense & send to smc */
+	TT_EVENT_CM2DM_POLL = BIT(6),         /**< @brief 20ms: CM2DM message polling */
+	TT_EVENT_LOGS_TO_SMC = BIT(7),        /**< @brief 20ms: send log chunk to smc */
+	TT_EVENT_WAKE = BIT(31),              /**< @brief Wake firmware for a generic reason */
 };
 
 /** @brief Bitmask of all Tenstorrent firmware events */
-#define TT_EVENT_MASK (TT_EVENT_WAKE)
+#define TT_EVENT_ANY UINT32_MAX
 
 /**
  * @brief Post an event to Tenstorrent firmware.

--- a/lib/tenstorrent/bh_chip/bh_chip.c
+++ b/lib/tenstorrent/bh_chip/bh_chip.c
@@ -123,7 +123,7 @@ void bh_chip_auto_reset(struct k_timer *timer)
 	chip->data.arc_wdog_triggered = true;
 	/* Cancel bus transfers, ARC is likely hung */
 	bh_chip_cancel_bus_transfer_set(chip);
-	tt_event_post(TT_EVENT_WAKE);
+	tt_event_post(TT_EVENT_WATCHDOG_EXPIRED);
 }
 
 int bh_chip_write_logs(struct bh_chip *chip, char *log_data, size_t log_size)
@@ -173,7 +173,7 @@ void therm_trip_detected(const struct device *dev, struct gpio_callback *cb, uin
 
 	chip->data.therm_trip_triggered = true;
 	bh_chip_cancel_bus_transfer_set(chip);
-	tt_event_post(TT_EVENT_WAKE);
+	tt_event_post(TT_EVENT_THERM_TRIP);
 }
 
 int therm_trip_gpio_setup(struct bh_chip *chip)
@@ -212,7 +212,7 @@ void pgood_change_detected(const struct device *dev, struct gpio_callback *cb, u
 	} else {
 		chip->data.pgood_fall_triggered = true;
 	}
-	tt_event_post(TT_EVENT_WAKE);
+	tt_event_post(TT_EVENT_PGOOD);
 }
 
 int pgood_gpio_setup(struct bh_chip *chip)

--- a/lib/tenstorrent/event/event.c
+++ b/lib/tenstorrent/event/event.c
@@ -21,7 +21,7 @@ uint32_t tt_event_wait(uint32_t events, k_timeout_t timeout)
 
 	ret = k_event_wait_safe(&tt_event, events, false, timeout);
 	if (ret != 0) {
-		LOG_INF("Received wake up event: requested=0x%08X received=0x%08X", events, ret);
+		LOG_DBG("Received wake up event: requested=0x%08X received=0x%08X", events, ret);
 	}
 
 	return ret;

--- a/lib/tenstorrent/jtag_bootrom/jtag_bootrom.c
+++ b/lib/tenstorrent/jtag_bootrom/jtag_bootrom.c
@@ -77,7 +77,7 @@ void gpio_asic_reset_callback(const struct device *port, struct gpio_callback *c
 			bh_chip_cancel_bus_transfer_set(chip);
 		}
 	}
-	tt_event_post(TT_EVENT_WAKE);
+	tt_event_post(TT_EVENT_PERST);
 }
 
 static struct gpio_callback preset_cb_data;


### PR DESCRIPTION
Create a distinct event for each activity in the DMC main loop. Slow activities check the signalled event bitmap. Some activities still have flags in the chip object to know when they've been triggered.

This is in preparation to move ia228_power_update to 1ms frequency. Fan update and CM2DM will stay at 20ms.
