### PR TITLE
ci: abbreviate workflow names slightly to fit status badges

### DIFF
--- a/.github/workflows/build-fw.yml
+++ b/.github/workflows/build-fw.yml
@@ -1,4 +1,4 @@
-name: Build Firmware
+name: Build
 
 on:
   workflow_call:

--- a/.github/workflows/hardware-long.yml
+++ b/.github/workflows/hardware-long.yml
@@ -1,4 +1,4 @@
-name: Hardware Long Tests
+name: HW Soak
 
 # Run long tests once nightly, at 00:00
 on:

--- a/.github/workflows/hardware-smoke.yml
+++ b/.github/workflows/hardware-smoke.yml
@@ -1,4 +1,4 @@
-name: Hardware Smoke Tests
+name: HW Smoke
 
 on:
   push:

--- a/.github/workflows/metal.yml
+++ b/.github/workflows/metal.yml
@@ -1,4 +1,4 @@
-name: Metal Tests 🤘
+name: Metal 🤘
 
 # Run long tests once nightly, at 00:00
 on:

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -1,4 +1,4 @@
-name: Run Unit Tests
+name: Unit
 
 on:
   push:


### PR DESCRIPTION
Currently, our status badges spill over from one line to the next because their names are a bit long.

Shorten the names so that our status badges can fit on one row.