### PR TITLE
scripts: tooling: tt-console: add option to skip pcie rescan

### DIFF
--- a/.github/workflows/hardware-long.yml
+++ b/.github/workflows/hardware-long.yml
@@ -79,7 +79,7 @@ jobs:
             --west-runner tt_flash \
             --device-testing -c \
             --device-flash-timeout 120 \
-            --device-serial-pty ../tt-zephyr-platforms/scripts/smc_console.py \
+            --device-serial-pty "../tt-zephyr-platforms/scripts/smc_console.py -p" \
             --flash-before \
             --outdir twister-e2e-stress
 
@@ -112,7 +112,7 @@ jobs:
           echo "SMC RTT logs:"
           python3 ./scripts/smc_console.py --rtt -n
           echo "SMC state dump:"
-          python3 ./scripts/dump_smc_state.py --asic-id $ASIC_ID
+          python3 ./scripts/dump_smc_state.py
 
   # Temporarily moved from hardware-smoke.yml until metal tests occupy less time for CI on each PR
   metal-test:

--- a/.github/workflows/hardware-smoke.yml
+++ b/.github/workflows/hardware-smoke.yml
@@ -250,7 +250,7 @@ jobs:
           ./scripts/twister -i \
             -p $SMC_BOARD --device-testing \
             --tag e2e \
-            --device-serial-pty "../tt-zephyr-platforms/scripts/smc_console.py -d $CONSOLE_DEV" \
+            --device-serial-pty "../tt-zephyr-platforms/scripts/smc_console.py -d $CONSOLE_DEV -p" \
             --failure-script "../tt-zephyr-platforms/scripts/smc_test_recovery.py --asic-id $ASIC_ID" \
             --flash-before \
             --west-flash \
@@ -266,7 +266,7 @@ jobs:
             --west-flash="--force" \
             --west-runner tt_flash \
             --device-testing -c \
-            --device-serial-pty "../tt-zephyr-platforms/scripts/smc_console.py -d $CONSOLE_DEV" \
+            --device-serial-pty "../tt-zephyr-platforms/scripts/smc_console.py -d $CONSOLE_DEV -p" \
             --failure-script "../tt-zephyr-platforms/scripts/smc_test_recovery.py --asic-id $ASIC_ID" \
             --flash-before \
             --outdir twister-e2e-flash


### PR DESCRIPTION
Add option to skip pcie rescan, and use it in CI tests. Automatic PCIe rescan can interfere with other tests trying to rescan the card at specific times.