### PR TITLE
ci: hardware-long: trigger on PR based on label

### DIFF
--- a/.github/workflows/hardware-long.yml
+++ b/.github/workflows/hardware-long.yml
@@ -2,6 +2,9 @@ name: Hardware Long Tests
 
 # Run long tests once nightly, at 00:00
 on:
+  pull_request:
+    types:
+      - labeled
   schedule:
     - cron: "0 0 * * *"
   workflow_dispatch: {}
@@ -11,12 +14,22 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  long-test-check:
+    runs-on: ubuntu-24.04
+    if: ${{ github.event_name == 'schedule' ||  github.event.label.name == 'long-tests' }}
+    steps:
+      - name: Long Test Check
+        run: |
+          echo "Long tests are required."
+
   build-fw-artifact:
+    needs: long-test-check
     uses: ./.github/workflows/build-fw.yml
     secrets:
       SIGNATURE_KEY: ${{ secrets.SIGNATURE_KEY }}
 
   gen-config:
+    needs: long-test-check
     runs-on: ubuntu-24.04
     outputs:
       matrix-config: ${{ steps.gen-config.outputs.matrix-config }}


### PR DESCRIPTION
 If the "long-tests" label is added to a PR, trigger hardware long tests on it.

This has the following conditions:

- the jobs won't be triggered unless a label is added (good)
     - this means we don't get a bunch of skipped jobs for hardware-long in the CI view (good)
- only those with write access to the repo can add labels (good)
- adding another label retriggers the logic for the jobs, and will cancel existing hardware long tests running on the PR (**bad**)
- pushing to the PR won't trigger tests to run again (**bad**)
- only way to rerun tests is to remove and readd the label (meh)
