### PR TITLE
app: dmc_rom_update: erase image magic in start of slot1

### DIFF
--- a/app/dmc_rom_update/src/main.c
+++ b/app/dmc_rom_update/src/main.c
@@ -13,11 +13,13 @@
 
 #define MCUBOOT_PART_NODE  DT_NODE_BY_FIXED_PARTITION_LABEL(mcuboot)
 #define BLUPDATE_PART_NODE DT_NODE_BY_FIXED_PARTITION_LABEL(blupdate)
+#define DMFW_PART_NODE     DT_NODE_BY_FIXED_PARTITION_LABEL(dmfw)
 
 BUILD_ASSERT(DT_FIXED_PARTITION_EXISTS(MCUBOOT_PART_NODE),
 	     "No mcuboot partition found in devicetree");
 BUILD_ASSERT(DT_FIXED_PARTITION_EXISTS(BLUPDATE_PART_NODE),
 	     "No blupdate partition found in devicetree");
+BUILD_ASSERT(DT_FIXED_PARTITION_EXISTS(DMFW_PART_NODE), "No dmfw partition found in devicetree");
 
 uint8_t flash_copy_buf[4 * 1024] __aligned(4);
 
@@ -26,7 +28,7 @@ int main(void)
 	const struct device *tgt_flash = FIXED_PARTITION_NODE_DEVICE(MCUBOOT_PART_NODE);
 	const struct device *src_flash = FIXED_PARTITION_NODE_DEVICE(BLUPDATE_PART_NODE);
 	int rc;
-	off_t tgt_off, src_off;
+	off_t tgt_off, src_off, dmfw_off;
 	size_t len, erase_len;
 
 	/*
@@ -37,10 +39,21 @@ int main(void)
 	printk("Starting DMFW rom update...\n");
 	tgt_off = DT_REG_ADDR(MCUBOOT_PART_NODE);
 	src_off = DT_REG_ADDR(BLUPDATE_PART_NODE);
+	dmfw_off = DT_REG_ADDR(DMFW_PART_NODE);
 	len = FIXED_PARTITION_NODE_SIZE(BLUPDATE_PART_NODE);
 	/* Erase an additional 0x200 bytes so the new slot0 header will be cleared */
 	erase_len = len + 0x200;
 
+	/*
+	 * Erase first sector of new DMFW slot1. This ensures that mcuboot won't see
+	 * a stale image magic in the slot during the bootstrap.
+	 */
+	printk("Erasing flash at 0x%lx, size 0x%zx\n", dmfw_off, 0x1000);
+	rc = flash_erase(src_flash, dmfw_off, 0x1000);
+	if (rc != 0) {
+		printk("Flash erase failed: %d\n", rc);
+		return rc;
+	}
 	printk("Erasing flash at 0x%lx, size 0x%zx\n", tgt_off, erase_len);
 	rc = flash_erase(tgt_flash, tgt_off, erase_len);
 	if (rc != 0) {


### PR DESCRIPTION
If DMC slot1 in the BL2 scheme has an new image in it, and the old pre-BL2 firmware is running on the DMC, when the DMFW rom update is attempted the bootstrap process will fail because of the magic in the start of the DMC slot1. To resolve this, erase slot1 of the new BL2 image during the rom update process.

Fixes #751