### PR TITLE
Resume the target (DMC & SMC) when gdb detaches

### DIFF
--- a/boards/tenstorrent/tt_blackhole/support/tt_blackhole_dmc.cfg
+++ b/boards/tenstorrent/tt_blackhole/support/tt_blackhole_dmc.cfg
@@ -11,3 +11,6 @@ $_TARGETNAME configure -event reset-end {
 	echo "Inducing small delay to allow RTT control block to be setup"
 	sleep 50
 }
+
+# When GDB detaches, let the target run.
+$_TARGETNAME configure -event gdb-detach { resume }

--- a/boards/tenstorrent/tt_blackhole/support/tt_blackhole_smc.cfg
+++ b/boards/tenstorrent/tt_blackhole/support/tt_blackhole_smc.cfg
@@ -128,3 +128,6 @@ arc-em.cpu1 configure -event reset-end "bh_reset_end"
 # Use hard breakpoints- the ROM copies over the memory in CSM during boot,
 # so soft breakpoints won't work
 gdb_breakpoint_override hard
+
+# When GDB detaches, let the target run.
+arc-em.cpu1 configure -event gdb-detach { resume }


### PR DESCRIPTION
Per https://sourceware.org/gdb/current/onlinedocs/gdb.html/Connecting.html, this is normal behaviour.