### PR TITLE
lib:tenstorrent:bh_arc: Set Recovery FW to Single SERDES

### DIFF
--- a/lib/tenstorrent/bh_arc/pcie.c
+++ b/lib/tenstorrent/bh_arc/pcie.c
@@ -469,14 +469,14 @@ static int pcie_init(void)
 	if (IS_ENABLED(CONFIG_TT_SMC_RECOVERY)) {
 		pci0_property_table = (FwTable_PciPropertyTable){
 			.pcie_mode = FwTable_PciPropertyTable_PcieMode_EP,
-			.num_serdes = 2,
+			.num_serdes = 1,
 			.pcie_bar0_size = PCIE_BAR0_SIZE_DEFAULT_MB,
 			.pcie_bar2_size = PCIE_BAR2_SIZE_DEFAULT_MB,
 			.pcie_bar4_size = PCIE_BAR4_SIZE_DEFAULT_MB,
 		};
 		pci1_property_table = (FwTable_PciPropertyTable){
 			.pcie_mode = FwTable_PciPropertyTable_PcieMode_EP,
-			.num_serdes = 2,
+			.num_serdes = 1,
 			.pcie_bar0_size = PCIE_BAR0_SIZE_DEFAULT_MB,
 			.pcie_bar2_size = PCIE_BAR2_SIZE_DEFAULT_MB,
 			.pcie_bar4_size = PCIE_BAR4_SIZE_DEFAULT_MB,


### PR DESCRIPTION
Some p300 cards were not enumerating with recovery/preflash firmware due to both SERDES being configured and second SERDES failing.
In production firmware, only one SERDES is configured and the 2 SERDES configuration is redundant. This change also fixes the failing p300 cases.