### PR TITLE
fw_table: enable aiclk ppm for Galaxy

### DIFF
--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/GALAXY/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/GALAXY/fw_table.txt
@@ -7,10 +7,10 @@ chip_limits {
   vdd_max: 900
   vdd_min: 700
   voltage_margin: 50
-  tdp_limit: 150
-  tdc_limit: 200
+  tdp_limit: 170
+  tdc_limit: 500
   thm_limit: 90
-  tdc_fast_limit: 220
+  tdc_fast_limit: 400
   therm_trip_l1_limit: 0
   bus_peak_limit: 0
   frequency_margin: 0
@@ -21,7 +21,7 @@ feature_enable {
   cg_en: true
   noc_translation_en: true
   ddr_train_en: true
-  aiclk_ppm_en: false
+  aiclk_ppm_en: true
   watchdog_en: false
   smbus_en: false
   fan_ctrl_en: false


### PR DESCRIPTION
Enable AICLK PPM on Galaxy, setting the following limits:
- TDP = 170 W
- Fast TDC = 400 A
- TDC = 500 A (effectively disabled)