### PR TITLE
scripts: dmc_reset + pcie_utils: reduce verbosity

### DIFF
--- a/scripts/pcie_utils.py
+++ b/scripts/pcie_utils.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
 
+import logging
 import os
 import subprocess
 import time
@@ -8,6 +9,8 @@ import time
 from pathlib import Path
 
 TT_PCIE_VID = "0x1e52"
+
+logger = logging.getLogger(Path(__file__).stem)
 
 
 def find_tt_devs():
@@ -31,7 +34,6 @@ def rescan_pcie():
     # First, we must find the PCIe card to power it off
     devs = find_tt_devs()
     for dev in devs:
-        print(f"Powering off device at {dev}")
         remove_path = Path(dev) / "remove"
         try:
             with open(remove_path, "w") as f:
@@ -42,7 +44,7 @@ def rescan_pcie():
                     f"echo 1 | sudo tee {remove_path} > /dev/null", shell=True
                 )
             except Exception as e:
-                print("Error, this script must be run with elevated permissions")
+                logger.error("this script must be run with elevated permissions")
                 raise e
 
     # Now, rescan the bus
@@ -56,5 +58,5 @@ def rescan_pcie():
             subprocess.call(f"echo 1 | sudo tee {rescan_path} > /dev/null", shell=True)
             time.sleep(1)
         except Exception as e:
-            print("Error, this script must be run with elevated permissions")
+            logger.error("this script must be run with elevated permissions")
             raise e


### PR DESCRIPTION
Currently, the dirty reset test logs about 6000 messages for its 1000 test iterations, and probably close to 5500 of those messages do not serve a useful purpose.

It's better to log errors with useful information than to log the same information over and over again for what is just expected behaviour.

This should make it easier to comb through CI logs to determine the root cause of a failure.

Example output prior to this change.
https://github.com/tenstorrent/tt-zephyr-platforms/actions/runs/18225967418/job/51897212403?pr=694

Example output after this change:
```shell
INFO: Dirty reset test iteration 0/1000
INFO: Dirty reset test iteration 10/1000
```