### PR TITLE
boards: tt_blackhole: p100: remove max6639 from devicetree

### DIFF
--- a/boards/tenstorrent/tt_blackhole/tt_blackhole_tt_blackhole_smc.dts
+++ b/boards/tenstorrent/tt_blackhole/tt_blackhole_tt_blackhole_smc.dts
@@ -105,12 +105,6 @@
 &i2c2 {
 	status = "disabled";
 
-	fanctl0: max6639@58 {
-		compatible = "maxim,max6639";
-		reg = <0x58>;
-		status = "disabled";
-	};
-
 	sw0: switch@72 {
 		compatible = "ti,tps22993";
 		reg = <0x72>;


### PR DESCRIPTION
The max6639 fan controller on p100 (scrappy) is hardwired to 100% due to a workaround for incorrect electrical interfacing between the fan and the fan controller.

Making the fan controller usable would require a bodge of some kind, which isn't someting that we want to do at scale, so simply remove the fan controller, since it's not really useful at this point.

See #595 for more details.