### PR TITLE
dts: arc: tenstorrent: make SPI interrupt highest priority

### DIFF
--- a/dts/arc/tenstorrent/tt_blackhole_smc.dtsi
+++ b/dts/arc/tenstorrent/tt_blackhole_smc.dtsi
@@ -335,7 +335,7 @@
 		compatible = "snps,designware-intc";
 		reg = <0x800c0000 0x1000>;
 		interrupt-parent = <&intc>;
-		interrupts = <33 0>;
+		interrupts = <33 1>;
 		interrupt-controller;
 		#interrupt-cells = <3>;
 		num-irqs = <34>;
@@ -345,7 +345,7 @@
 		compatible = "snps,designware-intc";
 		reg = <0x800d0000 0x1000>;
 		interrupt-parent = <&intc>;
-		interrupts = <34 0>;
+		interrupts = <34 1>;
 		interrupt-controller;
 		#interrupt-cells = <3>;
 		num-irqs = <22>;
@@ -355,7 +355,7 @@
 		compatible = "snps,designware-intc";
 		reg = <0x800e0000 0x1000>;
 		interrupt-parent = <&intc>;
-		interrupts = <35 0>;
+		interrupts = <35 1>;
 		interrupt-controller;
 		#interrupt-cells = <3>;
 		num-irqs = <64>;
@@ -373,7 +373,7 @@
 
 	ici: intercore-interrupt-unit {
 		compatible = "snps,archs-ici";
-		interrupts = <19 1>;
+		interrupts = <19 2>;
 		interrupt-parent = <&intc>;
 	};
 
@@ -384,13 +384,13 @@
 
 	timer0: timer0 {
 		compatible = "snps,arc-timer";
-		interrupts = <16 1>;
+		interrupts = <16 2>;
 		interrupt-parent = <&intc>;
 	};
 
 	timer1: timer1 {
 		compatible = "snps,arc-timer";
-		interrupts = <17 1>;
+		interrupts = <17 2>;
 		interrupt-parent = <&intc>;
 	};
 
@@ -639,7 +639,7 @@
 			compatible = "ns16550";
 			clocks = <&sysclk>;
 			reg = <0x80200000 0x1000>;
-			interrupts = <59 1>;
+			interrupts = <59 2>;
 			reg-shift = <2>;
 			status = "disabled";
 		};

--- a/zephyr/patches.yml
+++ b/zephyr/patches.yml
@@ -1,4 +1,12 @@
 patches:
+  - path: zephyr/arch-arc-core-support-multilevel-interrupt-priority.patch
+    sha256sum: f54c22822565e99a5fee4fbf8a56a88c0c21c180ca90d8db980810b4787452eb
+    module: zephyr
+    author: Daniel DeGrasse
+    email: ddegrasse@tenstorrent.com
+    date: 2025-09-16
+    comments: |
+      Support multilevel interrupt priority on ARC cores.
   - path: zephyr/twister-rtt-support.patch
     sha256sum: 2bd73942e827989cd513ce8aa971674ad9d9a928fe9bd21964488d051bb81807
     module: zephyr

--- a/zephyr/patches/zephyr/arch-arc-core-support-multilevel-interrupt-priority.patch
+++ b/zephyr/patches/zephyr/arch-arc-core-support-multilevel-interrupt-priority.patch
@@ -1,0 +1,45 @@
+From 7a07c75ae48b6086dd6dc1b5f97672f9ac6228ed Mon Sep 17 00:00:00 2001
+From: Daniel DeGrasse <ddegrasse@tenstorrent.com>
+Date: Tue, 16 Sep 2025 11:13:40 -0500
+Subject: [PATCH] arch: arc: core: support multilevel interrupt priority
+ setting
+
+Properly support setting priority for multilevel interrupts on ARC
+cores.
+
+Signed-off-by: Daniel DeGrasse <ddegrasse@tenstorrent.com>
+---
+ arch/arc/core/irq_manage.c | 18 +++++++++++++++++-
+ 1 file changed, 17 insertions(+), 1 deletion(-)
+
+diff --git a/arch/arc/core/irq_manage.c b/arch/arc/core/irq_manage.c
+index f6573f5e1bd..cc3cbf0cb7b 100644
+--- a/arch/arc/core/irq_manage.c
++++ b/arch/arc/core/irq_manage.c
+@@ -215,7 +215,23 @@ int arch_irq_is_enabled(unsigned int irq)
+
+ void z_irq_priority_set(unsigned int irq, unsigned int prio, uint32_t flags)
+ {
+-	ARG_UNUSED(flags);
++#ifdef CONFIG_MULTI_LEVEL_INTERRUPTS
++	unsigned int level = irq_get_level(irq);
++	const struct device *dev;
++
++#ifdef CONFIG_3RD_LEVEL_INTERRUPTS
++	if (level == 3) {
++		dev = z_get_sw_isr_device_from_irq(irq);
++		irq_set_priority_next_level(dev, irq_from_level_3(irq), prio, flags);
++		return;
++} else
++#endif
++	if (level == 2) {
++		dev = z_get_sw_isr_device_from_irq(irq);
++		irq_set_priority_next_level(dev, irq_from_level_2(irq), prio, flags);
++		return;
++	}
++#endif
+
+ 	__ASSERT(prio < CONFIG_NUM_IRQ_PRIO_LEVELS,
+ 		 "invalid priority %d for irq %d", prio, irq);
+--
+2.34.1


### PR DESCRIPTION
Make the SPI interrupt highest priority. This will ensure that the SPI
controller is never preempted while writing to the SPI flash.

Should fix test issues like this one: [tenstorrent/tt-zephyr-platforms/actions/runs/17655677993/job/50180829826](https://github.com/tenstorrent/tt-zephyr-platforms/actions/runs/17655677993/job/50180829826)