### PR TITLE
doc: develop: getting_started: only fetch blobs from tt-z-p

### DIFF
--- a/doc/develop/getting_started/index.rst
+++ b/doc/develop/getting_started/index.rst
@@ -46,7 +46,7 @@ Follow these steps to set up your TT Zephyr Platforms development environment:
    west sdk install
 
    # Step 8: Download binary blobs (firmware components)
-   west blobs fetch
+   west blobs fetch tt-zephyr-platforms
 
    # Step 9: Apply TT-specific patches
    west patch apply

--- a/scripts/ci-local-setup.yml
+++ b/scripts/ci-local-setup.yml
@@ -277,7 +277,7 @@
     #   ansible.builtin.shell: |
     #     cd tenstorrent &&
     #     . .venv/bin/activate &&
-    #     west blobs fetch
+    #     west blobs fetch tt-zephyr-platforms
 
     # - name: Apply west patches
     #   ansible.builtin.shell: |


### PR DESCRIPTION
In order to avoid the occasional error due to GitHub not being able to serve static content for whatever reason or that an upstream blob URL no longer exists, udpate our `west blobs fetch` instructions to only fetch from `tt-zephyr-platforms`, since we do not depend on any other blobs at this time.