### PR TITLE
fw_table: make p300 tdp more conservative

### DIFF
--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300A_L/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300A_L/fw_table.txt
@@ -7,7 +7,7 @@ chip_limits {
   vdd_max: 900
   vdd_min: 700
   voltage_margin: 50
-  tdp_limit: 500
+  tdp_limit: 86
   tdc_limit: 500
   thm_limit: 90
   tdc_fast_limit: 320

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300A_R/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300A_R/fw_table.txt
@@ -7,7 +7,7 @@ chip_limits {
   vdd_max: 900
   vdd_min: 700
   voltage_margin: 50
-  tdp_limit: 500
+  tdp_limit: 86
   tdc_limit: 500
   thm_limit: 90
   tdc_fast_limit: 320

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300B_L/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300B_L/fw_table.txt
@@ -7,7 +7,7 @@ chip_limits {
   vdd_max: 900
   vdd_min: 700
   voltage_margin: 50
-  tdp_limit: 500
+  tdp_limit: 94
   tdc_limit: 500
   thm_limit: 90
   tdc_fast_limit: 320

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300B_R/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300B_R/fw_table.txt
@@ -7,7 +7,7 @@ chip_limits {
   vdd_max: 900
   vdd_min: 700
   voltage_margin: 50
-  tdp_limit: 500
+  tdp_limit: 94
   tdc_limit: 500
   thm_limit: 90
   tdc_fast_limit: 320

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300C_L/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300C_L/fw_table.txt
@@ -7,7 +7,7 @@ chip_limits {
   vdd_max: 900
   vdd_min: 700
   voltage_margin: 50
-  tdp_limit: 500
+  tdp_limit: 158
   tdc_limit: 500
   thm_limit: 90
   tdc_fast_limit: 320

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300C_R/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300C_R/fw_table.txt
@@ -7,7 +7,7 @@ chip_limits {
   vdd_max: 900
   vdd_min: 700
   voltage_margin: 50
-  tdp_limit: 500
+  tdp_limit: 158
   tdc_limit: 500
   thm_limit: 90
   tdc_fast_limit: 320


### PR DESCRIPTION
On request from PCB power team, make p300 TDP limits more conservative, preventing each side from taking more than 50% of the total board power.

Numbers from [SYS-2123](https://tenstorrent.atlassian.net/browse/SYS-2123)