### PR TITLE
scripts: tooling: blackhole_recovery: wait 10 seconds for ASIC boot

### DIFF
--- a/scripts/tooling/blackhole_recovery/recover-blackhole.py
+++ b/scripts/tooling/blackhole_recovery/recover-blackhole.py
@@ -251,11 +251,16 @@ def main():
             time.sleep(2)
             pcie_utils.rescan_pcie()
             time.sleep(2)
-        # Now, check if all asics are functional
-        if not check_card_status(BOARD_ID_MAP[args.board]):
-            raise RuntimeError("Card did not recover successfully, try a reboot?")
-
-        print("Card recovered successfully")
+        timeout = 10  # seconds
+        timeout_ts = time.time() + timeout
+        while time.time() < timeout_ts:
+            if check_card_status(BOARD_ID_MAP[args.board]):
+                print("Card recovered successfully")
+                return
+            # Wait a bit and try again
+            time.sleep(1)
+        # If we get here, the card did not recover
+        raise RuntimeError("Card did not recover successfully, try a reboot?")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
In some recovery script runs, I've seen the ASIC fail to enumerate but then work fine when checked outside of the container (IE a few seconds later). Add a 10 second wait for enumeration after flashing, to reduce the odds we miss a successfully booting SMC

Tested with the following command `python3 ./scripts/tooling/blackhole_recovery/recover-blackhole.py /tmp/recovery.tar.gz p150a --force`

Using this recovery bundle:
[recovery.tar.gz](https://github.com/user-attachments/files/22954282/recovery.tar.gz)
