### PR TITLE
ci: build-fw: remove fetch-tags to avoid actions/checkout issue

### DIFF
--- a/.github/workflows/build-fw.yml
+++ b/.github/workflows/build-fw.yml
@@ -50,7 +50,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           path: tt-zephyr-platforms
-          fetch-tags: true
       - uses: ./tt-zephyr-platforms/.github/workflows/prepare-zephyr
         with:
           app-path: tt-zephyr-platforms


### PR DESCRIPTION
Remove the fetch-tags option because it causes a known issue with the checkout action.

https://github.com/actions/checkout/issues/1467

Link to failing CI job
https://github.com/tenstorrent/tt-zephyr-platforms/actions/runs/19310635313/job/55229730653