### PR TITLE
ci: hardware-smoke: temporarily disable prepare-container

### DIFF
--- a/.github/workflows/hardware-smoke.yml
+++ b/.github/workflows/hardware-smoke.yml
@@ -51,10 +51,40 @@ jobs:
         with:
           path: tt-zephyr-platforms
 
-      - name: Prepare Container
-        uses: ./tt-zephyr-platforms/.github/workflows/prepare-container
-        with:
-          app-path: tt-zephyr-platforms
+      # - name: Prepare Container
+      #   uses: ./tt-zephyr-platforms/.github/workflows/prepare-container
+      #   with:
+      #     app-path: tt-zephyr-platforms
+
+      - name: Prep Container
+        shell: bash
+        run: |
+          git config --global --add safe.directory ${GITHUB_WORKSPACE}
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          rm -Rf .west
+          west init -l tt-zephyr-platforms
+          echo "ZEPHYR_BASE=$PWD/zephyr" >> $GITHUB_ENV
+          echo "ZEPHYR_SDK_INSTALL_DIR=/opt/toolchains/zephyr-sdk-0.17.2" >> $GITHUB_ENV
+          west packages pip --install
+          west blobs fetch
+          west -v patch apply
+          if ! command -v modinfo &> /dev/null ; then
+            apt-get update
+            apt-get install -y kmod
+          fi
+          echo "Zephyr SDK: $ZEPHYR_SDK_INSTALL_DIR"
+          echo "Python: $( which python3 ) $( python3 --version )"
+          echo "Pip: $( which pip3 ) $( pip3 --version )"
+          echo "West: $( which west ) $( west --version )"
+          echo "CMake: $( which cmake ) $( cmake --version | head -n 1 )"
+          echo "Ninja: $( which ninja ) $( ninja --version )"
+          echo "Rustc: $( which rustc ) $( rustc --version )"
+          echo "Cargo: $( which cargo ) $( cargo --version )"
+          echo "PIP packages:"
+          pip3 freeze
+          echo "tt-kmd version:"
+          modinfo tenstorrent
 
       - name: Generate board names
         shell: bash


### PR DESCRIPTION
Temporarily disable the `prepare-container.yml` workflow, since it unfortunately does not work at all now.