### PR TITLE
ci: enable jobs to run on secondary P300a runner again

### DIFF
--- a/.github/ci_boards.json
+++ b/.github/ci_boards.json
@@ -11,7 +11,7 @@
   },
   {
     "board": "p300a",
-    "runs-on": "syseng-gh-13-lab-p300a",
+    "runs-on": "p300a-jtag",
     "metal-image": "ghcr.io/tenstorrent/tt-metal/upstream-tests-bh-p300:v0.62.0-dev20251015-5-g0cf6eeb32e"
   }
 ]


### PR DESCRIPTION
P300a runner has had its docker containers purged and no longer seems to be running into the -EACCES issue. Allow jobs to run on it again.