### PR TITLE
ci: auto-rebase: initial commit of auto-rebase workflow

### DIFF
--- a/.github/workflows/auto-rebase.yml
+++ b/.github/workflows/auto-rebase.yml
@@ -1,0 +1,25 @@
+name: Auto Rebase Pull Requests
+
+env:
+  AUTO_REBASE_LABEL: "auto-rebase 🤖"
+
+on:
+  schedule:
+    # Run daily at 3:00 AM UTC
+    - cron: '0 3 * * *'
+  workflow_dispatch: {} # Allow manual triggering
+
+permissions:
+  contents: write
+  pull-requests: write
+  actions: read
+
+jobs:
+  rebase:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: peter-evans/rebase@v3
+        with:
+          base: ${{ github.event.repository.default_branch }}
+          exclude-drafts: true
+          include-labels: ${{ env.AUTO_REBASE_LABEL }}


### PR DESCRIPTION
We have had issues in the past where PRs are passing tests prior to being merged, and then after being merged, tests fail.

One source of this type of error is "staleness". I.e. even though the PR can be rebased cleanly, there are functional changes in `main` that are new and can conflict with expectations in the pull-request branch, the last time that the tests were run.

Another source of this type of error are flakey tests and other sources of non-determinism (e.g. code paths that are changed in containers that are managed outside of the repository).

To reduce "staleness" as a source of this kind of error, add an auto-rebase workflow that will automatically rebase pull requests so that tests are re-run.

We actually want to see tests failing as a result of automatic rebasing, since that means we will not unintentionally introduce regressions. The theory is, that by minimizing the number of commits that a PR is behind `main`, we will mitigate most (hopefully all) of post-push CI errors that result from "stale" PRs.

The auto-rebase feature has the following criteria (at this time):

* pull request targets the repo default branch (main)
* pull request can be rebased without conflict
* pull request includes the label `auto-rebase 🤖`
* pull request is not in draft mode
* workflow runs at 3am

Successfully demonstrated the action running on the following (fork) PR (via manual trigger):
https://github.com/cfriedt/tt-zephyr-platforms/pull/8

While in draft (skipped):
https://github.com/cfriedt/tt-zephyr-platforms/actions/runs/18567583372/job/52932824046

Open, but without the required label (skipped):
https://github.com/cfriedt/tt-zephyr-platforms/actions/runs/18567624132/job/52932970490

Open and 2 commits behind `main`:
https://github.com/cfriedt/tt-zephyr-platforms/actions/runs/18567858552/job/52933780995

If necessary, we could change the trigger for this workflow to happen after _every_ push to `main`, but the noise from that would likely overwhelm our Hardware CI capabilities.

If this proves successful, we can make it the default for all open pull requests (so no `auto-rebase 🤖` label would be required). The `auto-rebase 🤖` label makes this feature opt-in.