### PR TITLE
ci: skip BL2 tests on PR

### DIFF
--- a/.github/workflows/hardware-smoke.yml
+++ b/.github/workflows/hardware-smoke.yml
@@ -181,7 +181,9 @@ jobs:
           fi
           echo "SIGNATURE_KEY_FILE=$SIGNATURE_KEY_FILE" >> "$GITHUB_ENV"
 
+      # Skip the BL2 test if the github event is not a push to main or a collab branch
       - name: run-e2e-bl2-test
+        if: ${{ github.event_name == 'push' }}
         run: |
           tt-zephyr-platforms/scripts/ci/run-bl2.sh -k $SIGNATURE_KEY_FILE \
             -p $ASIC_ID ${{ matrix.config.board }}


### PR DESCRIPTION
Skip BL2 test on PRs, and only run them on the main branch. This should improve CI execution times.