### PR TITLE
regulators: fix galaxy serdes programming regression

### DIFF
--- a/lib/tenstorrent/bh_arc/regulator_config.c
+++ b/lib/tenstorrent/bh_arc/regulator_config.c
@@ -388,6 +388,21 @@ static const RegulatorConfig ubb_config[] = {
 		.regulator_data = ubb_gddrio_data,
 		.count = ARRAY_SIZE(ubb_gddrio_data),
 	},
+	{
+		.address = SERDES_VDDL_ADDR,
+		.regulator_data = serdes_vr_data,
+		.count = ARRAY_SIZE(serdes_vr_data),
+	},
+	{
+		.address = SERDES_VDD_ADDR,
+		.regulator_data = serdes_vr_data,
+		.count = ARRAY_SIZE(serdes_vr_data),
+	},
+	{
+		.address = SERDES_VDDH_ADDR,
+		.regulator_data = serdes_vr_data,
+		.count = ARRAY_SIZE(serdes_vr_data),
+	},
 };
 
 const BoardRegulatorsConfig ubb_regulators_config = {


### PR DESCRIPTION
The SERDES VR register programming on Galaxy was accidentally removed during the refactoring in #461. Add it back in.