### PR TITLE
boards: tt_blackhole: fix dtc warning on i2c unit address

### DIFF
--- a/boards/tenstorrent/tt_blackhole/tt_blackhole_tt_blackhole_smc.dts
+++ b/boards/tenstorrent/tt_blackhole/tt_blackhole_tt_blackhole_smc.dts
@@ -58,10 +58,10 @@
 
 &i2c0 {
 	status = "okay";
-	smbus_target0: smbus@0A {
+	smbus_target0: smbus@a {
 		status = "okay";
 		compatible = "zephyr,smbus_target";
-		reg = <0x0A>;
+		reg = <0xa>;
 	};
 };
 


### PR DESCRIPTION
Fix the warnings related to using 0A for the unit address.

```
Warning (unit_address_format): /soc/i2c@80060000/smbus@0A: unit name should not have leading 0s
Warning (i2c_bus_reg): /soc/i2c@80060000/smbus@0A: I2C bus unit address format error, expected "a"
```