### PR TITLE
ci: fix e2e-stress invocation

### DIFF
--- a/.github/workflows/hardware-long.yml
+++ b/.github/workflows/hardware-long.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: run-e2e-stress-test
         run: |
-          tt-zephyr-platforms/scripts/ci/run-stress.sh -p $ASIC_ID ${{ matrix.config.board }}
+          tt-zephyr-platforms/scripts/ci/run-stress.sh ${{ matrix.config.board }}
 
       - name: Upload Stress Test results
         if: ${{ always() }}


### PR DESCRIPTION
Fix e2e-stress script invocation so that tests will actually run

Signed-off-by: Daniel DeGrasse <ddegrasse@tenstorrent.com>