### PR TITLE
docs: add visualization of CI job status

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,8 +16,143 @@ env:
   DOXYGEN_VERSION: 1.14.0
 
 jobs:
+  ci-stats:
+    strategy:
+      matrix:
+        board: [p100, p100a, p150a, p300a]
+    runs-on: ubuntu-22.04
+    permissions:
+      actions: read
+    steps:
+      - name: Install dependencies
+        run: |
+           npm install adm-zip csv-parse csv-stringify
+
+           pip install plotly pandas
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          path: tt-zephyr-platforms
+
+      - name: Download Past CI runs
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const AdmZip = require('adm-zip');
+            const fs = require('fs');
+            const { parse } = require('csv-parse/sync');
+            const { stringify } = require('csv-stringify/sync');
+
+            // Aggregate results by test name and workflow run
+            const testResults = {};
+            const artifacts = await github.rest.actions.listArtifactsForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: 'Stress test results (${{ matrix.board }})',
+            });
+            console.log(`Total artifacts found: ${artifacts.data.artifacts.length}`);
+
+            for (const artifact of artifacts.data.artifacts) {
+              const download = await github.rest.actions.downloadArtifact({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                artifact_id: artifact.id,
+                archive_format: 'zip'
+              });
+
+              const fname = `${artifact.name}-${artifact.id}-${artifact.workflow_run.head_sha}.zip`;
+              fs.writeFileSync(fname, Buffer.from(download.data));
+
+              const zip = new AdmZip(fname);
+              const zipEntries = zip.getEntries();
+
+              zipEntries.forEach(function (zipEntry) {
+                if (zipEntry.name === "recording.csv") {
+                  console.log(`Processing ${zipEntry.entryName} from artifact ${artifact.name} (${artifact.id})`);
+                  const content = zipEntry.getData().toString('utf8');
+
+                  // Parse CSV content
+                  const records = parse(content, {
+                    columns: true,
+                    trim: true
+                  });
+
+                  // Process each record
+                  records.forEach(record => {
+                    const testName = record.test_name;
+                    const workflowRunId = artifact.workflow_run.id;
+
+                    if (!testResults[testName]) {
+                      testResults[testName] = {};
+                    }
+
+                    if (artifact.workflow_run.head_branch != 'main') {
+                      console.log(`Skipping artifact ${artifact.id}, branch ${artifact.workflow_run.head_branch}`);
+                      return;
+                    }
+
+                    if (!testResults[testName][workflowRunId]) {
+                      testResults[testName][workflowRunId] = {
+                        commit: artifact.workflow_run.head_sha,
+                        branch: artifact.workflow_run.head_branch,
+                        timestamp: artifact.created_at,
+                        workflow_run_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${workflowRunId}`,
+                        total_tries: 0,
+                        fail_count: 0
+                      };
+                    }
+
+                    // Aggregate total_tries and fail_count
+                    testResults[testName][workflowRunId].total_tries += parseInt(record.total_tries);
+                    testResults[testName][workflowRunId].fail_count += parseInt(record.fail_count);
+                  });
+                }
+              });
+            }
+
+            // Create CSV files for each test
+            Object.entries(testResults).forEach(([testName, workflowRuns]) => {
+              // Convert to CSV
+              const csvData = [
+                ['Fail Count', 'Total Tries', 'Failure Percentage', 'Commit', 'Branch', 'Workflow Run URL', 'Timestamp']
+              ];
+
+              // Flatten the nested object into an array
+              Object.values(workflowRuns).forEach(result => {
+                csvData.push([
+                  result.fail_count,
+                  result.total_tries,
+                  result.total_tries > 0 ? (result.fail_count / result.total_tries * 100).toFixed(2) + '%' : '0.00%',
+                  result.commit,
+                  result.branch,
+                  result.workflow_run_url,
+                  result.timestamp
+                ]);
+              });
+
+              // Write CSV file
+              const csvContent = stringify(csvData);
+              fs.writeFileSync(`${testName} results.csv`, csvContent);
+              console.log(`Created ${testName} results.csv`);
+            });
+
+      - name: Generate HTML Report
+        run: |
+          python3 tt-zephyr-platforms/scripts/ci/render_ci_table.py . ci_stats.html ${{ matrix.board }}
+
+      - name: Upload CSV Results
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-result-summaries ${{ matrix.board }}
+          path: |
+            ci_stats.html
+            *results.csv
+
   build:
     runs-on: ubuntu-22.04
+    needs: ci-stats
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -68,6 +203,19 @@ jobs:
           mv _build_doxygen/html deploy/doxygen
           mv _build_sphinx/html/* deploy
           rm -rf _build_doxygen _build_sphinx
+
+      - name: Download CI Results
+        uses: actions/download-artifact@v4
+        with:
+          path: ci-results
+          pattern: test-result-summaries*
+
+      - name: Copy CI Results
+        run: |
+          for board in p100 p100a p150a p300a; do
+            cp "ci-results/test-result-summaries ${board}/ci_stats.html" \
+              tt-zephyr-platforms/doc/deploy/${board}_ci_stats.html
+          done
 
       - name: Setup pages
         if: github.event_name != 'pull_request'

--- a/scripts/ci/render_ci_table.py
+++ b/scripts/ci/render_ci_table.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import glob
+import os
+
+import pandas as pd
+import plotly.graph_objects as go
+
+# Parse command-line arguments
+parser = argparse.ArgumentParser(
+    description="Render CSVs as a Plotly graph.", allow_abbrev=False
+)
+parser.add_argument("csv_dir", type=str, help="Directory containing CSV files")
+parser.add_argument("html_file", type=str, help="Output HTML file")
+parser.add_argument("board", type=str, help="Board name")
+args = parser.parse_args()
+
+csv_files = glob.glob(os.path.join(args.csv_dir, "*.csv"))
+
+fig = go.Figure()
+
+for csv_path in csv_files:
+    df = pd.read_csv(csv_path)
+    label = os.path.splitext(os.path.basename(csv_path))[0]
+    x = df["Timestamp"] if df["Timestamp"].notnull().any() else df.index
+    y = list(
+        map(
+            lambda v: float(v.strip("%")) if isinstance(v, str) else v,
+            df["Failure Percentage"],
+        )
+    )
+    hover_text = [
+        (
+            f"Fail Count: {fc}<br>Total Tries: {tt}<br> Failure Percentage: {pr}<br>Commit: {cm}<br>Branch: {br}<br>"
+            f"Workflow: <a href='{url}' target='_blank'>{url}</a><br>Timestamp: {ts}"
+        )
+        for fc, tt, pr, cm, br, url, ts in zip(
+            df["Fail Count"],
+            df["Total Tries"],
+            df["Failure Percentage"],
+            df["Commit"],
+            df["Branch"],
+            df["Workflow Run URL"],
+            df["Timestamp"],
+        )
+    ]
+    fig.add_trace(
+        go.Scatter(
+            x=x,
+            y=y,
+            mode="lines+markers",
+            name=label,
+            hoverinfo="text",
+            hovertext=hover_text,
+            customdata=df["Workflow Run URL"],
+            hoverlabel=dict(
+                bgcolor="lightyellow", font=dict(color="black"), bordercolor="blue"
+            ),
+        )
+    )
+
+fig.update_layout(
+    title=f"Stress Test Results ({args.board.upper()})",
+    xaxis_title="Timestamp",
+    yaxis_title="Failure Percentage",
+    yaxis=dict(range=[0, 10]),
+    height=700,
+    showlegend=True,
+)
+
+
+# Save to HTML
+fig.write_html(args.html_file)
+
+# Inject JavaScript to open link on point click
+with open(args.html_file, "r") as f:
+    html = f.read()
+
+inject_js = """<script>
+document.addEventListener('DOMContentLoaded', function() {
+    var plot = document.getElementsByClassName('plotly-graph-div')[0];
+    if (plot) {
+        plot.on('plotly_click', function(data){
+            var url = data.points[0].customdata;
+            if (url) {
+                window.open(url, '_blank');
+            }
+        });
+    }
+});
+</script>"""
+
+# Insert before </body>
+html = html.replace("</body>", inject_js + "\n</body>")
+
+with open(args.html_file, "w") as f:
+    f.write(html)
+
+print(f"HTML file generated: {args.html_file}")


### PR DESCRIPTION
Add a job to visualize the results of all CI runs against `main` for e2e-stess tests. This visualization should help track the state of long tests, so we can see when issues are introduced into the tests