### PR TITLE
zephyr: patches: zephyr: align data tx and rx to 64 bytes

### DIFF
--- a/zephyr/patches.yml
+++ b/zephyr/patches.yml
@@ -8,7 +8,7 @@ patches:
     comments: |
       Support multilevel interrupt priority on ARC cores.
   - path: zephyr/check-compliance.patch
-    sha256sum: fa20f70530a7685f4e415f26ffd9eb79dba6cf1f85d6d35446b97fea573a5148
+    sha256sum: 71f8c8134745fa2fd553f6a0e7f3289abc27e468cada40df9a437ae505a69903
     module: zephyr
     author: Chris Friedt
     email: cfriedt@tenstorrent.com
@@ -184,4 +184,22 @@ patches:
     date: 2025-11-05
     comments: |
       Make data alignment in DMA SG test configurable according to its DT property
+      dma-buf-addr-alignment.
+  - path: zephyr/tests-drivers-dma-loop.patch
+    sha256sum: 452fa314b1185c661f95d27aef2955d9cb5f84490f0e4ded0475b030927e7e94
+    module: zephyr
+    author: Alex Apostolu
+    email: aapostolu@tenstorrent.com
+    date: 2025-11-07
+    comments: |
+      Make data alignment in DMA loop test configurable according to its DT property
+      dma-buf-addr-alignment.
+  - path: zephyr/tests-drivers-dma-blen.patch
+    sha256sum: a74bbf9eda803ba42bf10ae1fa93483f1359fa64ab783f68dc964da6bd5ed6cf
+    module: zephyr
+    author: Alex Apostolu
+    email: aapostolu@tenstorrent.com
+    date: 2025-11-07
+    comments: |
+      Make data alignment in DMA blen test configurable according to its DT property
       dma-buf-addr-alignment.

--- a/zephyr/patches/zephyr/check-compliance.patch
+++ b/zephyr/patches/zephyr/check-compliance.patch
@@ -1,5 +1,5 @@
 diff --git a/scripts/ci/check_compliance.py b/scripts/ci/check_compliance.py
-index a0fa1348bb6..2268e4517b6 100755
+index a0fa1348bb6..f2bbd7e2278 100755
 --- a/scripts/ci/check_compliance.py
 +++ b/scripts/ci/check_compliance.py
 @@ -291,7 +291,7 @@ class CheckPatch(ComplianceTest):
@@ -20,7 +20,7 @@ index a0fa1348bb6..2268e4517b6 100755
  
          if len(tmp_output) > 0:
              kconfigs += tmp_output + "\n"
-@@ -1254,7 +1254,10 @@ flagged.
+@@ -1254,7 +1254,11 @@ flagged.
          "COMPILER_RT_RTLIB",
          "CRC",  # Used in TI CC13x2 / CC26x2 SDK comment
          "DEEP_SLEEP",  # #defined by RV32M1 in ext/
@@ -28,10 +28,11 @@ index a0fa1348bb6..2268e4517b6 100755
          "DESCRIPTION",
 +        "DMC_RUN_SMBUS_TESTS",
 +        "DMA_SG_XFER_SIZE",
++        "DMA_LOOP_TRANSFER_SIZE",
          "ERR",
          "ESP_DIF_LIBRARY",  # Referenced in CMake comment
          "EXPERIMENTAL",
-@@ -1279,6 +1282,7 @@ flagged.
+@@ -1279,6 +1283,7 @@ flagged.
          "IAR_LIBCPP",
          "IAR_SEMIHOSTING",
          "IAR_ZEPHYR_INIT",
@@ -39,7 +40,7 @@ index a0fa1348bb6..2268e4517b6 100755
          "IPC_SERVICE_ICMSG_BOND_NOTIFY_REPEAT_TO_MS", # Used in ICMsg tests for intercompatibility
                                                        # with older versions of the ICMsg.
          "LIBGCC_RTLIB",
-@@ -1415,6 +1419,7 @@ class SysbuildKconfigCheck(KconfigCheck):
+@@ -1415,6 +1420,7 @@ class SysbuildKconfigCheck(KconfigCheck):
      # A different allowlist is used for symbols prefixed with SB_CONFIG_ (omitted here).
      UNDEF_KCONFIG_ALLOWLIST = {
          # zephyr-keep-sorted-start re(^\s+")
@@ -47,7 +48,7 @@ index a0fa1348bb6..2268e4517b6 100755
          "FOO",
          "MY_IMAGE", # Used in sysbuild documentation as example
          "OTHER_APP_IMAGE_NAME", # Used in sysbuild documentation as example
-@@ -1585,17 +1590,25 @@ class LicenseAndCopyrightCheck(ComplianceTest):
+@@ -1585,17 +1591,25 @@ class LicenseAndCopyrightCheck(ComplianceTest):
              self.fmtd_failure(severity, title, rel_path, desc=desc or "", line=1)
  
      def run(self) -> None:
@@ -78,7 +79,7 @@ index a0fa1348bb6..2268e4517b6 100755
  
          project = Project.from_directory(GIT_TOP)
          report = ProjectSubsetReport.generate(project, changed_files, multiprocessing=False)
-@@ -2020,6 +2033,11 @@ class KeepSorted(ComplianceTest):
+@@ -2020,6 +2034,11 @@ class KeepSorted(ComplianceTest):
          if not mime_type.startswith("text/"):
              return
  

--- a/zephyr/patches/zephyr/tests-drivers-dma-blen.patch
+++ b/zephyr/patches/zephyr/tests-drivers-dma-blen.patch
@@ -1,0 +1,12 @@
+diff --git a/tests/drivers/dma/chan_blen_transfer/src/test_buffers.c b/tests/drivers/dma/chan_blen_transfer/src/test_buffers.c
+index 3ec893f15c3..d3d04ea22fa 100644
+--- a/tests/drivers/dma/chan_blen_transfer/src/test_buffers.c
++++ b/tests/drivers/dma/chan_blen_transfer/src/test_buffers.c
+@@ -8,5 +8,5 @@
+ 
+ #include "test_buffers.h"
+ 
+-__aligned(32) char tx_data[TEST_BUF_SIZE] = "It is harder to be kind than to be wise........";
+-__aligned(32) char rx_data[TEST_BUF_SIZE] = { 0 };
++__aligned(64) char tx_data[TEST_BUF_SIZE] = "It is harder to be kind than to be wise........";
++__aligned(64) char rx_data[TEST_BUF_SIZE] = { 0 };

--- a/zephyr/patches/zephyr/tests-drivers-dma-loop.patch
+++ b/zephyr/patches/zephyr/tests-drivers-dma-loop.patch
@@ -1,0 +1,15 @@
+diff --git a/tests/drivers/dma/loop_transfer/src/test_dma_loop.c b/tests/drivers/dma/loop_transfer/src/test_dma_loop.c
+index dd8a8633dde..667019c14a7 100644
+--- a/tests/drivers/dma/loop_transfer/src/test_dma_loop.c
++++ b/tests/drivers/dma/loop_transfer/src/test_dma_loop.c
+@@ -33,8 +33,8 @@
+ 
+ #define TRANSFER_LOOPS (4)
+ 
+-static __aligned(32) uint8_t tx_data[CONFIG_DMA_LOOP_TRANSFER_SIZE];
+-static __aligned(32) uint8_t rx_data[TRANSFER_LOOPS][CONFIG_DMA_LOOP_TRANSFER_SIZE] = { { 0 } };
++static __aligned(64) uint8_t tx_data[CONFIG_DMA_LOOP_TRANSFER_SIZE];
++static __aligned(64) uint8_t rx_data[TRANSFER_LOOPS][CONFIG_DMA_LOOP_TRANSFER_SIZE] = { { 0 } };
+ 
+ volatile uint32_t transfer_count;
+ volatile uint32_t done;


### PR DESCRIPTION
Align data TX and RX buffers to 64 bytes as needed by the NOC DMA engine.

Later on I will make the alignment configurable so it's favourable for upstream. But for now just so it's not blocking anything, I hardcoded the alignment to 64.