### PR TITLE
doc: Add supported boards link

### DIFF
--- a/doc/_doxygen/main.md
+++ b/doc/_doxygen/main.md
@@ -1,3 +1,9 @@
 # Introduction
 
 Welcome to the tt-zephyr-platforms API description!
+
+This docuemntation provides an description of various SMC and DMC firmware facilities and their functional interfaces.
+
+# Supported Boards
+
+The firmware documented here is compatible with our [Supported Boards](/tt-zephyr-platforms/boards/index.html).


### PR DESCRIPTION
Add a link to our supported boards in doxygen.