### PR TITLE
doc: derive documentation version from bundle / release version

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,7 +36,16 @@ jobs:
 
           rm -f zephyr.tag
           wget https://docs.zephyrproject.org/latest/doxygen/html/zephyr.tag -O /tmp/zephyr.tag
-          doxygen
+
+          # We should try to limit the number of environment variables we reference in Doxyfile
+          # but they can be added here, as needed.
+          # For reference, this method of passing variables is based on Doxygen's examples
+          # https://github.com/doxygen/doxygen/issues/7975
+          ( \
+            cat Doxyfile; \
+            echo "PROJECT_NUMBER=$(../scripts/get_ttzp_version.py)"; \
+            echo "" \
+          ) | doxygen -
 
           make html
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,14 +1,20 @@
 # Copyright (c) 2025 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
 
+import sys
+
 from pathlib import Path
 
 TTZP = Path(__file__).parent.parent
 
+sys.path.insert(0, str(TTZP / "scripts"))
+
+from get_ttzp_version import get_ttzp_version  # noqa: E402
+
 project = "TT Zephyr Platforms"
 copyright = "2025, Tenstorrent AI ULC"
 author = "Tenstorrent AI ULC"
-release = "1.0.0"
+release = get_ttzp_version()
 extensions = [
     "sphinx.ext.intersphinx",
     "sphinx_rtd_theme",

--- a/scripts/get_ttzp_version.py
+++ b/scripts/get_ttzp_version.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+
+TTZP = Path(__file__).parent.parent
+
+
+def get_ttzp_version():
+    with open(TTZP / "VERSION", "r") as f:
+        lines = [line.split("=")[1].strip() for line in f.readlines() if "=" in line]
+    ver = ".".join(lines[:3])
+    if lines[4]:
+        ver += f"-{lines[4]}"
+    return ver
+
+
+if __name__ == "__main__":
+    print(get_ttzp_version())


### PR DESCRIPTION
Derive the version displayed in generated documentation from the release / bundle `VERSION` file at the root of the repository.

Testing Done:
```py
# with rc1 in VERSION file
>>> ver = get_ttzp_version()
>>> print(ver)
18.11.0-rc1

# with no rc1 in VERSION file
>>> ver = get_ttzp_version()
>>> print(ver)
18.11.0
```

```shell
$ grep -Rn "18\.11\.0" deploy
...
deploy/doxygen/structtt__vuart.html:24:   <div id="projectname">TT Zephyr Platforms<span id="projectnumber">&#160;18.11.0-rc1</span>
...
```