### PR TITLE
ci: build-fw: fetch tags from manifest repo and zephyr

### DIFF
--- a/.github/workflows/build-fw.yml
+++ b/.github/workflows/build-fw.yml
@@ -50,9 +50,19 @@ jobs:
       - uses: actions/checkout@v4
         with:
           path: tt-zephyr-platforms
+          fetch-tags: true
       - uses: ./tt-zephyr-platforms/.github/workflows/prepare-zephyr
         with:
           app-path: tt-zephyr-platforms
+
+      # Fetch tags from repositories in manifest. Needed so that
+      # git describe functions correctly when creating a build.
+      # We can remove this once https://github.com/zephyrproject-rtos/action-zephyr-setup/issues/56
+      # is fixed.
+      - name: Fetch Tags
+        shell: bash
+        run: |
+          west forall -c 'git fetch --unshallow || true'
 
       - name: Generate BOARD
         working-directory: tt-zephyr-platforms


### PR DESCRIPTION
Fetch with fetch-depth 0 when building firmware. This is desirable because it means that firmware binaries built within the CI job will have the proper "git describe" version string. Without this change, version strings in released builds look like the following:

```
*** Booting tt_blackhole with Zephyr OS d90d71c42c6d ***
*** TT_GIT_VERSION 66ca1d5a6b56 ***
```

While this isn't _required_, without it reproducible builds are a bit harder to achieve (since you have to delete your tags locally first to get the same `git describe` behavior)