### PR TITLE
doc: Add documentation for telemetry

### DIFF
--- a/doc/services/index.rst
+++ b/doc/services/index.rst
@@ -7,3 +7,4 @@ Firmware Services
    :maxdepth: 1
 
    tracing/index.rst
+   telemetry/index.rst

--- a/doc/services/telemetry/index.rst
+++ b/doc/services/telemetry/index.rst
@@ -1,0 +1,76 @@
+Telemetry
+=========
+
+In Chip Management Firmware, telemetry gathering and reporting is done in the file `telemetry.c </tt-zephyr-platforms/doxygen/telemetry_8c.html>`_. This telemetry is located within the ``tensix_sm`` (ARC) memory space (i.e., within ``NOC0 8-0``):
+
+See `telemetry table </tt-zephyr-platforms/doxygen/group__telemetry__table.html>`_ for information.
+
+Scratch Registers
+-----------------
+
+As per:
+
+``Scratch Registers | arc_ss.reset_unit.SCRATCH_RAM[0..63]``:
+
+- Address of ``telemetry_data`` is stored in ``reset_unit.SCRATCH_RAM[12]`` (WH: ARC_RESET.NOC_NODEID_Y_0)
+- Address of ``telemetry_table`` is stored in ``reset_unit.SCRATCH_RAM[13]`` (WH: ARC_RESET.NOC_NODEID_X_0)
+
+
+
+The telemetry table is updated every 100ms by a Zephyr worker thread.
+
+Procedure to Read Telemetry
+---------------------------
+
+Via MMIO Access to ARC Memory
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+(Generally, when you are connected to BH over PCIe)
+
+1. Find ``telemetry_table`` by reading ```reset_unit.SCRATCH_RAM[13]``.
+2. Check ``telemetry_table.entry_count`` to find out how many ``tag_table`` entries there are.
+3. Read through all ``tag_table`` entries and keep the tag-offset mapping around. These will not change unless the firmware gets updated and the chip is reset.
+4. To find specific telemetry entries:
+   - Look up the offset in the tag-offset mapping.
+   - Read 4 bytes starting from ``SCRATCH_RAM[12] + 4 * offset``.
+
+Via SMBUS
+~~~~~~~~~
+
+(i.e., from DMC or Galaxy UBB CPLD)
+
+1. Write the tag ID you wish to read to SMBUS address ``0x26``. This register is 8 bits wide—the SMBUS write should include a PEC.
+2. The tag ID is persistent, so it can be programmed once, and the telemetry data can be read multiple times from address ``0x27``.
+3. Read the telemetry tag data via SMBUS by issuing a block read to address ``0x27``. This register is 32 bits wide.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 20 60
+
+   * - Register
+     - Address
+     - Usage
+   * - TELEMETRY_TAG
+     - 0x26
+     - Write only. Write with telemetry tag value to select which telemetry field will be read when reading from TELEMETRY_DATA register.
+   * - TELEMETRY_DATA
+     - 0x27
+     - Read only. Read to get the latest telemetry data for the tag programmed to the TELEMETRY_TAG register.
+
+Via west attach
+~~~~~~~~~~~~~~~
+
+You can print ``telemetry_table.telemetry[<TAG>]`` in gdb.
+
+.. code-block:: shell
+
+   west attach
+   (gdb) print telemetry_table.telemetry[7]
+   $6 = 47
+
+Tag IDs
+-------
+
+Tag IDs are permanent in the sense that they’ll never change meaning, but may not be present.
+
+See `telemetry group </tt-zephyr-platforms/doxygen//group__telemetry__tags.html>`_ for more details.

--- a/lib/tenstorrent/bh_arc/status_reg.h
+++ b/lib/tenstorrent/bh_arc/status_reg.h
@@ -32,7 +32,21 @@
 #define STATUS_MSG_Q_ERR_FLAGS_REG_ADDR      RESET_UNIT_SCRATCH_RAM_REG_ADDR(9)
 #define SPI_BUFFER_INFO_REG_ADDR             RESET_UNIT_SCRATCH_RAM_REG_ADDR(10)
 #define STATUS_MSG_Q_INFO_REG_ADDR           RESET_UNIT_SCRATCH_RAM_REG_ADDR(11)
+/**
+ * @ingroup telemetry
+ * @brief Register address pointing to the telemetry data buffer.
+ *
+ * This register holds the address of the telemetry data buffer, which contains
+ * dynamically updated telemetry values.
+ */
 #define TELEMETRY_DATA_REG_ADDR              RESET_UNIT_SCRATCH_RAM_REG_ADDR(12)
+/**
+ * @ingroup telemetry
+ * @brief Register address pointing to the telemetry table.
+ *
+ * This register holds the address of the global telemetry table, which contains
+ * metadata and telemetry data.
+ */
 #define TELEMETRY_TABLE_REG_ADDR             RESET_UNIT_SCRATCH_RAM_REG_ADDR(13)
 #define PCIE_INIT_CPL_TIME_REG_ADDR          RESET_UNIT_SCRATCH_RAM_REG_ADDR(14)
 #define CMFW_START_TIME_REG_ADDR             RESET_UNIT_SCRATCH_RAM_REG_ADDR(15)

--- a/lib/tenstorrent/bh_arc/telemetry.c
+++ b/lib/tenstorrent/bh_arc/telemetry.c
@@ -38,19 +38,68 @@ static const struct device *const pll_dev_0 = DEVICE_DT_GET_OR_NULL(DT_NODELABEL
 static const struct device *const pll_dev_1 = DEVICE_DT_GET_OR_NULL(DT_NODELABEL(pll1));
 static const struct device *const pll_dev_4 = DEVICE_DT_GET_OR_NULL(DT_NODELABEL(pll4));
 
+/**
+ * @defgroup telemetry_table Telemetry Table
+ * @ingroup telemetry
+ * @brief Telemetry data structures and functions.
+ * @{
+ */
+
+/**
+ * @brief Represents an entry in the telemetry table.
+ */
 struct telemetry_entry {
+	/**
+	 * @brief The tag identifier for the telemetry entry.
+	 */
 	uint16_t tag;
+
+	/**
+	 * @brief The offset of the telemetry data in the table.
+	 */
 	uint16_t offset;
 };
 
+/**
+ * @brief Represents the telemetry table containing telemetry data and metadata.
+ */
 struct telemetry_table {
+	/**
+	 * @brief The version of the telemetry table.
+	 */
 	uint32_t version;
+
+	/**
+	 * @brief The number of entries in the telemetry table.
+	 */
 	uint32_t entry_count;
+
+	/**
+	 * @brief The table mapping telemetry tags to their offsets.
+	 */
 	struct telemetry_entry tag_table[TAG_COUNT];
+
+	/**
+	 * @brief The telemetry data corresponding to the tags.
+	 */
 	uint32_t telemetry[TAG_COUNT];
 };
 
 /* Global variables */
+
+/**
+ * @brief Documentation for telemetry table variables.
+ *
+ * This page contains detailed documentation for the telemetry table and its associated buffer.
+ */
+
+/**
+ * @brief Global telemetry table containing metadata and telemetry data.
+ *
+ * This table is used to store telemetry information, including tag mappings and data values.
+ * The address of this table is published in the @ref TELEMETRY_TABLE_REG_ADDR register.
+ */
+
 /* clang-format off */
 static struct telemetry_table telemetry_table = {
 	.tag_table = {
@@ -114,8 +163,16 @@ static struct telemetry_table telemetry_table = {
 		[58] = {TAG_THM_LIMIT_THROTTLE, TELEM_OFFSET(TAG_THM_LIMIT_THROTTLE)},
 	},
 };
-/* clang-format on */
+
+/**
+ * @brief Pointer to the telemetry data buffer.
+ *
+ * This buffer contains dynamically updated telemetry values. The address of this buffer
+ * is published in the @ref TELEMETRY_DATA_REG_ADDR register.
+ */
 static uint32_t *telemetry = &telemetry_table.telemetry[0];
+
+/** @} */ /* end of telemetry_table group */
 
 static struct k_timer telem_update_timer;
 static struct k_work telem_update_worker;

--- a/lib/tenstorrent/bh_arc/telemetry.h
+++ b/lib/tenstorrent/bh_arc/telemetry.h
@@ -9,81 +9,227 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-#define TELEMETRY_VERSION 0x00000100 /* v0.1.0 - Only update when redefining the
-				      * meaning of an existing tag
-				      * Semver format: 0 x 00 Major Minor Patch
-				      */
+/**
+ * @defgroup telemetry Telemetry
+ * @brief Telemetry definitions and functions
+ *
+ * @ref telemetry_tags "Telemetry Tags" describes the various telemetry indices the SMC firmawre
+ * currently supports. @ref telemetry_table "Telemetry Table" provides telemetry tracking
+ * infrastructure related information.
+ *
+ */
 
-/* Tags - these will be guaranteed and will not change */
-#define TAG_BOARD_ID_HIGH        1
-#define TAG_BOARD_ID_LOW         2
-#define TAG_ASIC_ID              3
-#define TAG_HARVESTING_STATE     4
-#define TAG_UPDATE_TELEM_SPEED   5
-#define TAG_VCORE                6
-#define TAG_TDP                  7
-#define TAG_TDC                  8
-#define TAG_VDD_LIMITS           9
-#define TAG_THM_LIMIT_SHUTDOWN   10
-#define TAG_ASIC_TEMPERATURE     11
-#define TAG_VREG_TEMPERATURE     12
-#define TAG_BOARD_TEMPERATURE    13
-#define TAG_AICLK                14
-#define TAG_AXICLK               15
-#define TAG_ARCCLK               16
-#define TAG_L2CPUCLK0            17
-#define TAG_L2CPUCLK1            18
-#define TAG_L2CPUCLK2            19
-#define TAG_L2CPUCLK3            20
-#define TAG_ETH_LIVE_STATUS      21
-#define TAG_GDDR_STATUS          22
-#define TAG_GDDR_SPEED           23
-#define TAG_ETH_FW_VERSION       24
-#define TAG_GDDR_FW_VERSION      25
-#define TAG_DM_APP_FW_VERSION    26
-#define TAG_DM_BL_FW_VERSION     27
+/** @brief  The current version of the tenstorrent telemetry interface
+ * v0.1.0 - Only update when redefining the meaning of an existing tag
+ * Semver format: 0 x 00 Major Minor Patch
+ */
+#define TELEMETRY_VERSION 0x00000100
+
+/**
+ * @defgroup telemetry_tags Telemetry Tags
+ * @ingroup telemetry
+ * @brief Telemetry tag definitions
+ * @{
+ */
+
+/** @brief High part of the board ID. */
+#define TAG_BOARD_ID_HIGH 1
+
+/** @brief Low part of the board ID. */
+#define TAG_BOARD_ID_LOW 2
+
+/** @brief ASIC ID. */
+#define TAG_ASIC_ID 3
+
+/** @brief Harvesting state of the system. */
+#define TAG_HARVESTING_STATE 4
+
+/** @brief Update interval for telemetry in milliseconds. */
+#define TAG_UPDATE_TELEM_SPEED 5
+
+/** @brief VCore voltage in millivolts. */
+#define TAG_VCORE 6
+
+/** @brief Thermal design power (TDP) in watts. */
+#define TAG_TDP 7
+
+/** @brief Thermal design current (TDC) in amperes. */
+#define TAG_TDC 8
+
+/** @brief VDD limits (min and max) in millivolts. */
+#define TAG_VDD_LIMITS 9
+
+/** @brief Thermal shutdown limit in degrees Celsius. */
+#define TAG_THM_LIMIT_SHUTDOWN 10
+
+/** @brief ASIC temperature in signed 16.16 fixed-point format. */
+#define TAG_ASIC_TEMPERATURE 11
+
+/** @brief Voltage regulator temperature in degrees Celsius. (Not implemented) */
+#define TAG_VREG_TEMPERATURE 12
+
+/** @brief Board temperature in degrees Celsius. (Not implemented) */
+#define TAG_BOARD_TEMPERATURE 13
+
+/** @brief AI clock frequency in megahertz. */
+#define TAG_AICLK 14
+
+/** @brief AXI clock frequency in megahertz. */
+#define TAG_AXICLK 15
+
+/** @brief ARC clock frequency in megahertz. */
+#define TAG_ARCCLK 16
+
+/** @brief L2CPU clock 0 frequency in megahertz. */
+#define TAG_L2CPUCLK0 17
+
+/** @brief L2CPU clock 1 frequency in megahertz. */
+#define TAG_L2CPUCLK1 18
+
+/** @brief L2CPU clock 2 frequency in megahertz. */
+#define TAG_L2CPUCLK2 19
+
+/** @brief L2CPU clock 3 frequency in megahertz. */
+#define TAG_L2CPUCLK3 20
+
+/** @brief Ethernet live status. */
+#define TAG_ETH_LIVE_STATUS 21
+
+/** @brief GDDR status. */
+#define TAG_GDDR_STATUS 22
+
+/** @brief GDDR speed in megabits per second. */
+#define TAG_GDDR_SPEED 23
+
+/** @brief Ethernet firmware version. */
+#define TAG_ETH_FW_VERSION 24
+
+/** @brief GDDR firmware version. */
+#define TAG_GDDR_FW_VERSION 25
+
+/** @brief DM application firmware version. */
+#define TAG_DM_APP_FW_VERSION 26
+
+/** @brief DM bootloader firmware version. */
+#define TAG_DM_BL_FW_VERSION 27
+
+/** @brief Flash bundle version. */
 #define TAG_FLASH_BUNDLE_VERSION 28
-#define TAG_CM_FW_VERSION        29
-#define TAG_L2CPU_FW_VERSION     30
-#define TAG_FAN_SPEED            31
-#define TAG_TIMER_HEARTBEAT      32
-#define TAG_TELEM_ENUM_COUNT     33
-#define TAG_ENABLED_TENSIX_COL   34
-#define TAG_ENABLED_ETH          35
-#define TAG_ENABLED_GDDR         36
-#define TAG_ENABLED_L2CPU        37
-#define TAG_PCIE_USAGE           38
-#define TAG_INPUT_CURRENT        39
-#define TAG_NOC_TRANSLATION      40
-#define TAG_FAN_RPM              41
-#define TAG_GDDR_0_1_TEMP        42
-#define TAG_GDDR_2_3_TEMP        43
-#define TAG_GDDR_4_5_TEMP        44
-#define TAG_GDDR_6_7_TEMP        45
-#define TAG_GDDR_0_1_CORR_ERRS   46
-#define TAG_GDDR_2_3_CORR_ERRS   47
-#define TAG_GDDR_4_5_CORR_ERRS   48
-#define TAG_GDDR_6_7_CORR_ERRS   49
-#define TAG_GDDR_UNCORR_ERRS     50
-#define TAG_MAX_GDDR_TEMP        51
-#define TAG_ASIC_LOCATION        52
-#define TAG_BOARD_POWER_LIMIT    53
-#define TAG_INPUT_POWER          54
-#define TAG_TDC_LIMIT_MAX        55
-#define TAG_THM_LIMIT_THROTTLE   56
-#define TAG_FW_BUILD_DATE        57
-#define TAG_TT_FLASH_VERSION     58
-#define TAG_ENABLED_TENSIX_ROW   59
-#define TAG_THERM_TRIP_COUNT     60
-#define TAG_ASIC_ID_HIGH         61
-#define TAG_ASIC_ID_LOW          62
-#define TAG_AICLK_LIMIT_MAX      63
-#define TAG_TDP_LIMIT_MAX        64
+
+/** @brief CM firmware version. */
+#define TAG_CM_FW_VERSION 29
+
+/** @brief L2CPU firmware version. */
+#define TAG_L2CPU_FW_VERSION 30
+
+/** @brief Fan speed as a percentage. */
+#define TAG_FAN_SPEED 31
+
+/** @brief Timer heartbeat counter. */
+#define TAG_TIMER_HEARTBEAT 32
+
+/** @brief Total number of telemetry tags. */
+#define TAG_TELEM_ENUM_COUNT 33
+
+/** @brief Enabled Tensix columns. */
+#define TAG_ENABLED_TENSIX_COL 34
+
+/** @brief Enabled Ethernet interfaces. */
+#define TAG_ENABLED_ETH 35
+
+/** @brief Enabled GDDR interfaces. */
+#define TAG_ENABLED_GDDR 36
+
+/** @brief Enabled L2CPU cores. */
+#define TAG_ENABLED_L2CPU 37
+
+/** @brief PCIe usage information. */
+#define TAG_PCIE_USAGE 38
+
+/** @brief Input current in amperes. */
+#define TAG_INPUT_CURRENT 39
+
+/** @brief NOC translation status. */
+#define TAG_NOC_TRANSLATION 40
+
+/** @brief Fan RPM. */
+#define TAG_FAN_RPM 41
+
+/** @brief GDDR 0 and 1 temperature. */
+#define TAG_GDDR_0_1_TEMP 42
+
+/** @brief GDDR 2 and 3 temperature. */
+#define TAG_GDDR_2_3_TEMP 43
+
+/** @brief GDDR 4 and 5 temperature. */
+#define TAG_GDDR_4_5_TEMP 44
+
+/** @brief GDDR 6 and 7 temperature. */
+#define TAG_GDDR_6_7_TEMP 45
+
+/** @brief GDDR 0 and 1 corrected errors. */
+#define TAG_GDDR_0_1_CORR_ERRS 46
+
+/** @brief GDDR 2 and 3 corrected errors. */
+#define TAG_GDDR_2_3_CORR_ERRS 47
+
+/** @brief GDDR 4 and 5 corrected errors. */
+#define TAG_GDDR_4_5_CORR_ERRS 48
+
+/** @brief GDDR 6 and 7 corrected errors. */
+#define TAG_GDDR_6_7_CORR_ERRS 49
+
+/** @brief GDDR uncorrected errors. */
+#define TAG_GDDR_UNCORR_ERRS 50
+
+/** @brief Maximum GDDR temperature. */
+#define TAG_MAX_GDDR_TEMP 51
+
+/** @brief ASIC location. */
+#define TAG_ASIC_LOCATION 52
+
+/** @brief Board power limit in watts. */
+#define TAG_BOARD_POWER_LIMIT 53
+
+/** @brief Input power in watts. */
+#define TAG_INPUT_POWER 54
+
+/** @brief Maximum TDC limit in amperes. */
+#define TAG_TDC_LIMIT_MAX 55
+
+/** @brief Thermal throttle limit in degrees Celsius. */
+#define TAG_THM_LIMIT_THROTTLE 56
+
+/** @brief Firmware build date. */
+#define TAG_FW_BUILD_DATE 57
+
+/** @brief TT flash version. */
+#define TAG_TT_FLASH_VERSION 58
+
+/** @brief Enabled Tensix rows. */
+#define TAG_ENABLED_TENSIX_ROW 59
+
+/** @brief Thermal trip count. */
+#define TAG_THERM_TRIP_COUNT 60
+
+/** @brief High part of the ASIC ID. */
+#define TAG_ASIC_ID_HIGH 61
+
+/** @brief Low part of the ASIC ID. */
+#define TAG_ASIC_ID_LOW 62
+
+/** @brief Maximum AI clock frequency. */
+#define TAG_AICLK_LIMIT_MAX 63
+
+/** @brief Maximum TDP limit in watts. */
+#define TAG_TDP_LIMIT_MAX 64
+
+/** @} */ /* end of telemetry_tag group */
 
 /* Not a real tag, signifies the last tag in the list.
  * MUST be incremented if new tags are defined.
  */
-#define TAG_COUNT                65
+#define TAG_COUNT 65
 
 /* Telemetry tags are at offset `tag` in the telemetry buffer */
 #define TELEM_OFFSET(tag) (tag)


### PR DESCRIPTION
Add documentation for telemetry.
Provide links between sphinx documentation and the underlying doxygen documentation where prudent.