### PR TITLE
ci: bump docker images in use to latest released version

### DIFF
--- a/.github/workflows/hardware-long.yml
+++ b/.github/workflows/hardware-long.yml
@@ -31,7 +31,7 @@ jobs:
               - p300a-jtag
     runs-on: ${{ matrix.config.runs-on }}
     container:
-      image: ghcr.io/danieldegrasse/tt-zephyr-platforms/ci-image:v18.8.0
+      image: ghcr.io/tenstorrent/tt-zephyr-platforms/ci-image:v18.12.0-rc1
       volumes:
         - /dev/hugepages-1G:/dev/hugepages-1G
         - /lib/modules:/lib/modules

--- a/.github/workflows/hardware-smoke.yml
+++ b/.github/workflows/hardware-smoke.yml
@@ -37,7 +37,7 @@ jobs:
               - p300a-jtag
     runs-on: ${{ matrix.config.runs-on }}
     container:
-      image: ghcr.io/danieldegrasse/tt-zephyr-platforms/ci-image:v18.8.0
+      image: ghcr.io/tenstorrent/tt-zephyr-platforms/ci-image:v18.12.0-rc1
       volumes:
         - /dev/hugepages-1G:/dev/hugepages-1G
         - /lib/modules:/lib/modules
@@ -192,7 +192,7 @@ jobs:
               - p300a-jtag
     runs-on: ${{ matrix.config.runs-on }}
     container:
-      image: ghcr.io/danieldegrasse/tt-zephyr-platforms/ci-image:v18.8.0
+      image: ghcr.io/tenstorrent/tt-zephyr-platforms/ci-image:v18.12.0-rc1
       volumes:
         - /dev/hugepages-1G:/dev/hugepages-1G
         - /lib/modules:/lib/modules

--- a/scripts/tooling/blackhole_recovery/recover-blackhole.sh
+++ b/scripts/tooling/blackhole_recovery/recover-blackhole.sh
@@ -4,8 +4,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-IMAGE_URL="ghcr.io/danieldegrasse/tt-zephyr-platforms/recovery-image"
-IMAGE_TAG="v0.0.1"
+IMAGE_URL="ghcr.io/tenstorrent/tt-zephyr-platforms/recovery-image"
+IMAGE_TAG="v18.12.0-rc1"
 
 # This script will download and run the blackhole recovery tool inside a
 # Docker container. Note that a recovery bundle can also be


### PR DESCRIPTION
Bump docker images to latest released version for CI, and use tenstorrent hosted images instead of ones hosted by @danieldegrasse's github account