### PR TITLE
ci: stop using github.ref

### DIFF
--- a/.github/workflows/build-fw.yml
+++ b/.github/workflows/build-fw.yml
@@ -25,7 +25,7 @@ on:
       - collab*
 
 concurrency:
-  group: ${{ github.workflow }}-build-fw-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 # TODO: read boards / board revs from a YAML file (generate a matrix)
@@ -52,7 +52,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           path: tt-zephyr-platforms
-          ref: ${{ github.ref }}
       - uses: ./tt-zephyr-platforms/.github/workflows/prepare-zephyr
         with:
           app-path: tt-zephyr-platforms
@@ -115,7 +114,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           path: tt-zephyr-platforms
-          ref: ${{ github.ref }}
       - uses: ./tt-zephyr-platforms/.github/workflows/prepare-zephyr
         with:
           app-path: tt-zephyr-platforms
@@ -158,7 +156,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           path: tt-zephyr-platforms
-          ref: ${{ github.ref }}
       - uses: ./tt-zephyr-platforms/.github/workflows/prepare-zephyr
         with:
           app-path: tt-zephyr-platforms
@@ -252,7 +249,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           path: tt-zephyr-platforms
-          ref: ${{ github.ref }}
       - uses: ./tt-zephyr-platforms/.github/workflows/prepare-zephyr
         with:
           app-path: tt-zephyr-platforms
@@ -278,7 +274,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           path: tt-zephyr-platforms
-          ref: ${{ github.ref }}
 
       - name: Download firmware artifacts
         uses: actions/download-artifact@v4
@@ -310,7 +305,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           path: tt-zephyr-platforms
-          ref: ${{ github.ref }}
       - uses: ./tt-zephyr-platforms/.github/workflows/prepare-zephyr
         with:
           app-path: tt-zephyr-platforms

--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -15,7 +15,7 @@ on:
       - v*-branch
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 jobs:
@@ -27,7 +27,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.ref }}
       - name: Run the script
         run: |
           make -j$(nproc) -C scripts/tooling OUTDIR=$PWD

--- a/.github/workflows/copyright-check.yml
+++ b/.github/workflows/copyright-check.yml
@@ -17,7 +17,7 @@ on:
       - collab*
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 jobs:
@@ -29,7 +29,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.ref }}
       - name: Run the script
         run: |
           ./scripts/check-copyright.py

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,6 +8,10 @@ on:
     branches: [main]
   pull_request: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 env:
   DOXYGEN_VERSION: 1.9.6
 

--- a/.github/workflows/hardware-long.yml
+++ b/.github/workflows/hardware-long.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 jobs:
@@ -43,7 +43,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.2.2
         with:
-          ref: ${{ github.ref }}
           path: tt-zephyr-platforms
 
       - name: Prepare Container

--- a/.github/workflows/hardware-smoke.yml
+++ b/.github/workflows/hardware-smoke.yml
@@ -17,7 +17,7 @@ on:
       - collab*
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 jobs:
@@ -49,7 +49,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.2.2
         with:
-          ref: ${{ github.ref }}
           path: tt-zephyr-platforms
 
       - name: Prepare Container
@@ -200,7 +199,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.2.2
         with:
-          ref: ${{ github.ref }}
           path: tt-zephyr-platforms
 
       - name: Prepare Container

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -17,7 +17,7 @@ on:
       - collab*
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 jobs:
@@ -29,7 +29,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.ref }}
       - name: Scan the code
         id: scancode
         uses: zephyrproject-rtos/action_scancode@v4

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -15,7 +15,7 @@ on:
       - v*-branch
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 jobs:
@@ -30,7 +30,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           path: tt-zephyr-platforms
-          ref: ${{ github.ref }}
       - uses: ./tt-zephyr-platforms/.github/workflows/prepare-zephyr
         with:
           app-path: tt-zephyr-platforms
@@ -75,7 +74,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           path: tt-zephyr-platforms
-          ref: ${{ github.ref }}
       - uses: ./tt-zephyr-platforms/.github/workflows/prepare-zephyr
         with:
           app-path: tt-zephyr-platforms

--- a/.github/workflows/verify-blob.yml
+++ b/.github/workflows/verify-blob.yml
@@ -13,7 +13,7 @@ on:
       - collab*
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 permissions:
@@ -29,7 +29,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{github.ref}}
           path: tt-zephyr-platforms
           fetch-depth: 0
 


### PR DESCRIPTION
The default `ref` for `actions/checkout` is

```
The branch, tag or SHA to checkout. When checking out the repository that
triggered a workflow, this defaults to the reference or SHA for that
event. Otherwise, uses the default branch.
```

We generally want our CI to use either the tag or SHA, so the default `ref` for `actions/checkout` is correct.

However, `github.ref` is incorrect, as described below.

```
The fully-formed ref of the branch or tag that triggered the workflow run.
For workflows triggered by push, this is the branch or tag ref that was
pushed. For workflows triggered by pull_request, this is the pull request
merge branch.
```

For push, we do not want the checkout to align with the branch, but the unique `sha`.

For pull requests, we do want the ref to be equal to `github.event.pull_request.number`, since subsequent force-pushes on the same branch should cancel previous jobs with the same PR number.

https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#github-context

Also, the tag `build-fw-` was copy-pasta'ed all over the place, so remove it where it is not required.

Also, for reusable workflows, `github.workflow` reflect the name of the top-level workflow being executed rather than any included reusable workflows. That means, `hardware-long` and `hardware-smoke` can also just use `github.workflow` without fear of conflicting with the `build-fw` workflow.

> The github.workflow variable provides context about the top-level workflow initiating the run.