### PR TITLE
doc: fix rendering of zephyr-app-commands

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,15 +17,25 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          path: tt-zephyr-platforms
 
       - name: Install dependencies
+        working-directory: tt-zephyr-platforms
         run: |
           wget --no-verbose "https://github.com/doxygen/doxygen/releases/download/Release_${DOXYGEN_VERSION//./_}/doxygen-${DOXYGEN_VERSION}.linux.bin.tar.gz"
           tar xf doxygen-${DOXYGEN_VERSION}.linux.bin.tar.gz
           echo "${PWD}/doxygen-${DOXYGEN_VERSION}/bin" >> $GITHUB_PATH
           pip install -r doc/requirements.txt
 
+      - name: Clone Zephyr
+        run: |
+          pip install west
+          west init -l tt-zephyr-platforms
+          west update
+
       - name: Build
+        working-directory: tt-zephyr-platforms
         run: |
           cd doc
 
@@ -53,13 +63,13 @@ jobs:
         if: github.event_name != 'pull_request'
         uses: actions/upload-pages-artifact@v3
         with:
-          path: doc/deploy
+          path: tt-zephyr-platforms/doc/deploy
 
       - name: Upload artifacts
         if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@v4
         with:
-          path: doc/deploy
+          path: tt-zephyr-platforms/doc/deploy
 
   deploy:
     runs-on: ubuntu-22.04

--- a/boards/tenstorrent/tt_blackhole/doc/index.rst
+++ b/boards/tenstorrent/tt_blackhole/doc/index.rst
@@ -91,28 +91,34 @@ Supported Features
    Some components are in the process of being migrated to Zephyr's driver model, and are
    currently implemented in the ``lib/tenstorrent/bh_arc`` library.
 
-.. :external+zephyr:zephyr:board-supported-hw::
-
 Building
 ========
 
 SMC firmware can be built using the standard Zephyr build system. For other apps, tests,
 and samples, simply point the build system to the desired app directory.
 
-.. :external+zephyr:zephyr-app-commands::
-   :zephyr-app: app/smc
+.. zephyr-app-commands::
+   :zephyr-app: <tt_zephyr_platforms>/app/smc
    :host-os: unix
    :board: tt_blackhole@p100a/tt_blackhole/smc
+   :flash-args: -r tt_flash --force
    :goals: build flash
    :compact:
 
 The ``tt-console`` app is a terminal-emulator-like utility that can be used to view log messages
 and interact with the Zephyr shell.
 
-.. code-block:: bash
+.. code-block:: shell
 
-   $ gcc -std=gnu11 -Iinclude -o tt-console scripts/tt-console/console.c
-   $ ./tt-console
+    # Build the TT console utility (for board communication)
+    make -j -C scripts/tooling OUTDIR=/tmp tt-console
+
+    # Reset the board and refresh PCIe connectivity
+    tt-smi -r
+    ./scripts/rescan-pcie.sh
+
+    # Connect to the board console
+    /tmp/tt-console
 
 Press ``Ctrl-x,a`` to exit the ``tt-console`` app.
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -2,8 +2,18 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from pathlib import Path
+import sys
 
 TTZP = Path(__file__).parent.parent
+ZEPHYR_BASE = TTZP.parent / "zephyr"
+
+# Add the '_extensions' directory to sys.path, to enable finding Sphinx
+# extensions within.
+sys.path.insert(0, str(ZEPHYR_BASE / "doc" / "_extensions"))
+
+# Add the '_scripts' directory to sys.path, to enable finding utility
+# modules.
+sys.path.insert(0, str(ZEPHYR_BASE / "doc" / "_scripts"))
 
 project = "TT Zephyr Platforms"
 copyright = "2025, Tenstorrent AI ULC"
@@ -13,6 +23,7 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx_rtd_theme",
     "sphinx_tabs.tabs",
+    "zephyr.application",
 ]
 templates_path = ["_templates"]
 exclude_patterns = ["_build_sphinx", "Thumbs.db", ".DS_Store"]

--- a/doc/develop/debugging/tracing.rst
+++ b/doc/develop/debugging/tracing.rst
@@ -12,12 +12,13 @@ To enable tracing for the ``tt_blackhole`` platform, you need to add the tracing
 configuration overlays to your build command. For example, to enable tracing
 when building for the ``p150a`` board revision, you would use the following command:
 
-.. :external+zephyr:zephyr-app-commands::
-   :zephyr-app: app/smc
+.. zephyr-app-commands::
+   :zephyr-app: <tt_zephyr_platforms>/app/smc
    :host-os: unix
    :board: tt_blackhole@p150a/tt_blackhole/smc
    :west-args: --sysbuild
    :build-args: -- -DEXTRA_CONF_FILE=tracing.conf -DEXTRA_DTC_OVERLAY_FILE=tracing.overlay
+   :flash-args: -r tt_flash --force
    :goals: build flash
    :compact:
 


### PR DESCRIPTION
Fix rendering of Zephyr app commands, and remove directives we aren't rendering at all