### PR TITLE
boards: tenstorrent: reset DMC prior to flashing SMC

### DIFF
--- a/boards/tenstorrent/tt_blackhole/support/tt_blackhole_smc.cfg
+++ b/boards/tenstorrent/tt_blackhole/support/tt_blackhole_smc.cfg
@@ -106,6 +106,15 @@ proc setup_cpu {core_index expected_id} {
 	$_TARGETNAME arc cache l2 auto 1
 }
 
+if {[info exists DMC_CFG]} {
+	# If a DMC config is provided, use it to reset the board prior to
+	# initializing the JTAG chain. This makes sure the bootrom workaround
+	# has been applied properly and can clear bad states on the SMC
+	exec $OPENOCD -s $OPENOCD_DEFAULT_PATH -f $DMC_CFG -c "init; reset; exit"
+	# DMC should be booted within ~14 ms, but give it lots of margin
+	sleep 100
+}
+
 jtag newtap security.cpu1 unknown1 -irlen 4 -ircapture 0x1 -expected-id 0x201444b1
 
 # OpenOCD discovers JTAG TAPs in reverse order.


### PR DESCRIPTION
Before running JTAG scan chain on SMC, reset the DMC if an openocd config is provided. This can help kick the SMC out of a bad state, since resetting the DMC will reapply the bootrom workaround.