### PR TITLE
doc: release: 18.11: add release notes based on github changelog

### DIFF
--- a/doc/release/migration-guide-18.10.md
+++ b/doc/release/migration-guide-18.10.md
@@ -1,5 +1,7 @@
 # v18.10.0
 
+## Migration Guide
+
 This document lists recommended and required changes for those migrating from the previous v18.9.0 firmware release to the new v18.10.0 firmware release.
 
 * PVT driver has been migrated to a [Zephyr sensor driver](https://docs.zephyrproject.org/latest/hardware/peripherals/sensor/index.html), using the new [read/decode API](https://docs.zephyrproject.org/latest/hardware/peripherals/sensor/read_and_decode.html#sensor-read-and-decode).

--- a/doc/release/migration-guide-18.11.md
+++ b/doc/release/migration-guide-18.11.md
@@ -1,5 +1,7 @@
 # v18.11.0
 
-> [!NOTE]
+## Migration Guide
+
 > This is a working draft for the up-coming v18.11.0 release.
+
 This document lists recommended and required changes for those migrating from the previous v18.10.0 firmware release to the new v18.11.0 firmware release.

--- a/doc/release/migration-guide-18.2.md
+++ b/doc/release/migration-guide-18.2.md
@@ -1,8 +1,9 @@
 # v18.2.0
 
+## Migration Guide
+
 This document lists recommended and required changes for those migrating from the previous v80.18.1 firmware release to the new v18.2.0 firmware release.
 
-> [!IMPORTANT]
 > TT-KMD Users are required to update v1.33 to ensure MPS limit is properly saved and restored.
 
 * Firmware Versioning: TT Zephyr Platforms has dropped the previous legacy `v80.major.minor.rc` numbering to more traditional [Semantic Versioning](https://semver.org). E.g.

--- a/doc/release/migration-guide-18.3.md
+++ b/doc/release/migration-guide-18.3.md
@@ -1,5 +1,7 @@
 # v18.3.0
 
+## Migration Guide
+
 This document lists recommended and required changes for those migrating from the previous v18.2.0 firmware release to the new v18.3.0 firmware release.
 
 * Going forward, and following the more standard semantic versioning of firmware, the filename

--- a/doc/release/migration-guide-18.4.md
+++ b/doc/release/migration-guide-18.4.md
@@ -1,7 +1,6 @@
 # v18.4.0
 
-> [!NOTE]
-> This is a working draft for the up-coming v18.4.0 release.
+## Migration Guide
 
 This document lists recommended and required changes for those migrating from the previous v18.3.0 firmware release to the new v18.4.0 firmware release.
 

--- a/doc/release/migration-guide-18.5.md
+++ b/doc/release/migration-guide-18.5.md
@@ -1,6 +1,5 @@
 # v18.5.0
 
-> [!NOTE]
-> This is a working draft for the up-coming v18.5.0 release.
+## Migration Guide
 
 This document lists recommended and required changes for those migrating from the previous v18.4.0 firmware release to the new v18.4.0 firmware release.

--- a/doc/release/migration-guide-18.6.md
+++ b/doc/release/migration-guide-18.6.md
@@ -1,5 +1,7 @@
 # v18.6.0
 
+## Migration Guide
+
 This document lists recommended and required changes for those migrating from the previous v18.5.0
 firmware release to the new v18.6.0 firmware release.
 

--- a/doc/release/migration-guide-18.7.md
+++ b/doc/release/migration-guide-18.7.md
@@ -1,5 +1,7 @@
 # v18.7.0
 
+## Migration Guide
+
 This document lists recommended and required changes for those migrating from the previous v18.6.0 firmware release to the new v18.7.0 firmware release.
 
 * RTT temporarily unavailable on SMC

--- a/doc/release/migration-guide-18.8.md
+++ b/doc/release/migration-guide-18.8.md
@@ -1,5 +1,7 @@
 # v18.8.0
 
+## Migration Guide
+
 This document lists recommended and required changes for those migrating from the previous v18.7.0 firmware release to the new v18.8.0 firmware release.
 
 * Update `pyluwen`, `tt-smi` and `tt-flash` to support more firmware telemetry values being added.

--- a/doc/release/migration-guide-18.9.md
+++ b/doc/release/migration-guide-18.9.md
@@ -1,3 +1,5 @@
 # v18.9.0
 
+## Migration Guide
+
 This document lists recommended and required changes for those migrating from the previous v18.8.0 firmware release to the new v18.9.0 firmware release.

--- a/doc/release/release-notes-18.11.md
+++ b/doc/release/release-notes-18.11.md
@@ -6,10 +6,27 @@ We are pleased to announce the release of TT Zephyr Platforms firmware version 1
 
 Major enhancements with this release include:
 
+## What's Changed
+
 <!-- H3 Performance Improvements, if applicable -->
+
+### Performance Improvements
+
+* soc: tt_blackhole: enable hardware floating-point in SMC FW
+
 <!-- H3 New and Experimental Features, if applicable -->
 <!-- H3 External Project Collaboration Efforts, if applicable -->
+
 <!-- H3 Stability Improvements, if applicable -->
+
+### Stability Improvements
+
+* boards: tt_blackhole: p150c: correct tdp_limit & tdc_limits
+* scripts: recover-blackhole: add recovery bundle scripting in-tree
+* patches: Fix smbus PEC correction patch
+* ci: workflows: hardware-long: update metal container version and test p300a
+* app: dmc: Move MFD, PWM and sensor configs to prj.conf
+* scripts: tooling: vuart: report error if card reads as `0xffff_ffff`
 
 <!-- H1 Security vulnerabilities fixed? -->
 
@@ -22,7 +39,32 @@ Major enhancements with this release include:
 <!-- UL Ethernet -->
 <!-- UL Telemetry -->
 <!-- UL Debug / Developer Features -->
+
+### Debug / Developer Features
+
+* `tt-zephyr-platforms`documentation is now available online at https://docs.tenstorrent.com/tt-zephyr-platforms 🙌🪁
+  * doc: getting_started: move contents from README.md to getting started guide, and publish to HTML
+  * doc: develop: add documentation for tracing
+* ci: build-native: publish tt-console and tt-tracing artifacts
+  * previously, users needed to build these binaries themselves with `make -C scripts/tooling`. Now they are built on every commit.
+* ci: release: ensure build artifacts for all board revisions are in zip
+* scripts: tt_boot_fs: ls: add hexdump functionality when verbose >= 2
+  * this allows us to inspect all contents of TT Boot FS .bin files without breaking out a separate hex editor
+* bh_arc: tt_shell: add shell support
+  * a common location for custom Tenstorrent shell commands
+  * print telemetry data with `telem` sub-command
+  * read (and write) asic state with `asic_state` sub-command
+* app: dmc: enable logging via DMC SMBUS path
+  * first logs to a local ringbuffer, and then data is sent over smbus from DMC to SMC
+  * users should now be able to view DMC logs with `tt-console -c 2`
+
 <!-- UL Drivers -->
+
+### Drivers
+
+* drivers: sensor: pvt: integrate pvt driver, add tolerance in tests, read efused temperature calibration
+* drivers: smbus: add platform-independent `zephyr,smbus-target` driver (should be upstreamed shortly)
+
 <!-- UL Libraries -->
 
 <!-- H2 New Samples, if applicable -->


### PR DESCRIPTION
We didn't manually add release notes in this sprint unfortunately, so use and modify GitHub's automatically-generated release notes.

Also added level-2 heading to distinguish the Migration Guide from Release Notes, along with some other drive-by cleanups.