### PR TITLE
zephyr: patches: add upstream url for smbus pcall pr

### DIFF
--- a/zephyr/patches.yml
+++ b/zephyr/patches.yml
@@ -127,6 +127,8 @@ patches:
     author: James Growden
     email: jgrowden@tenstorrent.com
     date: 2025-09-18
+    upstreamable: true
+    merge-pr: https://github.com/zephyrproject-rtos/zephyr/pull/97188
     comments: |
       Add support for BWBR smbus32 pcalls
   - path: zephyr/jedec-spi-nor-erase-block-size.patch


### PR DESCRIPTION
Add a url for the upstream smbus pcall pull request.