### PR TITLE
doc: Update doxygen

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  DOXYGEN_VERSION: 1.9.6
+  DOXYGEN_VERSION: 1.14.0
 
 jobs:
   build:


### PR DESCRIPTION
Update doxygen to the latest version; I want this because it makes our `@group` go to `Topics` vs `Modules`