### PR TITLE
CI: Fix unlaunched dut import

### DIFF
--- a/app/smc/pytest/e2e_stress.py
+++ b/app/smc/pytest/e2e_stress.py
@@ -21,7 +21,13 @@ from e2e_smoke import (
 
 # Needed to keep ruff from complaining about this "unused import"
 # ruff: noqa: F811
-from e2e_smoke import arc_chip_dut, launched_arc_dut, unlaunched_dut  # noqa: F401
+from e2e_smoke import arc_chip_dut, launched_arc_dut  # noqa: F401
+
+try:
+    from e2e_smoke import unlaunched_dut  # noqa: F401
+except ImportError:
+    pass  # we should have it from twister
+
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Some CI stress fixes:

1) Fix the unlaunched dut import when running via twister.

If twister exists, we do not create the unlaunched_dut fixture in e2e_smoke. So don't bother with trying to import anything. This works to get stress tests working locally via `run-e2e.sh`  and worked in this PR with some yaml mods to run stress on PR (although we still fail for other reasons...)

