### PR TITLE
boards: make tt_pyluwen not the default runner

### DIFF
--- a/boards/tenstorrent/tt_blackhole/board.cmake
+++ b/boards/tenstorrent/tt_blackhole/board.cmake
@@ -61,11 +61,13 @@ if(CONFIG_ARM)
   include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
 endif()
 
+if(CONFIG_SOC_TT_BLACKHOLE_SMC)
+  board_set_debugger_ifnset(tt_pyluwen)
+  board_finalize_runner_args(tt_pyluwen)
+endif()
+
 board_set_flasher_ifnset(tt_flash)
 board_finalize_runner_args(tt_flash)
 
 board_set_flasher_ifnset(tt_bootstrap)
 board_finalize_runner_args(tt_bootstrap --board-name ${CONFIG_BOARD_REVISION})
-
-board_set_debugger(tt_pyluwen)
-board_finalize_runner_args(tt_pyluwen)


### PR DESCRIPTION
Make tt_pyluwen not the default runner so people
don't have to specify -r openocd

Also, it is not supposed to work for DMC, so don't register it as a runner for DMC.

`west attach -H --domain dmc`

```
available runners in runners.yaml:
  openocd, jlink, stm32cubeprogrammer, tt_flash, tt_bootstrap
default runner in runners.yaml:
  openocd
```

i.e. tt_pyluwen runners is removed. Default once again is openocd.

`west attach -H  --domain smc`

```
available runners in runners.yaml:
  tt_pyluwen, openocd, tt_flash, tt_bootstrap
default runner in runners.yaml:
  openocd
```

So it's available for SMC, not available for DMC, and is the default for neither.