### PR TITLE
doc: Link sphinx documentation to doxygen documentation

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -25,11 +25,17 @@ extensions = [
     "sphinx_tabs.tabs",
     "zephyr.application",
 ]
-templates_path = ["_templates"]
+templates_path = [str(ZEPHYR_BASE / "doc/_templates")]
 exclude_patterns = ["_build_sphinx", "Thumbs.db", ".DS_Store"]
 html_theme = "sphinx_rtd_theme"
 external_content_contents = [
     (TTZP / "doc", "[!_]*"),
     (TTZP, "boards/**/*.rst"),
 ]
+
+html_context = {
+    "reference_links": {"API": "doxygen/index.html"},
+}
+
+
 intersphinx_mapping = {"zephyr": ("https://docs.zephyrproject.org/latest/", None)}


### PR DESCRIPTION
Link the tt-zephyr platforms sphinx documentation to our doxygen output via the reference links.