### PR TITLE
drivers: smbus: stm32: add rate-limited logging of PEC errors

### DIFF
--- a/lib/tenstorrent/bh_chip/bh_chip.c
+++ b/lib/tenstorrent/bh_chip/bh_chip.c
@@ -52,17 +52,6 @@ cm2dmMessageRet bh_chip_get_cm2dm_message(struct bh_chip *chip)
 							     wire_ack.val);
 	}
 
-	if (output.ret != 0 || (output.msg.msg_id != kCm2DmMsgIdNull && output.ack_ret != 0)) {
-		static k_timepoint_t message_ratelimit;
-
-		if (sys_timepoint_expired(message_ratelimit)) {
-			message_ratelimit = sys_timepoint_calc(K_SECONDS(1));
-
-			LOG_WRN("CM2DM SMBus communication failed. req: %d ack: %d", output.ret,
-				output.ack_ret);
-		}
-	}
-
 	return output;
 }
 

--- a/zephyr/patches.yml
+++ b/zephyr/patches.yml
@@ -102,7 +102,7 @@ patches:
     upstreamable: true
     merge-pr: https://github.com/zephyrproject-rtos/zephyr/pull/89501
   - path: zephyr/smbus_stm32-pec.patch
-    sha256sum: 6f3990f30437ff992cf2e52da656d1690180dcae15dfa4e7dbace02d28a4b852
+    sha256sum: 109616eaa2460b32e82417152f2e54a8c9a7a44c1cb54d488b942f9d38a8715c
     module: zephyr
     author: Andrew Lewycky
     email: alewycky@tenstorrent.com

--- a/zephyr/patches/zephyr/smbus_stm32-pec.patch
+++ b/zephyr/patches/zephyr/smbus_stm32-pec.patch
@@ -35,7 +35,7 @@ index c421c1c4504..04c0b08b02e 100644
  	if (config_value & SMBUS_MODE_HOST_NOTIFY) {
  		LOG_ERR("%s: not available", dev->name);
  		return -EINVAL;
-@@ -134,6 +129,87 @@ static int smbus_stm32_get_config(const struct device *dev, uint32_t *config)
+@@ -134,6 +129,102 @@ static int smbus_stm32_get_config(const struct device *dev, uint32_t *config)
  	return 0;
  }
  
@@ -117,7 +117,22 @@ index c421c1c4504..04c0b08b02e 100644
 +	uint8_t reported_pec = messages[num_msgs - 1].buf[0];
 +	uint8_t computed_pec = compute_pec(periph_addr, messages, num_msgs - 1);
 +
-+	return (reported_pec == computed_pec) ? 0 : -EIO;
++	struct pec_stats {
++		uint32_t total;
++		uint32_t errors;
++	};
++
++	static struct pec_stats stats;
++
++	stats.total++;
++	if (reported_pec != computed_pec) {
++		stats.errors++;
++		LOG_ERR_RATELIMIT_RATE(1000, "%s: PEC error. expected: %02x actual: %02x total: %u errors: %u",
++				       dev->name, reported_pec, computed_pec, stats.total, stats.errors);
++		return -EIO;
++	}
++
++	return 0;
 +}
 +
  static int smbus_stm32_quick(const struct device *dev, uint16_t periph_addr,


### PR DESCRIPTION
Add rate-limited logging of PEC errors maximally once per second. This should help to diagnose link quality issues.

Log output:
```shell
[00:00:01.517,000] <err> stm32_smbus: smbus3: PEC error. expected: ff actual: 9c total: 41 errors: 1
[00:00:09.197,000] <err> stm32_smbus: smbus3: PEC error. expected: ff actual: 9c total: 464 errors: 2
[00:00:17.377,000] <err> stm32_smbus: smbus3: PEC error. expected: ff actual: 9c total: 913 errors: 3
[00:00:20.617,000] <err> stm32_smbus: smbus3: PEC error. expected: ff actual: 9c total: 1091 errors: 4
[00:00:23.657,000] <err> stm32_smbus: smbus3: PEC error. expected: ff actual: 9c total: 1258 errors: 5
[00:00:25.957,000] <err> stm32_smbus: smbus3: PEC error. expected: ff actual: 9c total: 1384 errors: 6
```