### PR TITLE
Remove >/dev/null 2>&1 from build_combined_fwbundle.sh

### DIFF
--- a/scripts/build-combined-fwbundle.sh
+++ b/scripts/build-combined-fwbundle.sh
@@ -62,8 +62,7 @@ for REV in $BOARD_REVS; do
   fi
 
   echo "Building $BOARD"
-  west build -d "${TEMP_DIR}${REV}" --sysbuild -p -b "$BOARD" app/smc \
-    >/dev/null 2>&1
+  west build -d "${TEMP_DIR}${REV}" --sysbuild -p -b "$BOARD" app/smc
 done
 
 echo "Creating fw_pack-$RELEASE.fwbundle"


### PR DESCRIPTION
TIcket
https://github.com/tenstorrent/tt-zephyr-platforms/issues/703

build_combined_fwbundle.sh fails silently and doesn't show the error to the user.

Changes
- Remove >/dev/null 2>&1 from build_combined_fwbundle.sh 