### PR TITLE
app: dmc: add support for smbus block pcall

### DIFF
--- a/app/dmc/src/main.c
+++ b/app/dmc/src/main.c
@@ -299,6 +299,22 @@ static int bh_chip_run_smbus_tests(struct bh_chip *chip)
 		return -EIO;
 	}
 
+	/* Test block write block read call*/
+	uint32_t test_data = 0x1234FEDC;
+
+	ret = bharc_smbus_block_write_block_read(
+		&chip->config.arc, CMFW_SMBUS_TEST_WRITE_BLOCK_READ_BLOCK, sizeof(test_data),
+		(uint8_t *)&test_data, &count, data);
+	if (ret < 0) {
+		LOG_DBG("Failed to Perform block write block read command");
+		return ret;
+	}
+	(void)memcpy(&test_data, data, sizeof(test_data));
+	if (test_data != 0x1234FEDC) {
+		LOG_DBG("Incorrect read back value: Expected 0x1234FEDC; actual:0x%08X", test_data);
+		return -EIO;
+	}
+
 	/* Record test status into scratch register */
 	ret = bharc_smbus_block_write(&chip->config.arc, 0xDD, sizeof(pass_val),
 				      (uint8_t *)&pass_val);

--- a/include/tenstorrent/bh_arc.h
+++ b/include/tenstorrent/bh_arc.h
@@ -32,9 +32,9 @@ typedef struct dmStaticInfo {
 	uint32_t version;
 	uint32_t bl_version;
 	uint32_t app_version;
-	uint32_t arc_start_time;  /* Timestamp in ASIC refclk (50 MHz) */
+	uint32_t arc_start_time;   /* Timestamp in ASIC refclk (50 MHz) */
 	uint32_t dm_init_duration; /* Duration in DMC refclk (64 MHz) */
-	uint32_t arc_hang_pc; /* Program counter during last ARC hang */
+	uint32_t arc_hang_pc;      /* Program counter during last ARC hang */
 } __packed dmStaticInfo;
 
 typedef struct cm2dmMessage {
@@ -70,6 +70,8 @@ int bharc_smbus_block_read(const struct bh_arc *dev, uint8_t cmd, uint8_t *count
 int bharc_smbus_block_write(const struct bh_arc *dev, uint8_t cmd, uint8_t count, uint8_t *input);
 int bharc_smbus_word_data_write(const struct bh_arc *dev, uint16_t cmd, uint16_t word);
 int bharc_smbus_byte_data_write(const struct bh_arc *dev, uint8_t cmd, uint8_t word);
+int bharc_smbus_block_write_block_read(const struct bh_arc *dev, uint8_t cmd, uint8_t snd_count,
+				       uint8_t *send_buf, uint8_t *rcv_count, uint8_t *rcv_buf);
 
 #define BH_ARC_INIT(n)                                                                             \
 	{.smbus = SMBUS_DT_SPEC_GET(n),                                                            \

--- a/lib/tenstorrent/bh_chip/bh_arc.c
+++ b/lib/tenstorrent/bh_chip/bh_arc.c
@@ -71,6 +71,29 @@ int bharc_smbus_block_write(const struct bh_arc *dev, uint8_t cmd, uint8_t count
 	return ret;
 }
 
+int bharc_smbus_block_write_block_read(const struct bh_arc *dev, uint8_t cmd, uint8_t snd_count,
+				       uint8_t *send_buf, uint8_t *rcv_count, uint8_t *rcv_buf)
+{
+	int ret;
+
+	ret = bharc_enable_i2cbus(dev);
+	if (ret != 0) {
+		bharc_disable_i2cbus(dev);
+		return ret;
+	}
+
+	ret = smbus_block_pcall(dev->smbus.bus, dev->smbus.addr, cmd, snd_count, send_buf,
+				rcv_count, rcv_buf);
+
+	int newret = bharc_disable_i2cbus(dev);
+
+	if (ret == 0) {
+		return newret;
+	}
+
+	return ret;
+}
+
 int bharc_smbus_word_data_write(const struct bh_arc *dev, uint16_t cmd, uint16_t word)
 {
 	int ret;

--- a/zephyr/patches.yml
+++ b/zephyr/patches.yml
@@ -220,3 +220,11 @@ patches:
       read_processed should be called on every subsequent byte in the
       transaction, and it should also send the data fetched in the CB
       back on the wire.
+  - path: zephyr/stm32-bwbr.patch
+    sha256sum: 1c5f0cfe4e39b57f28bc5501e8c7a1e759765887de55fea03f21eec7e322f5d1
+    module: zephyr
+    author: James Growden
+    email: jgrowden@tenstorrent.com
+    date: 2025-09-18
+    comments: |
+      Add support for BWBR smbus32 pcalls

--- a/zephyr/patches/zephyr/stm32-bwbr.patch
+++ b/zephyr/patches/zephyr/stm32-bwbr.patch
@@ -1,0 +1,79 @@
+diff --git a/drivers/smbus/smbus_stm32.c b/drivers/smbus/smbus_stm32.c
+index b74d94cdc9d..3e93e8f4ef7 100644
+--- a/drivers/smbus/smbus_stm32.c
++++ b/drivers/smbus/smbus_stm32.c
+@@ -522,6 +522,65 @@ static int smbus_stm32_block_read(const struct device *dev, uint16_t periph_addr
+ 	return check_read_pec(dev, periph_addr, messages, ARRAY_SIZE(messages));
+ }
+ 
++int smbus_stm32_block_pcall(const struct device *dev,
++				       uint16_t addr, uint8_t cmd,
++				       uint8_t send_count, uint8_t *send_buf,
++				       uint8_t *recv_count, uint8_t *recv_buf)
++{
++	const struct smbus_stm32_config *config = dev->config;
++
++	uint8_t received_pec;
++
++	struct i2c_msg messages[] = {
++		{
++			.buf = &cmd,
++			.len = sizeof(cmd),
++			.flags = I2C_MSG_WRITE,
++		},
++		{
++			.buf = &send_count,
++			.len = sizeof(send_count),
++			.flags = I2C_MSG_WRITE,
++		},
++		{
++			.buf = send_buf,
++			.len = send_count,
++			.flags = I2C_MSG_WRITE,
++		},
++		{
++			.buf = NULL,	/* will point to next message's len field */
++			.len = 1,
++			.flags = I2C_MSG_READ | I2C_MSG_RESTART,
++		},
++		{
++			.buf = recv_buf,
++			.len = 0,	/* written by previous message! */
++			.flags = I2C_MSG_READ,
++		},
++		{
++			.buf = &received_pec,
++			.len = 1,
++			.flags = I2C_MSG_READ,
++		}
++	};
++
++	/* Count is read in msg 3 and stored in the len of msg 4.
++	 * This works because the STM I2C driver processes each message serially.
++	 * The addressing math assumes little-endian.
++	 */
++	messages[3].buf = (uint8_t*)&messages[4].len;
++
++	uint8_t num_msgs = prepare_read_pec(dev, messages, ARRAY_SIZE(messages));
++
++	int res = i2c_transfer(config->i2c_dev, messages, num_msgs, addr);
++
++	*recv_count = messages[4].len;
++
++	if (res != 0) return res;
++
++	return check_read_pec(dev, addr, messages, ARRAY_SIZE(messages));
++}
++
+ static int smbus_stm32_cancel(const struct device *dev)
+ {
+ 	const struct smbus_stm32_config *config = dev->config;
+@@ -556,7 +615,7 @@ static DEVICE_API(smbus, smbus_stm32_api) = {
+ 	.smbus_smbalert_set_cb = NULL,
+ 	.smbus_smbalert_remove_cb = NULL,
+ #endif /* CONFIG_SMBUS_STM32_SMBALERT */
+-	.smbus_block_pcall = NULL,
++	.smbus_block_pcall = smbus_stm32_block_pcall,
+ 	.smbus_host_notify_set_cb = NULL,
+ 	.smbus_host_notify_remove_cb = NULL,
+ };


### PR DESCRIPTION
Add support for block-write-block-read commands

For now, just test the usable test command during the bh_chip smbus tests. Future use could use this to expose full VUART I/O to DMC, or etc.