### PR TITLE
scripts: fixes for compliance checks

### DIFF
--- a/scripts/check-copyright.py
+++ b/scripts/check-copyright.py
@@ -52,7 +52,7 @@ PATHS = {
 }
 
 # Set of dirs to exclude from check
-EXCLUDE_DIRS = {"build/**", "twister-out*/**"}
+EXCLUDE_DIRS = {"**/build*/**", "build*/**", "twister-out*/**"}
 
 
 def is_excluded(filename):

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -18,3 +18,5 @@ fi
 
 set -e exec
 exec git diff --cached | ${zep_base}/scripts/checkpatch.pl -
+exec ruff format --diff $(git diff --name-only | grep ".py")
+exec ruff check --diff $(git diff --name-only | grep ".py")


### PR DESCRIPTION
Exclude subdirectories with "build" in the name, so the build folder for
the SPI FLM doesn't trigger the check.

Add ruff format/lint checks before commit, to catch errors earlier.