### PR TITLE
ci: build-fw: fix concurrency group name

### DIFF
--- a/.github/workflows/build-fw.yml
+++ b/.github/workflows/build-fw.yml
@@ -25,7 +25,7 @@ on:
       - collab*
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  group: ${{ github.workflow }}-build-fw-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 # TODO: read boards / board revs from a YAML file (generate a matrix)


### PR DESCRIPTION
build-fw needs a different concurrency group since other jobs depend on it. Otherwise github actions will error out with the message "a deadlock was detected for concurrency group"