### PR TITLE
[DNM] ci: add initial gitlab CI file

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,6 +10,30 @@ build-job:
     - west update
     - cd /tt-zephyr
     - ./tt-zephyr-platforms/scripts/ci/build-grendel.sh
+  artifacts:
+    paths:
+      - /tt-zephyr/twister-out/
 
   tags:
     - 8-core
+
+# Use the build-job output artifacts in downstream jobs
+test-job:
+  dependencies:
+    - build-job
+
+  script:
+    # Pull tt-smc repo to run Zephyr tests
+    - git clone https://gitlab-ci-token:${CI_JOB_TOKEN}@yyz-gitlab.local.tenstorrent.com:tensix/tensix-hw/tt_smc.git
+    - cd tt_smc
+    - source bin/setup_env.sh
+    - module list || true
+    - bender checkout --force || bender checkout --force
+    - cp twister-out/tt_grendel_smc_tt_grendel_smc/zephyr/tests/integration/kernel/integration.kernel/zephyr/zephyr.bin \
+      ./firmware/zephyr/grendel_smc_hello_world_smp_zephyr/grendel_smc_hello_world_smp_zephyr.bin
+    - ttem tb_uvm/yaml/regression_smc_chiplet.yaml smc_zephyr_hello_world_smp_test \
+      --stack flist,cgen,compile_smc_chiplet,sim --wave --no-lsf --seed 1 --c compile_smc_chiplet
+
+  tags:
+    - chiplet-ip
+  timeout: 60m

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -36,11 +36,11 @@ test-job:
     - module list || true
     - bender checkout --force || bender checkout --force
     - ls -la $OUTDIR
-    - echo $PWD
-    - tree .
-    - cp $OUTDIR/tt_grendel_smc_tt_grendel_smc/zephyr/tests/integration/kernel/integration.kernel/zephyr/zephyr.bin \
-      ./firmware/zephyr/grendel_smc_hello_world_smp_zephyr/grendel_smc_hello_world_smp_zephyr.bin
-    - ttem tb_uvm/yaml/regression_smc_chiplet.yaml smc_zephyr_hello_world_smp_test \
+    - >
+      cp $OUTDIR/tt_grendel_smc_tt_grendel_smc/zephyr/tests/integration/kernel/integration.kernel/zephyr/zephyr.bin
+        ./firmware/zephyr/grendel_smc_hello_world_smp_zephyr/grendel_smc_hello_world_smp_zephyr.bin
+    - >
+      ttem tb_uvm/yaml/regression_smc_chiplet.yaml smc_zephyr_hello_world_smp_test
       --stack flist,cgen,compile_smc_chiplet,sim --wave --no-lsf --seed 1 --c compile_smc_chiplet
   tags:
     - chiplet-ip

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -31,7 +31,7 @@ test-job:
     - source bin/setup_env.sh
     - module list || true
     - bender checkout --force || bender checkout --force
-    - cp twister-out/tt_grendel_smc_tt_grendel_smc/zephyr/tests/integration/kernel/integration.kernel/zephyr/zephyr.bin \
+    - cp /tt-zephyr/twister-out/twister-out/tt_grendel_smc_tt_grendel_smc/zephyr/tests/integration/kernel/integration.kernel/zephyr/zephyr.bin \
       ./firmware/zephyr/grendel_smc_hello_world_smp_zephyr/grendel_smc_hello_world_smp_zephyr.bin
     - ttem tb_uvm/yaml/regression_smc_chiplet.yaml smc_zephyr_hello_world_smp_test \
       --stack flist,cgen,compile_smc_chiplet,sim --wave --no-lsf --seed 1 --c compile_smc_chiplet

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,6 +11,7 @@ build-job:
     - west update
     - cd /tt-zephyr
     - ./tt-zephyr-platforms/scripts/ci/build-grendel.sh
+    - ls -la /tt-zephyr/twister-out/
   artifacts:
     paths:
       - /tt-zephyr/twister-out/
@@ -31,6 +32,7 @@ test-job:
     - source bin/setup_env.sh
     - module list || true
     - bender checkout --force || bender checkout --force
+    - ls -la /tt-zephyr/twister-out/
     - cp /tt-zephyr/twister-out/twister-out/tt_grendel_smc_tt_grendel_smc/zephyr/tests/integration/kernel/integration.kernel/zephyr/zephyr.bin \
       ./firmware/zephyr/grendel_smc_hello_world_smp_zephyr/grendel_smc_hello_world_smp_zephyr.bin
     - ttem tb_uvm/yaml/regression_smc_chiplet.yaml smc_zephyr_hello_world_smp_test \

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,15 @@
+build-job:
+  image: ghcr.io/tenstorrent/tt-zephyr-platforms/ci-image:v19.4.2
+  script:
+    - cd /tt-zephyr/tt-zephyr-platforms
+    # Pull repo revision to run CI on
+    - git remote add ci $CI_REPOSITORY_URL
+    - git fetch ci $CI_COMMIT_SHA
+    - git checkout FETCH_HEAD
+    - west packages pip --install
+    - west update
+    - cd /tt-zephyr
+    - ./tt-zephyr-platforms/scripts/ci/build-grendel.sh
+
+  tags:
+    - chiplet-ip

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,3 +1,7 @@
+variables:
+  OUTDIR: $CI_PROJECT_DIR/twister-out
+
+
 build-job:
   stage: build
   image: ghcr.io/tenstorrent/tt-zephyr-platforms/ci-image:v19.4.2
@@ -11,11 +15,10 @@ build-job:
     - west update
     - cd /tt-zephyr
     - ./tt-zephyr-platforms/scripts/ci/build-grendel.sh
-    - ls -la /tt-zephyr/twister-out/
+    - ls -la $OUTDIR
   artifacts:
     paths:
-      - /tt-zephyr/twister-out/
-
+      - $OUTDIR
   tags:
     - 8-core
 
@@ -32,12 +35,11 @@ test-job:
     - source bin/setup_env.sh
     - module list || true
     - bender checkout --force || bender checkout --force
-    - ls -la /tt-zephyr/twister-out/
-    - cp /tt-zephyr/twister-out/twister-out/tt_grendel_smc_tt_grendel_smc/zephyr/tests/integration/kernel/integration.kernel/zephyr/zephyr.bin \
+    - ls -la $OUTDIR
+    - cp $OUTDIR/tt_grendel_smc_tt_grendel_smc/zephyr/tests/integration/kernel/integration.kernel/zephyr/zephyr.bin \
       ./firmware/zephyr/grendel_smc_hello_world_smp_zephyr/grendel_smc_hello_world_smp_zephyr.bin
     - ttem tb_uvm/yaml/regression_smc_chiplet.yaml smc_zephyr_hello_world_smp_test \
       --stack flist,cgen,compile_smc_chiplet,sim --wave --no-lsf --seed 1 --c compile_smc_chiplet
-
   tags:
     - chiplet-ip
   timeout: 60m

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -36,12 +36,8 @@ test-job:
     - module list || true
     - bender checkout --force || bender checkout --force
     - ls -la $OUTDIR
-    - >
-      cp $OUTDIR/tt_grendel_smc_tt_grendel_smc/zephyr/tests/integration/kernel/integration.kernel/zephyr/zephyr.bin
-        ./firmware/zephyr/grendel_smc_hello_world_smp_zephyr/grendel_smc_hello_world_smp_zephyr.bin
-    - >
-      ttem tb_uvm/yaml/regression_smc_chiplet.yaml smc_zephyr_hello_world_smp_test
-      --stack flist,cgen,compile_smc_chiplet,sim --wave --no-lsf --seed 1 --c compile_smc_chiplet
+    - cp $OUTDIR/tt_grendel_smc_tt_grendel_smc/zephyr/tests/integration/kernel/integration.kernel/zephyr/zephyr.bin ./firmware/zephyr/grendel_smc_hello_world_smp_zephyr/grendel_smc_hello_world_smp_zephyr.bin
+    - ttem tb_uvm/yaml/regression_smc_chiplet.yaml smc_zephyr_hello_world_smp_test --stack flist,cgen,compile_smc_chiplet,sim --wave --no-lsf --seed 1 --c compile_smc_chiplet
   tags:
     - chiplet-ip
   timeout: 60m

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -37,7 +37,7 @@ test-job:
     - bender checkout --force || bender checkout --force
     - ls -la $OUTDIR
     - cp $OUTDIR/tt_grendel_smc_tt_grendel_smc/zephyr/tests/integration/kernel/integration.kernel/zephyr/zephyr.bin ./firmware/zephyr/grendel_smc_hello_world_smp_zephyr/grendel_smc_hello_world_smp_zephyr.bin
-    - ttem tb_uvm/yaml/regression_smc_chiplet.yaml smc_zephyr_hello_world_smp_test --stack flist,cgen,compile_smc_chiplet,sim --wave --no-lsf --seed 1 --c compile_smc_chiplet
+    - ttem tb_uvm/yaml/regression_smc_chiplet.yaml smc_zephyr_hello_world_smp_test --stack flist,cgen,compile_smc_chiplet,sim --no-wave --lsf --seed 1 --c compile_smc_chiplet
   tags:
     - chiplet-ip
   timeout: 60m

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -36,7 +36,7 @@ test-job:
     - module list || true
     - bender checkout --force || bender checkout --force
     - ls -la $OUTDIR
-    - cp $OUTDIR/tt_grendel_smc_tt_grendel_smc/zephyr/tests/integration/kernel/integration.kernel/zephyr/zephyr.bin ./firmware/zephyr/grendel_smc_hello_world_smp_zephyr/grendel_smc_hello_world_smp_zephyr.bin
+    - cp $OUTDIR/tt_grendel_smc_tt_grendel_smc/zephyr/tests/arch/riscv/atomic/arch.riscv.atomic/zephyr/zephyr.bin ./firmware/zephyr/grendel_smc_hello_world_smp_zephyr/grendel_smc_hello_world_smp_zephyr.bin
     - ttem tb_uvm/yaml/regression_smc_chiplet.yaml smc_zephyr_hello_world_smp_test --stack flist,cgen,compile_smc_chiplet,sim --no-wave --lsf --seed 1 --c compile_smc_chiplet
   artifacts:
     when: always

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -36,7 +36,8 @@ test-job:
     - module list || true
     - bender checkout --force || bender checkout --force
     - ls -la $OUTDIR
-    - tree $OUTDIR
+    - echo $PWD
+    - tree .
     - cp $OUTDIR/tt_grendel_smc_tt_grendel_smc/zephyr/tests/integration/kernel/integration.kernel/zephyr/zephyr.bin \
       ./firmware/zephyr/grendel_smc_hello_world_smp_zephyr/grendel_smc_hello_world_smp_zephyr.bin
     - ttem tb_uvm/yaml/regression_smc_chiplet.yaml smc_zephyr_hello_world_smp_test \

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,7 +24,7 @@ test-job:
 
   script:
     # Pull tt-smc repo to run Zephyr tests
-    - git clone https://gitlab-ci-token:${CI_JOB_TOKEN}@yyz-gitlab.local.tenstorrent.com:tensix/tensix-hw/tt_smc.git
+    - git clone https://gitlab-ci-token:${CI_JOB_TOKEN}@yyz-gitlab.local.tenstorrent.com/tensix/tensix-hw/tt_smc.git
     - cd tt_smc
     - source bin/setup_env.sh
     - module list || true

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -38,6 +38,10 @@ test-job:
     - ls -la $OUTDIR
     - cp $OUTDIR/tt_grendel_smc_tt_grendel_smc/zephyr/tests/integration/kernel/integration.kernel/zephyr/zephyr.bin ./firmware/zephyr/grendel_smc_hello_world_smp_zephyr/grendel_smc_hello_world_smp_zephyr.bin
     - ttem tb_uvm/yaml/regression_smc_chiplet.yaml smc_zephyr_hello_world_smp_test --stack flist,cgen,compile_smc_chiplet,sim --no-wave --lsf --seed 1 --c compile_smc_chiplet
+  artifacts:
+    when: always
+    paths:
+      - tb_uvm/out/
   tags:
     - chiplet-ip
   timeout: 60m

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,5 @@
 build-job:
+  stage: build
   image: ghcr.io/tenstorrent/tt-zephyr-platforms/ci-image:v19.4.2
   script:
     - cd /tt-zephyr/tt-zephyr-platforms
@@ -19,12 +20,13 @@ build-job:
 
 # Use the build-job output artifacts in downstream jobs
 test-job:
+  stage: test
   dependencies:
     - build-job
 
   script:
     # Pull tt-smc repo to run Zephyr tests
-    - git clone https://gitlab-ci-token:${CI_JOB_TOKEN}@yyz-gitlab.local.tenstorrent.com/tensix/tensix-hw/tt_smc.git
+    - git clone git@yyz-gitlab.local.tenstorrent.com:tensix/tensix-hw/tt_smc.git
     - cd tt_smc
     - source bin/setup_env.sh
     - module list || true

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -41,7 +41,7 @@ test-job:
   artifacts:
     when: always
     paths:
-      - tb_uvm/out/
+      - tt_smc/tb_uvm/out/
   tags:
     - chiplet-ip
   timeout: 60m

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -36,6 +36,7 @@ test-job:
     - module list || true
     - bender checkout --force || bender checkout --force
     - ls -la $OUTDIR
+    - tree $OUTDIR
     - cp $OUTDIR/tt_grendel_smc_tt_grendel_smc/zephyr/tests/integration/kernel/integration.kernel/zephyr/zephyr.bin \
       ./firmware/zephyr/grendel_smc_hello_world_smp_zephyr/grendel_smc_hello_world_smp_zephyr.bin
     - ttem tb_uvm/yaml/regression_smc_chiplet.yaml smc_zephyr_hello_world_smp_test \

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,4 +12,4 @@ build-job:
     - ./tt-zephyr-platforms/scripts/ci/build-grendel.sh
 
   tags:
-    - chiplet-ip
+    - 8-core

--- a/scripts/ci/build-grendel.sh
+++ b/scripts/ci/build-grendel.sh
@@ -9,4 +9,4 @@
 OUTDIR=${OUTDIR:-twister-out}
 
 # Build all grendel platforms
-./zephyr/scripts/twister -p tt_grendel_smc -T ./zephyr/samples/hello_world --outdir $OUTDIR
+./zephyr/scripts/twister -p tt_grendel_smc -T ./zephyr/tests/integration/kernel --outdir $OUTDIR

--- a/scripts/ci/build-grendel.sh
+++ b/scripts/ci/build-grendel.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Tenstorrent AI ULC
+
+# This script builds grendel platforms within the tt-zephyr-platforms CI
+# image environment.
+
+# Build all grendel platforms
+./zephyr/scripts/twister -p tt_grendel_smc -T ./zephyr/samples/hello_world

--- a/scripts/ci/build-grendel.sh
+++ b/scripts/ci/build-grendel.sh
@@ -6,5 +6,7 @@
 # This script builds grendel platforms within the tt-zephyr-platforms CI
 # image environment.
 
+OUTDIR=${OUTDIR:-twister-out}
+
 # Build all grendel platforms
-./zephyr/scripts/twister -p tt_grendel_smc -T ./zephyr/samples/hello_world
+./zephyr/scripts/twister -p tt_grendel_smc -T ./zephyr/samples/hello_world --outdir $OUTDIR

--- a/scripts/ci/build-grendel.sh
+++ b/scripts/ci/build-grendel.sh
@@ -9,4 +9,4 @@
 OUTDIR=${OUTDIR:-twister-out}
 
 # Build all grendel platforms
-./zephyr/scripts/twister -p tt_grendel_smc -T ./zephyr/tests/integration/kernel --outdir $OUTDIR
+./zephyr/scripts/twister -p tt_grendel_smc -T ./zephyr/tests/arch/riscv/atomic/ --outdir $OUTDIR


### PR DESCRIPTION
For now this PR will be a testbed where additional commits are pushed (if gitlab CI triggers on this PR at all, which is not a given)

This PR needs to be created from tt-zephyr-platforms instead of a fork due to restrictions on how gitlab CI triggers PR jobs