### PR TITLE
lib: bh_arc: add spi write lock/unlock commands

### DIFF
--- a/include/tenstorrent/smc_msg.h
+++ b/include/tenstorrent/smc_msg.h
@@ -117,6 +117,11 @@ enum tt_smc_msg {
 	TT_SMC_MSG_EFUSE_BURN = 0xBF,
 	TT_SMC_MSG_PING_DM = 0xC0,
 	TT_SMC_MSG_SET_WDT_TIMEOUT = 0xC1,
+	/** @brief Flash write unlock request */
+	TT_SMC_MSG_FLASH_UNLOCK = 0xC2,
+	/** @brief Flash write lock request */
+	TT_SMC_MSG_FLASH_LOCK = 0xC3,
+	/** @brief Confirm SPI flash succeeded */
 	TT_SMC_MSG_CONFIRM_FLASHED_SPI = 0xC4,
 };
 

--- a/lib/tenstorrent/bh_arc/spi_eeprom.c
+++ b/lib/tenstorrent/bh_arc/spi_eeprom.c
@@ -37,6 +37,7 @@ static uint8_t spi_page_buf[SPI_BUFFER_SIZE];
 /* Global buffer for SPI programming */
 static uint8_t spi_global_buffer[SPI_BUFFER_SIZE];
 static struct flash_pages_info page_info;
+static bool flash_locked = true;
 
 static const struct device *flash = DEVICE_DT_GET_OR_NULL(DT_NODELABEL(spi_flash));
 
@@ -198,6 +199,11 @@ static uint8_t write_eeprom_handler(const union request *request, struct respons
 	uint32_t num_bytes = request->data[2];
 	uint8_t *csm_addr = (uint8_t *)request->data[3];
 
+	if (flash_locked) {
+		/* Flash is locked; cannot write */
+		return 2;
+	}
+
 	if (!device_is_ready(flash)) {
 		/* Flash init failed */
 		return 1;
@@ -222,9 +228,23 @@ static uint8_t confirm_flashed_spi_handler(const union request *request, struct 
 	return 0;
 }
 
+static uint8_t flash_lock_handler(const union request *request, struct response *response)
+{
+	flash_locked = true;
+	return 0;
+}
+
+static uint8_t flash_unlock_handler(const union request *request, struct response *response)
+{
+	flash_locked = false;
+	return 0;
+}
+
 REGISTER_MESSAGE(TT_SMC_MSG_READ_EEPROM, read_eeprom_handler);
 REGISTER_MESSAGE(TT_SMC_MSG_WRITE_EEPROM, write_eeprom_handler);
 REGISTER_MESSAGE(TT_SMC_MSG_CONFIRM_FLASHED_SPI, confirm_flashed_spi_handler);
+REGISTER_MESSAGE(TT_SMC_MSG_FLASH_LOCK, flash_lock_handler);
+REGISTER_MESSAGE(TT_SMC_MSG_FLASH_UNLOCK, flash_unlock_handler);
 
 static int InitSpiFS(void)
 {


### PR DESCRIPTION
Add commands to lock and unlock the SPI for flash writing. This
deliberately breaks the SPI write API for old versions of
luwen/tt-flash, so that users can't easily downgrade their firmware
unintentionally.

Signed-off-by: Daniel DeGrasse <ddegrasse@tenstorrent.com>