### PR TITLE
ci: limit P300a jobs to functional runner

### DIFF
--- a/.github/ci_boards.json
+++ b/.github/ci_boards.json
@@ -11,7 +11,7 @@
   },
   {
     "board": "p300a",
-    "runs-on": "p300a-jtag",
+    "runs-on": "syseng-gh-13-lab-p300a",
     "metal-image": "ghcr.io/tenstorrent/tt-metal/upstream-tests-bh-p300:v0.62.0-dev20251015-5-g0cf6eeb32e"
   }
 ]


### PR DESCRIPTION
Limit P300a jobs to the functional runner until the other runner is properly reconfigured to support job execution