### PR TITLE
improvements for test error reporting

### DIFF
--- a/.github/workflows/hardware-long.yml
+++ b/.github/workflows/hardware-long.yml
@@ -110,7 +110,10 @@ jobs:
           echo "DMC RTT logs:"
           python3 ./scripts/dmc_rtt.py -n
           echo "SMC RTT logs:"
-          python3 ./scripts/smc_console.py --rtt -n --openocd /opt/tenstorrent/bin/openocd-rtt
+          python3 ./scripts/smc_console.py --rtt -n
+          echo "SMC state dump:"
+          python3 ./scripts/dump_smc_state.py --asic-id $ASIC_ID
+
   # Temporarily moved from hardware-smoke.yml until metal tests occupy less time for CI on each PR
   metal-test:
     needs: build-fw-artifact

--- a/.github/workflows/hardware-long.yml
+++ b/.github/workflows/hardware-long.yml
@@ -37,7 +37,7 @@ jobs:
       image: ghcr.io/danieldegrasse/tt-zephyr-platforms/ci-image:v18.8.0
       volumes:
         - /dev/hugepages-1G:/dev/hugepages-1G
-        - /opt/tenstorrent:/opt/tenstorrent
+        - /lib/modules:/lib/modules
       options: '--device /dev/tenstorrent --device /dev/bus/usb --privileged'
     steps:
       - name: Checkout

--- a/.github/workflows/hardware-smoke.yml
+++ b/.github/workflows/hardware-smoke.yml
@@ -66,8 +66,10 @@ jobs:
 
           if [ ${{ matrix.config.board }} = 'p300a' ]; then
             echo "CONSOLE_DEV=/dev/tenstorrent/1" >> "$GITHUB_ENV"
+            echo "ASIC_ID=1" >> "$GITHUB_ENV"
           else
             echo "CONSOLE_DEV=/dev/tenstorrent/0" >> "$GITHUB_ENV"
+            echo "ASIC_ID=0" >> "$GITHUB_ENV"
           fi
 
       - name: build-tt-smc_console
@@ -163,6 +165,8 @@ jobs:
           python3 ./scripts/dmc_rtt.py -n
           echo "SMC RTT logs:"
           python3 ./scripts/smc_console.py --rtt -n
+          echo "SMC state dump:"
+          python3 ./scripts/dump_smc_state.py --asic-id $ASIC_ID
 
   smoke-e2e-test:
     strategy:
@@ -215,10 +219,12 @@ jobs:
           DMC_BOARD="$(./scripts/rev2board.sh "${{ matrix.config.board }}" dmc)"
           echo "DMC_BOARD=$DMC_BOARD" >> "$GITHUB_ENV"
 
-          if [ ${{matrix.board}} = 'p300a' ]; then
+          if [ ${{ matrix.config.board }} = 'p300a' ]; then
             echo "CONSOLE_DEV=/dev/tenstorrent/1" >> "$GITHUB_ENV"
+            echo "ASIC_ID=1" >> "$GITHUB_ENV"
           else
             echo "CONSOLE_DEV=/dev/tenstorrent/0" >> "$GITHUB_ENV"
+            echo "ASIC_ID=0" >> "$GITHUB_ENV"
           fi
 
       - name: run-e2e-tests
@@ -287,3 +293,5 @@ jobs:
           python3 ./scripts/dmc_rtt.py -n
           echo "SMC RTT logs:"
           python3 ./scripts/smc_console.py --rtt -n
+          echo "SMC state dump:"
+          python3 ./scripts/dump_smc_state.py --asic-id $ASIC_ID

--- a/.github/workflows/hardware-smoke.yml
+++ b/.github/workflows/hardware-smoke.yml
@@ -199,6 +199,12 @@ jobs:
         with:
           app-path: tt-zephyr-platforms
 
+      - name: build-tt-smc_console
+        working-directory: tt-zephyr-platforms/scripts/tooling
+        run: |
+          # Build tt-console
+          make
+
       - name: Generate board names
         working-directory: tt-zephyr-platforms
         shell: bash

--- a/.github/workflows/hardware-smoke.yml
+++ b/.github/workflows/hardware-smoke.yml
@@ -130,6 +130,7 @@ jobs:
           ./scripts/twister -i \
             -p $SMC_BOARD --device-testing \
             --device-serial-pty "../tt-zephyr-platforms/scripts/smc_console.py -d $CONSOLE_DEV" \
+            --failure-script "../tt-zephyr-platforms/scripts/smc_test_recovery.py --asic-id $ASIC_ID" \
             --west-flash \
             --flash-before \
             --tag smoke \
@@ -248,6 +249,7 @@ jobs:
             -p $SMC_BOARD --device-testing \
             --tag e2e \
             --device-serial-pty "../tt-zephyr-platforms/scripts/smc_console.py -d $CONSOLE_DEV" \
+            --failure-script "../tt-zephyr-platforms/scripts/smc_test_recovery.py --asic-id $ASIC_ID" \
             --flash-before \
             --west-flash \
             -T ../tt-zephyr-platforms/app \
@@ -263,6 +265,7 @@ jobs:
             --west-runner tt_flash \
             --device-testing -c \
             --device-serial-pty "../tt-zephyr-platforms/scripts/smc_console.py -d $CONSOLE_DEV" \
+            --failure-script "../tt-zephyr-platforms/scripts/smc_test_recovery.py --asic-id $ASIC_ID" \
             --flash-before \
             --outdir twister-e2e-flash
 

--- a/.github/workflows/hardware-smoke.yml
+++ b/.github/workflows/hardware-smoke.yml
@@ -41,6 +41,7 @@ jobs:
       image: ghcr.io/danieldegrasse/tt-zephyr-platforms/ci-image:v18.8.0
       volumes:
         - /dev/hugepages-1G:/dev/hugepages-1G
+        - /lib/modules:/lib/modules
       options: '--device /dev/tenstorrent --device /dev/bus/usb --privileged'
     steps:
       - name: Checkout
@@ -191,6 +192,7 @@ jobs:
       image: ghcr.io/danieldegrasse/tt-zephyr-platforms/ci-image:v18.8.0
       volumes:
         - /dev/hugepages-1G:/dev/hugepages-1G
+        - /lib/modules:/lib/modules
       options: '--device /dev/tenstorrent --device /dev/bus/usb --privileged'
     steps:
       - name: Checkout

--- a/.github/workflows/prepare-container/action.yml
+++ b/.github/workflows/prepare-container/action.yml
@@ -38,7 +38,7 @@ runs:
           echo "Removing old west configuration"
           rm -rf ".west"
         fi
-        west init -l tt-zephyr-platforms || true
+        west init -l ${{ inputs.app-path }} || true
         west config --global update.narrow true
         west update --path-cache /tt-zephyr || ( rm -rf modules bootloader tools && west update --path-cache /tt-zephyr)
         west forall -c 'git reset --hard HEAD'
@@ -63,3 +63,27 @@ runs:
       shell: bash
       run: |
         west -v patch apply
+
+    - name: Install modinfo
+      shell: bash
+      run: |
+        if ! command -v modinfo &> /dev/null ; then
+          apt-get update
+          apt-get install -y kmod
+        fi
+
+    - name: Log system state
+      shell: bash
+      run: |
+        echo "Zephyr SDK: $ZEPHYR_SDK_INSTALL_DIR"
+        echo "Python: $( which python3 ) $( python3 --version )"
+        echo "Pip: $( which pip3 ) $( pip3 --version )"
+        echo "West: $( which west ) $( west --version )"
+        echo "CMake: $( which cmake ) $( cmake --version | head -n 1 )"
+        echo "Ninja: $( which ninja ) $( ninja --version )"
+        echo "Rustc: $( which rustc ) $( rustc --version )"
+        echo "Cargo: $( which cargo ) $( cargo --version )"
+        echo "PIP packages:"
+        pip3 freeze
+        echo "tt-kmd version:"
+        modinfo tenstorrent

--- a/app/dmc/sysbuild/mcuboot.conf
+++ b/app/dmc/sysbuild/mcuboot.conf
@@ -1,2 +1,4 @@
 # This is required to speed-up boot times for bootrom patching
 CONFIG_BOOT_VALIDATE_SLOT0=n
+# Always clear the segger RTT control block on boot
+CONFIG_SEGGER_RTT_INIT_MODE_ALWAYS=y

--- a/app/smc/pytest/e2e_smoke.py
+++ b/app/smc/pytest/e2e_smoke.py
@@ -54,15 +54,9 @@ def get_arc_chip(unlaunched_dut: DeviceAdapter, asic_id):
     for any test to run
     """
     logger.info(f"Getting ASIC ID {asic_id}")
-    # This is a hack- the RTT terminal doesn't work in pytest, so
-    # we directly call this internal API to flash the DUT.
-    unlaunched_dut.generate_command()
-    if unlaunched_dut.device_config.extra_test_args:
-        unlaunched_dut.command.extend(
-            unlaunched_dut.device_config.extra_test_args.split()
-        )
+    # Try to flash the DUT
     try:
-        unlaunched_dut._flash_and_run()
+        unlaunched_dut.launch()
     except TwisterHarnessException:
         pytest.exit("Failed to flash DUT")
     except TwisterHarnessTimeoutException:

--- a/app/smc/pytest/e2e_stress.py
+++ b/app/smc/pytest/e2e_stress.py
@@ -106,7 +106,7 @@ def test_pcie_fw_load_time(arc_chip):
     )
 
 
-def test_smi_reset():
+def test_smi_reset(arc_chip, asic_id):
     """
     Checks that tt-smi resets are working successfully
     """
@@ -116,7 +116,7 @@ def test_smi_reset():
     dmfw_ping_max = 0
     for i in range(total_tries):
         logger.info(f"Iteration {i}:")
-        result = smi_reset_test()
+        result = smi_reset_test(asic_id)
 
         if not result:
             logger.warning(f"tt-smi reset failed on iteration {i}")

--- a/app/smc/pytest/vuart.py
+++ b/app/smc/pytest/vuart.py
@@ -1,49 +1,26 @@
 # Copyright (c) 2025 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
 
-import os
-import pytest
-import subprocess
-
-from pathlib import Path
-
-from e2e_smoke import ARC_STATUS, get_arc_chip
+from e2e_smoke import get_arc_chip
 from twister_harness import DeviceAdapter
-
-SCRIPT_ROOT = Path(__file__)
-MODULE_ROOT = SCRIPT_ROOT.parents[3]
-SCRIPT_DIR = MODULE_ROOT / "scripts" / "tooling"
+import pytest
 
 
 @pytest.fixture(scope="session")
-def tt_console(tmp_path_factory: Path):
-    tt_console_exe = tmp_path_factory.getbasetemp() / "tt-console"
-    cmd = "make tt-console"
-    subprocess.run(cmd.split(), capture_output=True, check=True, cwd=SCRIPT_DIR)
-    cmd = f"cp {SCRIPT_DIR / 'tt-console'} {tt_console_exe}"
-    subprocess.run(cmd.split(), capture_output=True, check=True)
-    return tt_console_exe
+def arc_chip_dut(unlaunched_dut: DeviceAdapter, asic_id):
+    get_arc_chip(unlaunched_dut, asic_id)
+    return unlaunched_dut
 
 
-@pytest.fixture(scope="session")
-def arc_chip(unlaunched_dut: DeviceAdapter, asic_id):
-    return get_arc_chip(unlaunched_dut, asic_id)
-
-
-def test_compile_tt_console(tt_console: Path):
-    assert os.access(tt_console, os.X_OK)
-
-
-def test_boot_banner(tt_console: Path, arc_chip, asic_id):
-    arc_chip.axi_read32(ARC_STATUS)
-
-    # run 'tt-console' in quiet mode, and timeout after 3 s
-    cmd = f"{tt_console} -d /dev/tenstorrent/{asic_id} -q -w 3000"
-    proc = subprocess.run(cmd.split(), capture_output=True, check=True)
-
-    out = proc.stdout.decode("utf-8")
-
-    # check that the boot banner is seen on the console
-    assert "Booting tt_blackhole with Zephyr OS" in out
-
-    print(f"\nconsole output successfully captured:\n{out}")
+def test_boot_banner(arc_chip_dut):
+    """
+    Validates that the boot banner is printed correctly. This should run before
+    any tests that reset the chip.
+    """
+    # Wait 3 seconds for console output
+    output = arc_chip_dut.readlines_until(
+        "Booting tt_blackhole with Zephyr OS", timeout=3000
+    )
+    out_str = "\n".join(output)
+    assert "Booting tt_blackhole with Zephyr OS" in out_str
+    print(f"\nconsole output successfully captured:\n{out_str}")

--- a/boards/tenstorrent/tt_blackhole/board.cmake
+++ b/boards/tenstorrent/tt_blackhole/board.cmake
@@ -6,7 +6,7 @@ if(CONFIG_SOC_TT_BLACKHOLE_DMC)
 endif()
 
 if(CONFIG_SOC_TT_BLACKHOLE_SMC)
-  board_runner_args(openocd "--config=${BOARD_DIR}/support/tt_blackhole_smc.cfg" "--use-elf")
+  board_runner_args(openocd "--config=${BOARD_DIR}/support/tt_blackhole_smc.cfg" "--use-elf" "--verify")
 endif()
 
 if(CONFIG_ARM)

--- a/scripts/dmc_rtt.py
+++ b/scripts/dmc_rtt.py
@@ -19,7 +19,7 @@ DEFAULT_SEARCH_BASE = 0x20000000
 DEFAULT_SEARCH_RANGE = 0x80000
 
 
-def start_dmc_rtt():
+def start_dmc_rtt(args):
     """
     Main function to start RTT console
     """
@@ -28,9 +28,9 @@ def start_dmc_rtt():
         search_base=DEFAULT_SEARCH_BASE,
         search_range=DEFAULT_SEARCH_RANGE,
     )
-    rtt_helper.parse_args(sys.argv[1:])
+    rtt_helper.parse_args(args)
     rtt_helper.run_rtt_server()
 
 
 if __name__ == "__main__":
-    start_dmc_rtt()
+    start_dmc_rtt(sys.argv[1:])

--- a/scripts/dump_smc_state.py
+++ b/scripts/dump_smc_state.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+This script dumps SMC state data. It is intended to aid in debugging a hung
+SMC. The script requires that the SMC be accessible over PCIe, but does not
+require that the application firmware be in a good state.
+"""
+
+import argparse
+import errno
+import pyluwen
+
+from pcie_utils import rescan_pcie
+
+# Register definitions
+ICCM_BASE = 0x0
+ARC_RESET_UNIT = 0x80030000
+SCRATCH_0 = ARC_RESET_UNIT + 0x60
+SMC_SCRATCH_RAM_BASE = ARC_RESET_UNIT + 0x400
+
+SMC_POSTCODE_REG = SCRATCH_0
+ARC_PC_CORE_0 = ARC_RESET_UNIT + 0x0C00
+
+# Offsets within scratch RAM for named registers
+SCRATCH_REGS = {
+    "FW Version": 0x00,
+    "Boot Status 0": 0x08,
+    "Boot Status 1": 0x0C,
+    "Error Status 0": 0x10,
+    "Error Status 1": 0x14,
+    "Message Queue Status": 0x24,
+    "SPI Buffer": 0x28,
+    "MSG QUEUE INFO": 0x2C,
+    "Telemetry Base": 0x30,
+    "Telemetry Struct Addr": 0x34,
+    "PCIe Init Timestamp": 0x38,
+    "CMFW Init Timestamp": 0x3C,
+    "DMFW Bootrom Timestamp": 0x40,
+    "DMFW Init Duration": 0x44,
+    "I2C target state 0": 0x4C,
+    "I2C target state 1": 0x50,
+    "ARC hang pc": 0x54,
+    "VUART 0 address": 0xA0,
+    "VUART 1 address": 0xA4,
+    "VUART 2 address": 0xA8,
+    "VUART 3 address": 0xAC,
+    "VUART 4 address": 0xB0,
+    "VUART 5 address": 0xB4,
+    "VUART 6 address": 0xB8,
+    "VUART 7 address": 0xBC,
+    "VUART 8 address": 0xC0,
+    "VUART 9 address": 0xC4,
+    "VUART 10 address": 0xC8,
+    "VUART 11 address": 0xCC,
+    "VUART 12 address": 0xD0,
+    "VUART 13 address": 0xD4,
+    "VUART 14 address": 0xD8,
+    "VUART 15 address": 0xDC,
+}
+
+# List of all possible states to dump
+ALL_STATES = ["scratch", "pc", "crash"]
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Dump SMC state data for debugging.", allow_abbrev=False
+    )
+    parser.add_argument(
+        "--states",
+        type=str,
+        nargs="+",
+        default=ALL_STATES,
+        help="Specify one or more subsets of SMC state to dump (default: all).",
+    )
+    parser.add_argument(
+        "--asic-id",
+        type=int,
+        default=0,
+        help="Specify which ASIC to dump state from (default: 0).",
+    )
+    return parser.parse_args()
+
+
+def dump_scratch(chip):
+    """
+    Dump SMC scratch registers
+    """
+    print("SMC Scratch Registers:")
+    print(f"SMC Postcode: 0x{chip.axi_read32(SMC_POSTCODE_REG):08x}")
+    for name, offset in SCRATCH_REGS.items():
+        val = chip.axi_read32(SMC_SCRATCH_RAM_BASE + offset)
+        print(f"{name}: 0x{val:08x}")
+
+
+def dump_states(asic_id, states=ALL_STATES):
+    """
+    Dump specified SMC states from given ASIC
+    Callable as a module or from the main function
+    """
+    # Don't detect chips with detect_chips(), since that has status checks
+    chip = pyluwen.PciChip(asic_id)
+    try:
+        postcode = chip.axi_read32(SMC_POSTCODE_REG)
+        if postcode == 0xFFFFFFFF:
+            print("SMC appears to need a pcie reset to be accessible")
+            rescan_pcie()
+            chip = pyluwen.PciChip(asic_id)
+    except Exception as e:
+        print(f"Error accessing SMC ASIC {asic_id}: {e}")
+        print("Make sure the SMC is powered on and accessible over PCIe")
+        return errno.EIO
+    if "pc" in states:
+        pc = chip.axi_read32(ARC_PC_CORE_0)
+        print(f"ARC PC: 0x{pc:08x}")
+    if "scratch" in states:
+        dump_scratch(chip)
+    if "crash" in states:
+        crash_reason = chip.axi_read32(ICCM_BASE)
+        print(f"Crash reason: 0x{crash_reason:08x}")
+        crash_blink = chip.axi_read32(ICCM_BASE + 0x4)
+        print(f"Crash BLINK: 0x{crash_blink:08x}")
+
+
+def main():
+    """
+    Main function to dump SMC state
+    """
+    args = parse_args()
+    return dump_states(args.asic_id, states=args.states)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/smc_test_recovery.py
+++ b/scripts/smc_test_recovery.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+This script performs recovery actions after a test failure. It is intended
+to be run as part of a test framework's post-test hook. It dumps SMC state data,
+reads DMC logs, and resets the SMC. The script requires that the SMC be
+accessible over PCIe, but does not require that the application firmware be in a
+good state.
+"""
+
+import argparse
+
+import dump_smc_state
+import dmc_reset
+import dmc_rtt
+import pcie_utils
+
+
+def parse_args():
+    """
+    Parse command line arguments
+    """
+    parser = argparse.ArgumentParser(
+        description="Perform recovery actions after a test failure", allow_abbrev=False
+    )
+    parser.add_argument(
+        "--asic-id",
+        type=int,
+        default=0,
+        help="ASIC ID of the target device (default: 0)",
+    )
+    return parser.parse_args()
+
+
+def reset_dmc():
+    """
+    Reset the DMC, so the SMC will reboot
+    """
+
+    # Use dmc_reset module as a library to reset the DMC
+    def args():
+        return None
+
+    args.config = dmc_reset.DEFAULT_DMC_CFG
+    args.debug = 0
+    args.openocd = dmc_reset.DEFAULT_OPENOCD
+    args.scripts = dmc_reset.DEFAULT_SCRIPTS_DIR
+    args.jtag_id = None
+    args.hexfile = None
+
+    dmc_reset.reset_dmc(args)
+
+
+def recover_smc(asic_id):
+    """
+    Perform recovery actions on the SMC
+    """
+    # Dump SMC state
+    dump_smc_state.dump_states(asic_id)
+    # Read DMC logs via RTT
+    dmc_rtt.start_dmc_rtt(["--non-blocking"])
+    # Reset DMC
+    reset_dmc()
+    # Rescan PCIe to ensure device is accessible
+    pcie_utils.rescan_pcie()
+
+
+def main():
+    """
+    Main function to perform recovery actions
+    """
+    args = parse_args()
+    recover_smc(args.asic_id)
+
+
+if __name__ == "__main__":
+    main()

--- a/soc/tenstorrent/tt_blackhole/CMakeLists.txt
+++ b/soc/tenstorrent/tt_blackhole/CMakeLists.txt
@@ -22,6 +22,10 @@ if(CONFIG_SOC_TT_BLACKHOLE_SMC)
 
   zephyr_library()
   zephyr_library_sources(soc.c)
+  zephyr_library_include_directories(PRIVATE
+    ${ZEPHYR_BASE}/kernel/include
+    ${ARCH_DIR}/${ARCH}/include
+  )
   zephyr_library_sources_ifdef(CONFIG_FPU_SHARING fpu_init.c)
 
   set(SOC_LINKER_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/tt_blackhole_smc.ld CACHE INTERNAL "")

--- a/zephyr/patches.yml
+++ b/zephyr/patches.yml
@@ -220,3 +220,13 @@ patches:
       read_processed should be called on every subsequent byte in the
       transaction, and it should also send the data fetched in the CB
       back on the wire.
+  - path: zephyr/scripts-pylib-pytest-twister-harness-ensure-serial.patch
+    sha256sum: a638bb624dbf6b1a087c21c3312ac574402ef89d9788ce8987fbeb8c69e55e69
+    module: zephyr
+    author: Daniel DeGrasse
+    email: ddegrasse@tenstorrent.com
+    date: 2025-09-17
+    upstreamable: true
+    comments: |
+      Ensure that the serial connection is properly closed when terminating the process.
+      This prevents issues with lingering connections that can interfere with subsequent tests.

--- a/zephyr/patches.yml
+++ b/zephyr/patches.yml
@@ -230,3 +230,15 @@ patches:
     comments: |
       Ensure that the serial connection is properly closed when terminating the process.
       This prevents issues with lingering connections that can interfere with subsequent tests.
+  - path: zephyr/scripts-twister-add-failure_script-parameter-to-run.patch
+    sha256sum: eb1db0329a50cc20e536a221b1c8cb641cd09d4fb62e7fb0a3f8eb5fddcecdc3
+    module: zephyr
+    author: Daniel DeGrasse
+    email: ddegrasse@tenstorrent.com
+    date: 2025-09-17
+    upstreamable: true
+    merge-pr: https://github.com/zephyrproject-rtos/zephyr/pull/96180
+    comments: |
+      Add support for a failure_script parameter to twister. This script will be executed
+      whenever a test fails, allowing for custom failure handling such as
+      dumping logs, resetting hardware, etc.

--- a/zephyr/patches/zephyr/scripts-pylib-pytest-twister-harness-ensure-serial.patch
+++ b/zephyr/patches/zephyr/scripts-pylib-pytest-twister-harness-ensure-serial.patch
@@ -1,0 +1,30 @@
+From 7798051ae8978956352389243c92270e67e9de8c Mon Sep 17 00:00:00 2001
+From: Daniel DeGrasse <ddegrasse@tenstorrent.com>
+Date: Wed, 17 Sep 2025 17:40:35 -0500
+Subject: [PATCH] scripts: pylib: pytest-twister-harness: ensure serial-pty
+ terminates
+
+Ensure serial-pty process terminates, by forwarding SIGTERM to all
+children of the serial-pty process.
+
+Signed-off-by: Daniel DeGrasse <ddegrasse@tenstorrent.com>
+---
+ .../src/twister_harness/device/hardware_adapter.py             | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/scripts/pylib/pytest-twister-harness/src/twister_harness/device/hardware_adapter.py b/scripts/pylib/pytest-twister-harness/src/twister_harness/device/hardware_adapter.py
+index 79a3a935644..1e377fc81b2 100644
+--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/device/hardware_adapter.py
++++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/device/hardware_adapter.py
+@@ -193,8 +193,7 @@ class HardwareAdapter(DeviceAdapter):
+     def _close_serial_pty(self) -> None:
+         """Terminate the process opened for serial pty script"""
+         if self._serial_pty_proc:
+-            self._serial_pty_proc.terminate()
+-            self._serial_pty_proc.communicate(timeout=self.base_timeout)
++            terminate_process(self._serial_pty_proc)
+             logger.debug('Process %s terminated', self.device_config.serial_pty)
+             self._serial_pty_proc = None
+
+--
+2.34.1

--- a/zephyr/patches/zephyr/scripts-twister-add-failure_script-parameter-to-run.patch
+++ b/zephyr/patches/zephyr/scripts-twister-add-failure_script-parameter-to-run.patch
@@ -1,0 +1,206 @@
+From a9c2d915f1bab195dc6202bf62cbfa6e13b8ffda Mon Sep 17 00:00:00 2001
+From: Daniel DeGrasse <ddegrasse@tenstorrent.com>
+Date: Wed, 17 Sep 2025 16:35:34 -0500
+Subject: [PATCH] scripts: twister: add failure_script parameter to run after
+ test failure
+
+Add "failure_script", a commandline or hardware map parameter that
+allows users to execute a custom script after a testcase fails on a DUT.
+This can be useful to dump device state after a test failure, especially
+one that did not produce any console output.
+
+Signed-off-by: Daniel DeGrasse <ddegrasse@tenstorrent.com>
+---
+ scripts/pylib/twister/twisterlib/environment.py |  5 +++++
+ scripts/pylib/twister/twisterlib/handlers.py    |  6 ++++++
+ scripts/pylib/twister/twisterlib/hardwaremap.py | 12 ++++++++++--
+ scripts/schemas/twister/hwmap-schema.yaml       |  6 ++++++
+ scripts/tests/twister/test_handlers.py          |  2 ++
+ scripts/tests/twister/test_hardwaremap.py       |  4 ++++
+ 6 files changed, 33 insertions(+), 2 deletions(-)
+
+diff --git a/scripts/pylib/twister/twisterlib/environment.py b/scripts/pylib/twister/twisterlib/environment.py
+index f956f853c2b..41a3fc551e5 100644
+--- a/scripts/pylib/twister/twisterlib/environment.py
++++ b/scripts/pylib/twister/twisterlib/environment.py
+@@ -683,6 +683,11 @@ structure in the main Zephyr tree: boards/<vendor>/<board_name>/""")
+                         before device handler open serial port and invoke runner.
+                         """)
+
++    parser.add_argument("--failure-script",
++                        help="""specify a failures script. This will be executed
++                        on test failure.
++                        """)
++
+     parser.add_argument(
+         "--quarantine-list",
+         action="append",
+diff --git a/scripts/pylib/twister/twisterlib/handlers.py b/scripts/pylib/twister/twisterlib/handlers.py
+index dc1ff258935..ce43c530061 100755
+--- a/scripts/pylib/twister/twisterlib/handlers.py
++++ b/scripts/pylib/twister/twisterlib/handlers.py
+@@ -522,6 +522,12 @@ class DeviceHandler(Handler):
+     def make_dut_available(self, dut):
+         if self.instance.status in [TwisterStatus.ERROR, TwisterStatus.FAIL]:
+             dut.failures_increment()
++            if dut.failure_script:
++                logger.debug(f"Running failure script: {dut.failure_script}")
++                timeout = 30
++                if dut.script_param:
++                    timeout = dut.script_param.get("failure_script_timeout", timeout)
++                self.run_custom_script(re.split('[, ]', dut.failure_script), timeout=timeout)
+         logger.debug(f"Release DUT:{dut.platform}, Id:{dut.id}, "
+                      f"counter:{dut.counter}, failures:{dut.failures}")
+         # get all DUTs with the same id
+diff --git a/scripts/pylib/twister/twisterlib/hardwaremap.py b/scripts/pylib/twister/twisterlib/hardwaremap.py
+index 74c384ab5d6..3b1d5381362 100644
+--- a/scripts/pylib/twister/twisterlib/hardwaremap.py
++++ b/scripts/pylib/twister/twisterlib/hardwaremap.py
+@@ -49,7 +49,8 @@ class DUT:
+                  runner=None,
+                  flash_timeout=60,
+                  flash_with_test=False,
+-                 flash_before=False):
++                 flash_before=False,
++                 failure_script=None):
+
+         self.serial = serial
+         self.baud = serial_baud or 115200
+@@ -70,6 +71,7 @@ class DUT:
+         self.post_script = post_script
+         self.pre_script = pre_script
+         self.script_param = script_param
++        self.failure_script = failure_script
+         self.probe_id = None
+         self.notes = None
+         self.lock = Lock()
+@@ -198,6 +200,7 @@ class HardwareMap:
+                 self.add_device(self.options.device_serial,
+                                 self.options.platform[0],
+                                 self.options.pre_script,
++                                self.options.failure_script,
+                                 False,
+                                 baud=self.options.device_serial_baud,
+                                 flash_timeout=self.options.device_flash_timeout,
+@@ -209,6 +212,7 @@ class HardwareMap:
+                 self.add_device(self.options.device_serial_pty,
+                                 self.options.platform[0],
+                                 self.options.pre_script,
++                                self.options.failure_script,
+                                 True,
+                                 flash_timeout=self.options.device_flash_timeout,
+                                 flash_with_test=self.options.device_flash_with_test,
+@@ -238,6 +242,7 @@ class HardwareMap:
+         serial,
+         platform,
+         pre_script,
++        failure_script,
+         is_pty,
+         baud=None,
+         flash_timeout=60,
+@@ -248,6 +253,7 @@ class HardwareMap:
+             platform=platform,
+             connected=True,
+             pre_script=pre_script,
++            failure_script=failure_script,
+             serial_baud=baud,
+             flash_timeout=flash_timeout,
+             flash_with_test=flash_with_test,
+@@ -291,6 +297,7 @@ class HardwareMap:
+             product = dut.get('product')
+             fixtures = dut.get('fixtures', [])
+             connected = dut.get('connected') and ((serial or serial_pty) is not None)
++            failure_script = dut.get('failure_script')
+             if not connected:
+                 continue
+             for plat in platforms:
+@@ -309,7 +316,8 @@ class HardwareMap:
+                               post_flash_script=post_flash_script,
+                               script_param=script_param,
+                               flash_timeout=flash_timeout,
+-                              flash_with_test=flash_with_test)
++                              flash_with_test=flash_with_test,
++                              failure_script=failure_script)
+                 new_dut.fixtures = fixtures
+                 new_dut.counter = 0
+                 self.duts.append(new_dut)
+diff --git a/scripts/schemas/twister/hwmap-schema.yaml b/scripts/schemas/twister/hwmap-schema.yaml
+index 142d4a1969b..f369a84f3f3 100644
+--- a/scripts/schemas/twister/hwmap-schema.yaml
++++ b/scripts/schemas/twister/hwmap-schema.yaml
+@@ -50,6 +50,9 @@ sequence:
+       "pre_script":
+         type: str
+         required: false
++      "failure_script":
++        type: str
++        required: false
+       "fixtures":
+         type: seq
+         required: false
+@@ -77,3 +80,6 @@ sequence:
+           "post_flash_timeout":
+             type: int
+             required: false
++          "failure_script_timeout":
++            type: int
++            required: false
+diff --git a/scripts/tests/twister/test_handlers.py b/scripts/tests/twister/test_handlers.py
+index e4710060a35..41938878ffd 100644
+--- a/scripts/tests/twister/test_handlers.py
++++ b/scripts/tests/twister/test_handlers.py
+@@ -1439,6 +1439,7 @@ def test_devicehandler_handle(
+         pre_script='dummy pre script',
+         post_script='dummy post script',
+         post_flash_script='dummy post flash script',
++        failure_script='dummy failure script',
+         flash_timeout=60,
+         flash_with_test=True
+     )
+@@ -1491,6 +1492,7 @@ def test_devicehandler_handle(
+         mock.call('dummy pre script', mock.ANY),
+         mock.call('dummy post flash script', mock.ANY),
+-        mock.call('dummy post script', mock.ANY)
++        mock.call('dummy post script', mock.ANY),
++        mock.call('dummy failure script', mock.ANY)
+     ])
+
+     if expected_reason:
+diff --git a/scripts/tests/twister/test_hardwaremap.py b/scripts/tests/twister/test_hardwaremap.py
+index 5dc61dc1d9e..81586d47c65 100644
+--- a/scripts/tests/twister/test_hardwaremap.py
++++ b/scripts/tests/twister/test_hardwaremap.py
+@@ -57,6 +57,7 @@ TESTDATA_1 = [
+             'pre_script': 'dummy pre script',
+             'post_script': 'dummy post script',
+             'post_flash_script': 'dummy post flash script',
++            'failure_script': 'dummy failure script',
+             'runner': 'dummy runner',
+             'flash_timeout': 30,
+             'flash_with_test': True,
+@@ -64,6 +65,7 @@ TESTDATA_1 = [
+                 'pre_script_timeout' : 30,
+                 'post_flash_timeout' : 30,
+                 'post_script_timeout' : 30,
++                'failure_script_timeout' : 30,
+                 }
+         },
+         {
+@@ -79,6 +81,7 @@ TESTDATA_1 = [
+             'pre_script': 'dummy pre script',
+             'post_script': 'dummy post script',
+             'post_flash_script': 'dummy post flash script',
++            'failure_script': 'dummy failure script',
+             'runner': 'dummy runner',
+             'flash_timeout': 30,
+             'flash_with_test': True,
+@@ -86,6 +89,7 @@ TESTDATA_1 = [
+                 'pre_script_timeout' : 30,
+                 'post_flash_timeout' : 30,
+                 'post_script_timeout' : 30,
++                'failure_script_timeout' : 30,
+                 }
+         },
+         '<dummy platform (dummy product) on dummy serial>'
+--
+2.34.1


### PR DESCRIPTION
Add two crash handlers:
- a custom version of k_sys_fatal_error_handler
- a custom reset handler

Both crash handlers will log the system BLINK (crash address) into ICCM
at address 0x0000_0004. The reset handler will execute if the ARC
inadvertently triggers a soft reset, and the fatal error handler will
execute for cases that Zephyr considers a fatal exception.

Additionally, add a script to dump SMC state after a crash. This script will be run after a failure in pytest or CI as a whole, and can help us debug a crash on the ARC core.

Finally, exit pytest if the DUT fails to flash or enumerate. This will reduce log verbosity, since if the ARC fails to enumerate there is no point running the pytests and getting a bunch of errors.

Add CI steps to log the machine state, so that we can more easily reproduce errors in CI on local systems.