### PR TITLE
poc: enable hotloading firmware

### DIFF
--- a/app/smc/boards/tt_blackhole_smc_partitions.dtsi
+++ b/app/smc/boards/tt_blackhole_smc_partitions.dtsi
@@ -32,7 +32,14 @@ slot1_partition: &smc_recovery {};
 		compatible = "zephyr,memory-region", "mmio-sram";
 		zephyr,memory-region = "CSM-APP";
 		device_type = "memory";
-		reg = <0x10010000 0x6f000>; /* 444 KiB for application */
+		reg = <0x10010000 0x6e000>; /* 440 KiB for application */
+	};
+
+	csm_persistent: memory@1007e000 {
+		compatible = "zephyr,memory-region", "mmio-sram";
+		zephyr,memory-region = "CSM-PERSISTENT";
+		device_type = "memory";
+		reg = <0x1007e000 0x1000>; /* 4 KiB for persistent storage */
 	};
 
 	csm_shared: memory@1007f000 {

--- a/include/tenstorrent/smc_msg.h
+++ b/include/tenstorrent/smc_msg.h
@@ -128,6 +128,8 @@ enum tt_smc_msg {
 	TT_SMC_MSG_FLASH_LOCK = 0xC3,
 	/** @brief Confirm SPI flash succeeded */
 	TT_SMC_MSG_CONFIRM_FLASHED_SPI = 0xC4,
+	/** @brief Hotload request */
+	TT_SMC_MSG_HOTLOAD = 0xC5,
 };
 
 /** @} */

--- a/lib/tenstorrent/bh_arc/CMakeLists.txt
+++ b/lib/tenstorrent/bh_arc/CMakeLists.txt
@@ -17,6 +17,7 @@ zephyr_library_sources_ifndef(
   functional_efuse.c
   gddr.c
   harvesting.c
+  hotload.c
   i2c_messages.c
   noc.c
   noc_init.c
@@ -64,6 +65,7 @@ zephyr_library_sources(
 zephyr_library_sources_ifdef(CONFIG_TT_SHELL tt_shell.c)
 
 zephyr_linker_sources(DATA_SECTIONS iterables.ld)
+zephyr_linker_sources(SECTIONS hotload.ld)
 if(CONFIG_ARC)
   zephyr_library_link_libraries(${ZEPHYR_CURRENT_MODULE_DIR}/zephyr/blobs/tt_blackhole_libpciesd.a)
 endif()

--- a/lib/tenstorrent/bh_arc/Kconfig
+++ b/lib/tenstorrent/bh_arc/Kconfig
@@ -18,7 +18,7 @@ if TT_BH_ARC
 
 config TT_BH_ARC_NUM_MSG_CODES
 	int "Number of message codes"
-	default 197
+	default 198
 	help
 	  The number of message codes
 

--- a/lib/tenstorrent/bh_arc/hotload.c
+++ b/lib/tenstorrent/bh_arc/hotload.c
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2025 Tenstorrent AI ULC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file hotload.c
+ * @brief Hotload handling implementation
+ *
+ */
+
+#include <tenstorrent/smc_msg.h>
+#include <tenstorrent/msgqueue.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/sys_io.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/drivers/clock_control/clock_control_tt_bh.h>
+#include <zephyr/drivers/clock_control.h>
+#include <zephyr/linker/devicetree_regions.h>
+
+#define SCRATCH0         0x80030400
+#define GLOBAL_RESET     0x80030000
+#define ETH_RESET        0x80030008
+#define DDR_RESET        0x80030010
+#define I2C_CNTL         0x800300f0
+#define SPI_CNTL         0x800300f8
+#define ARC_MISC_CTRL    0x80030100
+#define PLL0_CNTL_OFFSET 0x80020100
+#define SCRATCH_MAGIC    0xCAFEBABE
+
+struct arc_vector_table {
+	void (*reset)(void); /* Reset vector */
+};
+
+Z_GENERIC_SECTION(.hotload.data)
+static struct arc_vector_table *vt;
+
+Z_GENERIC_SECTION(.hotload.text)
+static void delay(void)
+{
+	/* Simple delay loop */
+	for (volatile int i = 0; i < 100000; i++) {
+		__asm__ volatile("nop");
+	}
+}
+
+/*
+ * This function sits within a custom RAM region the hotload cannot overwrite.
+ * It MUST not reference external symbols, because when this code
+ * runs the remainder of the firmware image will be overwritten
+ */
+
+Z_GENERIC_SECTION(.hotload.text)
+void wait_jump_request(struct k_timer *timer)
+{
+	volatile uint32_t *reg;
+
+	ARG_UNUSED(timer);
+	/*
+	 * Disable interrupts, we will keep them locked
+	 * until we jump to new firmware
+	 */
+	irq_lock();
+
+	/* Indicate to host we are ready to jump */
+	reg = (uint32_t *)SCRATCH0;
+	*reg = SCRATCH_MAGIC;
+	while (*reg == SCRATCH_MAGIC) {
+		/* Wait for host to clear the ready signal */
+	}
+
+	/*
+	 * TODO- it is unclear if we need to reset more here. For now,
+	 * these resets are sufficient to get the hotload working with
+	 * mission mode CMFW
+	 */
+
+	/* Resets must be asserted at slow clock speed. Bypass PLLs */
+	for (uint32_t i = 0; i < 5; i++) {
+		reg = (uint32_t *)(PLL0_CNTL_OFFSET + (i * 0x100));
+		*reg &= ~BIT(4);
+		delay();
+		reg = (uint32_t *)(PLL0_CNTL_OFFSET + (i * 0x11C));
+		*reg = 0x0; /* Disable postdivs */
+		delay();
+	}
+
+	/* Reset the PCIe/NOC complex */
+	reg = (uint32_t *)GLOBAL_RESET;
+	/* Clear noc and pcie reset */
+	*reg &= ~(BIT(1) | BIT(8));
+
+	/* Reset ETH */
+	reg = (uint32_t *)ETH_RESET;
+	*reg = 0x0;
+	/* Reset DDR */
+	reg = (uint32_t *)DDR_RESET;
+	*reg = 0x0;
+	/* Reset SPI */
+	reg = (uint32_t *)SPI_CNTL;
+	*reg |= BIT(4); /* SPI reset */
+	delay();
+	/* Deassert SPI reset */
+	*reg &= ~BIT(4);
+	/* Assert I2C reset */
+	reg = (uint32_t *)I2C_CNTL;
+	*reg |= BIT(4); /* I2C reset */
+	delay();
+	/* Deassert I2C reset */
+	*reg &= ~BIT(4);
+	/* Jump to the new firmware image */
+	vt->reset();
+}
+
+K_TIMER_DEFINE(jump_timer, wait_jump_request, NULL);
+
+static uint8_t hotload_handler(const union request *request, struct response *response)
+{
+	vt = (void *)request->data[1];
+
+	/* Start jump handler */
+	k_timer_start(&jump_timer, K_MSEC(100), K_NO_WAIT);
+
+	/* Indicate success to host */
+	return 0;
+}
+
+REGISTER_MESSAGE(TT_SMC_MSG_HOTLOAD, hotload_handler);
+
+/* Set by linker, */
+extern char _hotload_load_addr[];
+extern char _hotload_start[];
+extern char _hotload_size[];
+
+/* Copy hotload section to correct offset */
+static int hotload_init(void)
+{
+	memcpy((void *)&_hotload_start, (void *)_hotload_load_addr, (size_t)_hotload_size);
+	return 0;
+}
+
+SYS_INIT(hotload_init, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);

--- a/lib/tenstorrent/bh_arc/hotload.ld
+++ b/lib/tenstorrent/bh_arc/hotload.ld
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2025 Tenstorrent AI ULC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+SECTION_PROLOGUE(.hotload,,)
+{
+	_hotload_start = .;
+	KEEP(*(.hotload.*))
+	_hotload_end = .;
+} > CSM_PERSISTENT AT > SRAM
+_hotload_load_addr = LOADADDR(.hotload);
+_hotload_size = _hotload_end - _hotload_start;

--- a/scripts/load-fw.py
+++ b/scripts/load-fw.py
@@ -1,0 +1,39 @@
+#!/bin/env python3
+
+# Copyright (c) 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+"""
+Script to load firmware onto a Tenstorrent chip using pyluwen.
+Usage: python3 load-fw.py <firmware_file> <jump_address> <load_address>
+Example for production firmware:
+python3 ./scripts/load-fw.py build/smc/zephyr/zephyr.bin 0x10010400 0x10010000
+"""
+
+import sys
+import pyluwen
+
+ARC_SCRATCH0 = 0x80030400
+SCRATCH_MAGIC = 0xCAFEBABE
+
+chip = pyluwen.detect_chips()[0]
+
+jump_addr = int(sys.argv[2], 0)
+load_addr = int(sys.argv[3], 0)
+
+# Use an ARC message to load the firmware
+chip.arc_msg(0xC5, True, False, jump_addr & 0xFFFF, jump_addr >> 16, 1000)
+scratch0 = chip.axi_read32(ARC_SCRATCH0)  # Read the ready signal
+while scratch0 != SCRATCH_MAGIC:
+    scratch0 = chip.axi_read32(ARC_SCRATCH0)  # Wait for ARC to be halted
+print("ARCs halted, loading firmware...")
+
+with open(sys.argv[1], "rb") as f:
+    fw_data = f.read()
+    # Write the firmware to the chip's memory
+    chip.axi_write(load_addr, fw_data)
+
+# Now, we need to release the ARC to run the new firmware
+scratch0 = chip.axi_read32(ARC_SCRATCH0)
+scratch0 = 0  # Clear the halt signal
+chip.axi_write32(ARC_SCRATCH0, scratch0)
+print("Firmware load complete.")

--- a/zephyr/patches.yml
+++ b/zephyr/patches.yml
@@ -160,3 +160,11 @@ patches:
     comments: |
       Add support for read-frequency property in jedec,spi-nor binding and
       enable using the flash page layout API with the driver.
+  - path: zephyr/arch-arc-v2-add-dt-linker-section-definitions.patch
+    sha256sum: 16883fd65a04402677ee53e2e16ed27c8eb4534ed6fd28136b9022689c51437b
+    module: zephyr
+    author: Daniel DeGrasse
+    email: ddegrasse@tenstorrent.com
+    date: 2025-11-19
+    comments: |
+      Add DT linker section definitions for ARCv2 architecture.

--- a/zephyr/patches/zephyr/arch-arc-v2-add-dt-linker-section-definitions.patch
+++ b/zephyr/patches/zephyr/arch-arc-v2-add-dt-linker-section-definitions.patch
@@ -1,0 +1,44 @@
+From 2e05ae76fbe4dd9a023989bbab37301acb400b49 Mon Sep 17 00:00:00 2001
+From: Daniel DeGrasse <ddegrasse@tenstorrent.com>
+Date: Wed, 19 Nov 2025 11:02:58 -0600
+Subject: [PATCH] arch: arc v2: add dt linker section definitions
+
+Add dt linker section definitions for ARC V2 platforms.
+
+Signed-off-by: Daniel DeGrasse <ddegrasse@tenstorrent.com>
+---
+ include/zephyr/arch/arc/v2/linker.ld | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/include/zephyr/arch/arc/v2/linker.ld b/include/zephyr/arch/arc/v2/linker.ld
+index 1b1bd291148..504256cf0c7 100644
+--- a/include/zephyr/arch/arc/v2/linker.ld
++++ b/include/zephyr/arch/arc/v2/linker.ld
+@@ -12,6 +12,7 @@
+ #include <zephyr/linker/sections.h>
+ #include <zephyr/linker/linker-defs.h>
+ #include <zephyr/linker/linker-tool.h>
++#include <zephyr/linker/devicetree_regions.h>
+
+ /* physical address of RAM */
+ #ifdef CONFIG_HARVARD
+@@ -73,6 +74,7 @@ MEMORY {
+ #ifdef YCCM_START
+ 	YCCM  (rw)  : ORIGIN = YCCM_START,  LENGTH = YCCM_SIZE
+ #endif
++	LINKER_DT_REGIONS()
+ 	/* Used by and documented in include/linker/intlist.ld */
+ 	IDT_LIST  (wx)      : ORIGIN = 0xFFFFF7FF, LENGTH = 2K
+ }
+@@ -325,6 +327,9 @@ SECTIONS {
+ 	__arc_rw_sram_size = SRAM_START + SRAM_SIZE - _image_ram_start;
+ #endif
+
++	/* Sections generated from 'zephyr,memory-region' nodes */
++	LINKER_DT_SECTIONS()
++
+ 	/DISCARD/ : {
+ 		/* Discard all destructors */
+ 		*(.dtors*)
+--
+2.34.1


### PR DESCRIPTION
This proof of concept is in an early stage. It supports hotloading
firmware over the original firmware, provided the memory region at
0x1007e000 is not overwritten by the new firmware.

The load sequence works as follows:
- build firmware
- load firmware using load-fw.py script, providing load address and jump
  address

Examples:

west build -p always -b tt_blackhole@p150a/tt_blackhole/smc --sysbuild app/smc/
./scripts/load-fw.py build/smc/zephyr/zephyr.bin 0x10010400 0x10010000

west build -p always -b tt_blackhole@p150a/tt_blackhole/smc \
               ../zephyr/samples/hello_world/
./scripts/load-fw.py build/zephyr/zephyr.bin 0x10000000 0x10000000

This is still *very* unreliable, sometimes the write to memory fails to complete. Still debugging why this is the case.
