### PR TITLE
app: smc: fix dmfw update process

### DIFF
--- a/app/smc/sysbuild.cmake
+++ b/app/smc/sysbuild.cmake
@@ -69,6 +69,12 @@ if(NOT "${BOARD_REVISION}" STREQUAL "galaxy")
     BOARD       ${SB_CONFIG_DMC_BOARD}
     BUILD_ONLY 1
   )
+  # We need to make sure the first slot of the DMC image visable to mcuboot
+  # is padded with 4KB of 0x00 bytes to allow for swap using offset.
+  # Generate that padding file here
+  add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/dmc-slot-padding.bin
+    COMMAND dd if=/dev/zero bs=4096 count=1 of=${CMAKE_BINARY_DIR}/dmc-slot-padding.bin
+  )
 endif()
 
 # Make sure MCUBoot is build only
@@ -85,6 +91,7 @@ set_config_string(mcuboot CONFIG_BOOT_SIGNATURE_KEY_FILE "${SB_CONFIG_BOOT_SIGNA
 set(OUTPUT_FWBUNDLE ${CMAKE_BINARY_DIR}/update.fwbundle)
 
 set(DMC_OUTPUT_BIN ${CMAKE_BINARY_DIR}/dmc/zephyr/zephyr.bin)
+set(DMC_SLOT_BIN ${CMAKE_BINARY_DIR}/dmc-slot-padding.bin)
 set(SMC_OUTPUT_BIN ${CMAKE_BINARY_DIR}/${DEFAULT_IMAGE}/zephyr/zephyr.signed.bin)
 set(RECOVERY_OUTPUT_BIN ${CMAKE_BINARY_DIR}/recovery/zephyr/zephyr.signed.bin)
 set(MCUBOOT_OUTPUT_BIN ${CMAKE_BINARY_DIR}/mcuboot/zephyr/zephyr.bin)
@@ -134,7 +141,7 @@ else()
 
   set(BOOTFS_DEPS ${SMC_OUTPUT_BIN} ${RECOVERY_OUTPUT_BIN} ${MCUBOOT_OUTPUT_BIN}
      ${DMC_OUTPUT_BIN} ${ROM_UPDATE_BIN} ${MCUBOOT_BL2_BIN} ${TRAILER_OUTPUT}
-     ${TRAILER_OUTPUT_CONFIRMED})
+     ${TRAILER_OUTPUT_CONFIRMED} ${DMC_SLOT_BIN})
 endif()
 
 # ======== Generate filesystem ========

--- a/boards/tenstorrent/tt_blackhole/tt_blackhole_fixed_partitions.dtsi
+++ b/boards/tenstorrent/tt_blackhole/tt_blackhole_fixed_partitions.dtsi
@@ -180,6 +180,7 @@ partitions {
 	dmfw: partition@22d000 {
 		label = "dmfw";
 		reg = <0x22d000 DT_SIZE_K(452)>;
+		binary-path = "$BUILD_DIR/dmc-slot-padding.bin";
 	};
 
 	/*

--- a/boards/tenstorrent/tt_blackhole/tt_blackhole_tt_blackhole_smc_galaxy.overlay
+++ b/boards/tenstorrent/tt_blackhole/tt_blackhole_tt_blackhole_smc_galaxy.overlay
@@ -5,4 +5,5 @@
  */
 
 /delete-node/ &blupdate;
+/delete-node/ &dmfw;
 /delete-node/ &dmfwimg;


### PR DESCRIPTION
When DMFW update executes, every other update will result in MCUBoot printing the message:

"E: Secondary header magic detected in first sector, wrong upload address?"

and failing to swap to the new image. To resolve this, include a block of 4KB of zeros at the start of the DMFW image so that this section of eeprom will always be erased by tt-flash