### PR TITLE
manifest: update zephyr version to fix stm32 include

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -17,7 +17,7 @@ manifest:
     - name: zephyr
       remote: zephyrproject-rtos
       # a stable-ish commit before v4.3.0-rc1
-      revision: b4d5cd3c474652478c6b0e55819dcf012afe7d13
+      revision: 66998ef445e318b13aa05e05c7e53fa90bed21c7
       import:
         name-allowlist:
           - cmsis_6


### PR DESCRIPTION
STM32 module moved their directories around, which causes our west blobs fetch to fail on a bad link.

Update zephyr to the version that fixes the issue.