### PR TITLE
app: smc: pytest: remove chip object if arc timeout is set by KMD

### DIFF
--- a/app/smc/pytest/e2e_smoke.py
+++ b/app/smc/pytest/e2e_smoke.py
@@ -561,10 +561,12 @@ def arc_watchdog_test(asic_id):
             logger.warning(
                 "ARC did not reset, waiting 10 additional seconds to see if ARC core resets"
             )
+            del arc_chip
             time.sleep(10)
             rescan_pcie()
             arc_chip = pyluwen.detect_chips()[asic_id]
             hang_pc = arc_chip.axi_read32(ARC_HANG_PC_REG_ADDR)
+            del arc_chip
             if hang_pc == 0:
                 logger.error("ARC core was not reset after ten seconds")
                 return False


### PR DESCRIPTION
If arc timeout is set to 10 seconds by kmd, remove the chip object after we detect it again. Otherwise, we occasionally hit the -ENODEV error that occurs when trying to reuse a file descriptor from before the chip was reset.

Testing locally to P300C, this appears to resolve the intermittent error with the watchdog test