### PR TITLE
ci: cleanup-branches: omit collab branches from cleanup

### DIFF
--- a/.github/workflows/cleanup-branches.yml
+++ b/.github/workflows/cleanup-branches.yml
@@ -24,7 +24,7 @@ jobs:
           for branch in $ALL_BRANCHES; do
             echo -n "Found branch $branch..."
 
-            if [[ "$branch" == "main" || "$branch" =~ ^v.*-branch$ ]]; then
+            if [[ "$branch" == "main" || "$branch" =~ ^v.*-branch$ || "$branch" =~ ^collab.* ]]; then
               echo -e "  \033[32mSkipping\033[0m"
               continue
             fi


### PR DESCRIPTION
Collaboration branches are where collaborative work is done that will be merged into main at a later time.

Allow for manual management of these branches so that they are not automatically removed.