### PR TITLE
 app: smc: pytest: add 19.0 upgrade test

### DIFF
--- a/app/smc/pytest/e2e_smoke.py
+++ b/app/smc/pytest/e2e_smoke.py
@@ -374,18 +374,6 @@ def temperature_sensors_test(arc_chip_dut, asic_id):
     return fail_count
 
 
-def test_upgrade_from_18_10(arc_chip_dut, tmp_path: Path, board_name, unlaunched_dut):
-    upgrade_from_version_test(
-        arc_chip_dut,
-        tmp_path,
-        board_name,
-        unlaunched_dut,
-        "18.10.0",
-        (13 << 16),
-        (19 << 16),
-    )
-
-
 def test_upgrade_from_19_00(arc_chip_dut, tmp_path: Path, board_name, unlaunched_dut):
     upgrade_from_version_test(
         arc_chip_dut,


### PR DESCRIPTION
~Add test to validate updating from one version of 19.0 firmware to
another version. Since no released version of 19.0 firmware exists, we
currently flash a custom recovery bundle with 19.0 partitions but 18.0
version numbers, and validate upgrades from that.~

Add test to validate we can update from 19.0 to latest built firmware. Since firmware builds do not get signed with production keys on PRs, we need to replace the running copy of MCUBoot on the DMC with one that will accept our signature key.
