### PR TITLE
boards: tt_blackhole: p300x: grow the dmfw partition by 4k

### DIFF
--- a/boards/tenstorrent/tt_blackhole/tt_blackhole_fixed_partitions.dtsi
+++ b/boards/tenstorrent/tt_blackhole/tt_blackhole_fixed_partitions.dtsi
@@ -78,7 +78,7 @@ partitions {
 
 	bmfw: partition@4c000 {
 		label = "bmfw";
-		reg = <0x4c000 DT_SIZE_K(64)>;
+		reg = <0x4c000 DT_SIZE_K(68)>;
 		binary-path = "$BUILD_DIR/dmc/zephyr/zephyr.signed.bin";
 		read-only;
 	};


### PR DESCRIPTION
Increase the dmfw partition size by 4k to avoid an error about it being too small.

https://github.com/tenstorrent/tt-zephyr-platforms/actions/runs/17959218440/job/51078353403