### PR TITLE
scripts: tt_bootstrap: fix CI support

### DIFF
--- a/scripts/tt_bootstrap.py
+++ b/scripts/tt_bootstrap.py
@@ -251,10 +251,10 @@ class TTBootStrapRunner(ZephyrBinaryRunner):
         # Write out the bootfs binary for debugging
         with open(self.build_dir / "bootfs.bin", "wb") as f:
             self.logger.debug("Writing bootfs binary to build directory")
-            f.write(bootfs.to_binary())
+            f.write(bootfs.to_binary(True))
         operations = [
             FlashOperation(
-                bootfs.to_intel_hex(), self.pyocd_path / Path(cfg["pyocd-config"])
+                bootfs.to_intel_hex(True), self.pyocd_path / Path(cfg["pyocd-config"])
             )
         ]
         return operations


### PR DESCRIPTION
Fix flashing support in CI for tt-bootstrap. After the merge of c94ac519 (scripts: tt_boot_fs: only write provisioning data if --all is passed, 2025-06-25), tt_boot_fs APIs changed for generating output hex and bin files. Update the tt-bootstrap runner to use these APIs properly.