### PR TITLE
zephyr: patches: add patch for spi-nor erase-block-size property

### DIFF
--- a/zephyr/patches.yml
+++ b/zephyr/patches.yml
@@ -258,3 +258,14 @@ patches:
     date: 2025-09-18
     comments: |
       Add support for BWBR smbus32 pcalls
+  - path: zephyr/jedec-spi-nor-erase-block-size.patch
+    sha256sum: 1d5b8698e8e9470e1aeeaed9b92712df6684e729d39081693ce69b0e9eaaf7b8
+    module: zephyr
+    author: Chris Friedt
+    email: cfriedt@tenstorrent.com
+    date: 2025-09-23
+    upstreamable: true
+    merge-pr: https://github.com/zephyrproject-rtos/zephyr/pull/96443
+    comments: |
+      Add an optional erase-block-size property to the jedec,spi-nor binding so that mcuboot
+      does not complain about slot1_size not being defined.

--- a/zephyr/patches/zephyr/jedec-spi-nor-erase-block-size.patch
+++ b/zephyr/patches/zephyr/jedec-spi-nor-erase-block-size.patch
@@ -1,0 +1,12 @@
+diff --git a/dts/bindings/mtd/jedec,spi-nor.yaml b/dts/bindings/mtd/jedec,spi-nor.yaml
+index aea41f0a331..fe231e3b458 100644
+--- a/dts/bindings/mtd/jedec,spi-nor.yaml
++++ b/dts/bindings/mtd/jedec,spi-nor.yaml
+@@ -21,3 +21,7 @@ properties:
+   reset-gpios:
+     type: phandle-array
+     description: RESETn pin
++  erase-block-size:
++    type: int
++    description: |
++      The minimum erasable block size of the device, in bytes.


### PR DESCRIPTION
Add a patch to upstream zephyr to avoid mcuboot warning about slot1_size.

Before:
```shell
west build --sysbuild -p -b tt_blackhole@p100a/tt_blackhole/dmc app/dmc
...
CMake Warning at CMakeLists.txt:517 (message):
  Unable to determine erase size of slot1 partition, cannot calculate minimum
  sector usage
```
