### PR TITLE
app: dmc: support legacy ping command

### DIFF
--- a/app/dmc/src/main.c
+++ b/app/dmc/src/main.c
@@ -120,9 +120,15 @@ static bool process_ping(struct bh_chip *chip, uint8_t msg_id, uint32_t msg_data
 	uint32_t retries = 0;
 
 	do {
-		uint16_t data;
+		uint16_t data = 0xA5A5;
 
-		ret = bharc_smbus_word_data_read(&chip->config.arc, CMFW_SMBUS_PING_V2, &data);
+		if (msg_data == 0) {
+			ret = bharc_smbus_word_data_read(&chip->config.arc,
+							 CMFW_SMBUS_PING_V2, &data);
+		} else {
+			ret = bharc_smbus_word_data_write(&chip->config.arc,
+							  CMFW_SMBUS_PING, data);
+		}
 		retries++;
 	} while (ret != 0U && retries < 10);
 

--- a/include/tenstorrent/msgqueue.h
+++ b/include/tenstorrent/msgqueue.h
@@ -241,6 +241,21 @@ struct debug_noc_translation_rqst {
 	uint8_t skip_eth_hi;
 };
 
+
+/** @brief Host request to ping DMC
+ * @details Messages of this type are processed by @ref ping_dm_handler
+ */
+struct dmc_ping_rqst {
+	/** @brief The command code corresponding to @ref TT_SMC_MSG_PING_DM */
+	uint8_t command_code;
+
+	/** @brief Three bytes of padding */
+	uint8_t pad[3];
+
+	/** @brief Use legacy ping mode */
+	bool legacy_ping;
+};
+
 /** @brief A tenstorrent host request*/
 union request {
 	/** @brief The interpretation of the request as an array of uint32_t entries*/
@@ -280,6 +295,9 @@ union request {
 
 	/** @brief A debug NOC translation request */
 	struct debug_noc_translation_rqst debug_noc_translation;
+
+	/** @brief A dmc ping request */
+	struct dmc_ping_rqst dmc_ping;
 };
 
 /** @} */

--- a/include/tenstorrent/smc_msg.h
+++ b/include/tenstorrent/smc_msg.h
@@ -117,6 +117,7 @@ enum tt_smc_msg {
 	TT_SMC_MSG_SET_LAST_SERIAL = 0xBE,
 	/** @brief eFuse burn request (not supported) */
 	TT_SMC_MSG_EFUSE_BURN = 0xBF,
+	/** @brief Ping DMC request */
 	TT_SMC_MSG_PING_DM = 0xC0,
 	TT_SMC_MSG_SET_WDT_TIMEOUT = 0xC1,
 	/** @brief Flash write unlock request */

--- a/lib/tenstorrent/bh_arc/cm2dm_msg.c
+++ b/lib/tenstorrent/bh_arc/cm2dm_msg.c
@@ -195,6 +195,17 @@ static uint8_t reset_dm_handler(const union request *request, struct response *r
 
 REGISTER_MESSAGE(TT_SMC_MSG_TRIGGER_RESET, reset_dm_handler);
 
+/**
+ * @brief Handler for host request to ping DMC
+ *
+ * Handler for a host request to ping the DMC. This request is used to test
+ * SMBUS stability.
+ * @param[in] request The request, of type @ref dmc_ping_rqst, with command code
+ *	@ref TT_SMC_MSG_PING_DM to ping the DMC. If @ref dmc_ping_rqst::legacy_ping is
+ *	false, The SMC requests a block read; otherwise, the SMC requests a block write.
+ * @param[out] response The response to the host. Set to 1 if DMC is alive, 0 otherwise.
+ * @return 0
+ */
 static uint8_t ping_dm_handler(const union request *request, struct response *response)
 {
 	int ret;
@@ -202,7 +213,7 @@ static uint8_t ping_dm_handler(const union request *request, struct response *re
 
 	/* Send a ping to the dmfw */
 	k_sem_reset(&dmfw_ping_sem);
-	PostCm2DmMsg(kCm2DmMsgIdPing, 0);
+	PostCm2DmMsg(kCm2DmMsgIdPing, request->dmc_ping.legacy_ping);
 	/* Delay to allow DMFW to respond */
 	timestamp = k_uptime_get();
 	ret = k_sem_take(&dmfw_ping_sem, K_MSEC(CONFIG_TT_BH_ARC_DMFW_PING_TIMEOUT));


### PR DESCRIPTION
If SMC message has nonzero request data value, use legacy ping command. This enables testing with the legacy ping command on newer firmware.