### PR TITLE
boards: tt_blackhole: p300: configure gpiof 7 and 8 as hogs

### DIFF
--- a/boards/tenstorrent/tt_blackhole/tt_blackhole_tt_blackhole_dmc_p300a.overlay
+++ b/boards/tenstorrent/tt_blackhole/tt_blackhole_tt_blackhole_dmc_p300a.overlay
@@ -189,6 +189,20 @@
 	};
 };
 
+&gpiof {
+	i2c0-bus-switch-enable {
+		gpio-hog;
+		gpios = <8 GPIO_ACTIVE_LOW>;
+		output-low;
+	};
+
+	i2c1-bus-switch-enable {
+		gpio-hog;
+		gpios = <7 GPIO_ACTIVE_LOW>;
+		output-low;
+	};
+};
+
 /*
  * Chip 0
  * nss: PA4 CS (spi1_nss_pa4)


### PR DESCRIPTION
Configure gpio port f, pins 7 and 8 as GPIO hogs. This means, that they are configured earlier than virtually all other peripherals.

Strapping GPIO for Blackhole are attached to I2C GPIO expanders on both i2c1 and i2c3. The GPIO expanders themselves are behind i2c bus switches which may or may not be enabled before we attempt to use the I2C GPIO expanders.

Clearly, we do want to enable the bus switches when we attempt to communicate with the GPIO port expanders, which happens in the init function for the drivers for the port expanders (pcaxx series, iirc).

The lines themselves are called MCU_I2C0_SW_EN (port f, pin 8) and MCU_I2C1_SW_EN (port f, pin 7).