### PR TITLE
zephyr: patches: check-compliance: kconfig: exclude default pwm port

### DIFF
--- a/zephyr/patches.yml
+++ b/zephyr/patches.yml
@@ -8,7 +8,7 @@ patches:
     comments: |
       Support multilevel interrupt priority on ARC cores.
   - path: zephyr/check-compliance.patch
-    sha256sum: 6dba8fade73d86b8d07e73599b326f89355d0d6806a1bef55508d631d505e0c3
+    sha256sum: dc78ea04be55acc74544e9cb4426413e0545cb581994653d1283852f7754eb08
     module: zephyr
     author: Chris Friedt
     email: cfriedt@tenstorrent.com

--- a/zephyr/patches/zephyr/check-compliance.patch
+++ b/zephyr/patches/zephyr/check-compliance.patch
@@ -20,9 +20,10 @@ index 13a2b4839e9..99aeda03600 100755
  
          if len(tmp_output) > 0:
              kconfigs += tmp_output + "\n"
-@@ -1255,6 +1255,7 @@ flagged.
+@@ -1255,6 +1255,8 @@ flagged.
          "CRC",  # Used in TI CC13x2 / CC26x2 SDK comment
          "DEEP_SLEEP",  # #defined by RV32M1 in ext/
++        "DEFAULT_PWM_PORT",
          "DESCRIPTION",
 +        "DMC_RUN_SMBUS_TESTS",
          "ERR",
@@ -36,14 +37,6 @@ index 13a2b4839e9..99aeda03600 100755
          "IPC_SERVICE_ICMSG_BOND_NOTIFY_REPEAT_TO_MS", # Used in ICMsg tests for intercompatibility
                                                        # with older versions of the ICMsg.
          "LIBGCC_RTLIB",
-@@ -1322,6 +1324,7 @@ flagged.
-         "SHIFT",
-         "SINGLE_APPLICATION_SLOT", # Used in sysbuild for MCUboot configuration
-         "SINGLE_APPLICATION_SLOT_RAM_LOAD", # Used in sysbuild for MCUboot configuration
-+        "SKIP_ZERO_DUTY_CYCLE_TEST",
-         "SOC_SDKNG_UNSUPPORTED", # Used in modules/hal_nxp/mcux/CMakeLists.txt
-         "SOC_SERIES_", # Used as regex in scripts/utils/board_v1_to_v2.py
-         "SOC_WATCH",  # Issue 13749
 @@ -1412,6 +1415,7 @@ class SysbuildKconfigCheck(KconfigCheck):
      # A different allowlist is used for symbols prefixed with SB_CONFIG_ (omitted here).
      UNDEF_KCONFIG_ALLOWLIST = {


### PR DESCRIPTION
The compliance workflow was failing due to Zephyr's KconfigCheck test not being able to pick up Kconfig options defined in upstream tests and samples.

```shell
ERROR   : Test Kconfig failed:
...
CONFIG_DEFAULT_PWM_PORT \
 test-conf/tests/drivers/pwm/pwm_api/boards/\
 tt_blackhole_tt_blackhole_dmc.conf:21
```

The long-term solution for this is to parse `Kconfig*` files that exist in testsuites and samples in the `check_compliance.py` script upstream.

Also removed the `SKIP_ZERO_DUTY_CYCLE_TEST` exception, since that does not exist any longer.