### PR TITLE
ci: metal: add gen-config to needs of metal-test

### DIFF
--- a/.github/workflows/metal.yml
+++ b/.github/workflows/metal.yml
@@ -30,7 +30,7 @@ jobs:
           echo "matrix-config=$MATRIX_CONFIG" | tee -a $GITHUB_OUTPUT
 
   metal-test:
-    needs: build-fw-artifact
+    needs: [build-fw-artifact, gen-config]
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Add `gen-config` to needs of `metal-test`. This was likely lost during a rebase and caused the workflow to fail, even though all jobs completed successfully.

https://github.com/tenstorrent/tt-zephyr-platforms/actions/runs/18908411315

<img width="1168" height="678" alt="Screenshot 2025-10-29 at 9 27 21 AM" src="https://github.com/user-attachments/assets/72b4572b-3ecc-4a91-947b-e5278ccdc79c" />