### PR TITLE
drivers: Coding standard updates for clock_control_tt_bh

### DIFF
--- a/drivers/clock_control/clock_control_tt_bh.c
+++ b/drivers/clock_control/clock_control_tt_bh.c
@@ -331,7 +331,7 @@ static void clock_control_tt_bh_update(const struct clock_control_tt_bh_config *
 	clock_control_tt_bh_config_vco(config, settings);
 
 	/* Power sequence requires PLLEN get asserted 1us after all inputs are stable. */
-	/* Wait 5x this time to be convervative */
+	/* Wait 5x this time to be conservative */
 	k_busy_wait(5);
 
 	/* Power up PLLs */
@@ -561,7 +561,7 @@ static int clock_control_tt_bh_init(const struct device *dev)
 	clock_control_tt_bh_config_vco(config, &config->init_settings);
 
 	/* Power sequence requires PLLEN get asserted 1us after all inputs are stable. */
-	/* Wait 5x this time to be convervative */
+	/* Wait 5x this time to be conservative */
 	k_busy_wait(5);
 
 	/* Power up PLLs */


### PR DESCRIPTION
It is against coding guidelines to use typedefs for structs when it can be easily avoided, so clean up the file so it matches these guidelines.

https://docs.tenstorrent.com/tt-zephyr-platforms/contribute/coding_guidelines/index.html#struct-and-enum-definitions

As well - I've received feedback in the past that we should take efforts to namespace our enums/structs/unions with `tt` or otherwise reasonably namespacing conventions in order to avoid competition with globally visible tags.