### PR TITLE
boards: tenstorrent: reduce p300 I2C clock speeds

### DIFF
--- a/boards/tenstorrent/tt_blackhole/tt_blackhole_tt_blackhole_dmc_p300a.overlay
+++ b/boards/tenstorrent/tt_blackhole/tt_blackhole_tt_blackhole_dmc_p300a.overlay
@@ -133,6 +133,15 @@
 	};
 };
 
+/* Reduce I2C speed to 100kHz */
+&i2c1 {
+	clock-frequency = <I2C_BITRATE_STANDARD>;
+};
+
+&i2c3 {
+	clock-frequency = <I2C_BITRATE_STANDARD>;
+};
+
 /*
  * Chip 1
  * sck: PA6


### PR DESCRIPTION
Reduce P300 I2C clock speeds to 100KHz. This resolves periodic SMBUS errors logged by the STM32, at the cost of some I2C performance