### PR TITLE
.github: workflows: hardware-long: add manufacturing test job

### DIFF
--- a/.github/workflows/build-fw.yml
+++ b/.github/workflows/build-fw.yml
@@ -393,6 +393,11 @@ jobs:
         shell: bash
         run: |
           ./build-flm.sh
+      - name: Upload Flash Loader Module
+        uses: actions/upload-artifact@v4
+        with:
+          name: bh-flm
+          path: tt-system-firmware/scripts/tooling/blackhole_recovery/data/bh_flm/build/*.flm
 
   smc-build-only-tests:
     runs-on: ubuntu-24.04

--- a/.github/workflows/hardware-long.yml
+++ b/.github/workflows/hardware-long.yml
@@ -33,6 +33,7 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       matrix-config: ${{ steps.gen-config.outputs.matrix-config }}
+      mfg-matrix-config: ${{ steps.gen-config.outputs.mfg-matrix-config }}
     steps:
       - uses: actions/checkout@v4
       - id: gen-config
@@ -41,6 +42,9 @@ jobs:
           # Filter to only Blackhole boards (product == "bh"), then remove the product field
           MATRIX_CONFIG="$(jq -c '[.[] | select(.product == "bh") | del(.product)]' .github/ci_boards.json)"
           echo "matrix-config=$MATRIX_CONFIG" | tee -a $GITHUB_OUTPUT
+          # Same filter, but exclude galaxy board (for manufacturing tests)
+          MFG_MATRIX_CONFIG="$(jq -c '[.[] | select(.product == "bh" and .board != "galaxy") | del(.product)]' .github/ci_boards.json)"
+          echo "mfg-matrix-config=$MFG_MATRIX_CONFIG" | tee -a $GITHUB_OUTPUT
 
   e2e-stress-test:
     name: BH E2E Stress Test on ${{ matrix.config.board }}
@@ -164,3 +168,107 @@ jobs:
             exit 1
           fi
           echo "Successfully verified that tensix-enabled column count is correct: $TENSIX_COUNT"
+
+  manufacturing-test:
+    needs: [build-fw-artifact, gen-config]
+    strategy:
+      fail-fast: false
+      matrix:
+        config: ${{ fromJson(needs.gen-config.outputs.mfg-matrix-config) }}
+    runs-on: ${{ matrix.config.runs-on }}
+    container:
+      image: ghcr.io/tenstorrent/tt-zephyr-platforms/ci-image:v18.12.0-rc1
+      volumes:
+        - /dev/hugepages-1G:/dev/hugepages-1G
+        - /opt/tenstorrent/kmd-builds/:/opt/tenstorrent/kmd-builds/
+      options: '--device /dev/tenstorrent --device /dev/bus/usb --privileged'
+    steps:
+      - name: Cleanup State
+        if: ${{ always() }}
+        run: |
+          ls -la
+          rm -rf *
+
+      - name: Checkout
+        uses: actions/checkout@v4.2.2
+        with:
+          path: tt-system-firmware
+
+      - name: Prepare Container
+        uses: ./tt-system-firmware/.github/workflows/prepare-container
+        with:
+          app-path: tt-system-firmware
+          kmd-version: ${{ matrix.config.kmd_build }}
+
+      - name: Derive board properties
+        id: board-map
+        shell: bash
+        run: |
+          BOARD="${{ matrix.config.board }}"
+          ASSEMBLY_BOARD=$(echo "$BOARD" | sed 's/[a-z]$//')
+          # p100 uses the same assembly test firmware as p150
+          if [[ "$ASSEMBLY_BOARD" == "p100" ]]; then
+            ASSEMBLY_BOARD="p150"
+          fi
+          echo "assembly_board=$ASSEMBLY_BOARD" | tee -a $GITHUB_OUTPUT
+          # p300 variants have 2 ASICs, all others have 1
+          if [[ "$ASSEMBLY_BOARD" == p300 ]]; then
+            echo "num_asics=2" | tee -a $GITHUB_OUTPUT
+          else
+            echo "num_asics=1" | tee -a $GITHUB_OUTPUT
+          fi
+
+      - name: Download preflash firmware
+        uses: actions/download-artifact@v4
+        with:
+          name: preflash-fw
+          path: artifacts/preflash
+
+      - name: Download assembly test firmware
+        uses: actions/download-artifact@v4
+        with:
+          name: assembly-fw-${{ steps.board-map.outputs.assembly_board }}
+          path: artifacts/assembly-fw
+
+      - name: Download assembly MCUBoot
+        uses: actions/download-artifact@v4
+        with:
+          name: assembly-mcuboot-${{ steps.board-map.outputs.assembly_board }}
+          path: artifacts/assembly-mcuboot
+
+      - name: Download combined firmware bundle
+        uses: actions/download-artifact@v4
+        with:
+          name: combined-fwbundle
+          path: artifacts/fwbundle
+
+      - name: Download Flash Loader Module
+        uses: actions/download-artifact@v4
+        with:
+          name: bh-flm
+          path: tt-system-firmware/scripts/tooling/blackhole_recovery/data/bh_flm/build
+
+      - name: Run manufacturing test
+        shell: bash
+        run: |
+          tt-system-firmware/scripts/ci/run-manufacturing-test.sh \
+            -p artifacts/preflash \
+            -m artifacts/assembly-mcuboot \
+            -a artifacts/assembly-fw \
+            -f artifacts/fwbundle \
+            ${{ matrix.config.board }}
+
+      # ---- Debug info on failure ----
+      - name: Print RTT logs
+        if: ${{ failure() }}
+        working-directory: tt-system-firmware
+        run: |
+          echo "DMC RTT logs:"
+          python3 ./scripts/dmc_rtt.py -n
+          echo "SMC RTT logs:"
+          python3 ./scripts/smc_console.py --rtt -n
+          NUM_ASICS=${{ steps.board-map.outputs.num_asics }}
+          for ((i=0; i<NUM_ASICS; i++)); do
+            echo "SMC state dump for ASIC $i:"
+            python3 ./scripts/dump_smc_state.py --asic-id $i
+          done

--- a/scripts/ci/run-manufacturing-test.sh
+++ b/scripts/ci/run-manufacturing-test.sh
@@ -1,0 +1,156 @@
+#!/bin/env bash
+
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 Tenstorrent AI ULC
+
+# This script runs the manufacturing test sequence for Blackhole boards.
+# It assumes the following:
+# - pyocd is installed and available in the PATH
+# - tt-flash is installed and available in the PATH
+# - The DUT is connected and accessible via JTAG
+# - All required firmware artifacts are available in the specified directories
+
+set -e
+
+TT_Z_P_ROOT=$(realpath "$(dirname "$(realpath "$0")")"/../..)
+
+function print_help {
+	echo "Usage: $(basename "$0") [options] <board_name>"
+	echo ""
+	echo "Run the manufacturing test sequence for a Blackhole board."
+	echo ""
+	echo "Options:"
+	echo "  -p <dir>   Directory containing preflash ihex (default: artifacts/preflash)"
+	echo "  -m <dir>   Directory containing assembly MCUBoot ELF"
+	echo "             (default: artifacts/assembly-mcuboot)"
+	echo "  -a <dir>   Directory containing assembly app hex (default: artifacts/assembly-fw)"
+	echo "  -f <dir>   Directory containing production fwbundle (default: artifacts/fwbundle)"
+	echo "  -h         Show this help"
+}
+
+if [ $# -lt 1 ]; then
+	print_help
+	exit 1
+fi
+
+PREFLASH_DIR="artifacts/preflash"
+MCUBOOT_DIR="artifacts/assembly-mcuboot"
+ASSEMBLY_FW_DIR="artifacts/assembly-fw"
+FWBUNDLE_DIR="artifacts/fwbundle"
+
+while getopts "p:m:a:f:h" opt; do
+	case "$opt" in
+		p) PREFLASH_DIR=$OPTARG ;;
+		m) MCUBOOT_DIR=$OPTARG ;;
+		a) ASSEMBLY_FW_DIR=$OPTARG ;;
+		f) FWBUNDLE_DIR=$OPTARG ;;
+		h) print_help; exit 0 ;;
+		\?) print_help; exit 1 ;;
+	esac
+done
+shift $((OPTIND-1))
+
+BOARD=$1
+
+if [ -z "$BOARD" ]; then
+	echo "ERROR: Board name is required"
+	print_help
+	exit 1
+fi
+
+# Derive board properties
+ASSEMBLY_BOARD=$(echo "$BOARD" | sed 's/[a-z]$//')
+# p300 variants have 2 ASICs, all others have 1
+if [[ "$ASSEMBLY_BOARD" == p300 ]]; then
+	NUM_ASICS=2
+else
+	NUM_ASICS=1
+fi
+
+echo "Board: $BOARD, Assembly board: $ASSEMBLY_BOARD, Num ASICs: $NUM_ASICS"
+echo "Preflash dir: $PREFLASH_DIR"
+echo "MCUBoot dir: $MCUBOOT_DIR"
+echo "Assembly FW dir: $ASSEMBLY_FW_DIR"
+echo "FW bundle dir: $FWBUNDLE_DIR"
+
+function verify_pcie_enumeration {
+	local DESCRIPTION=$1
+	echo "Verifying PCIe enumeration ($DESCRIPTION)..."
+	local TIMEOUT=60
+	local ELAPSED=0
+	while true; do
+		local COUNT=0
+		for dev in /sys/bus/pci/devices/*/vendor; do
+			if [ -f "$dev" ] && [ "$(cat "$dev")" = "0x1e52" ]; then
+				COUNT=$((COUNT + 1))
+			fi
+		done
+		echo "Detected $COUNT Tenstorrent PCIe endpoint(s), expected $NUM_ASICS"
+		if [ "$COUNT" -ge "$NUM_ASICS" ]; then
+			echo "PASS: All $NUM_ASICS endpoint(s) enumerated"
+			return 0
+		fi
+		if [ "$ELAPSED" -ge "$TIMEOUT" ]; then
+			echo "FAIL: Only $COUNT of $NUM_ASICS endpoint(s)" \
+				"enumerated after ${TIMEOUT}s"
+			return 1
+		fi
+		echo "Rescanning PCIe bus..."
+		echo 1 > /sys/bus/pci/rescan
+		sleep 2
+		ELAPSED=$((ELAPSED + 2))
+	done
+}
+
+# ---- Step 1: Erase SPI + flash preflash ihex ----
+echo "=== Step 1: Erase SPI and flash preflash ihex ==="
+PREFLASH_IHEX=$(ls "$PREFLASH_DIR"/preflash-*.ihex | head -1)
+echo "Using preflash image: $PREFLASH_IHEX"
+python3 "$TT_Z_P_ROOT"/scripts/spi_flash.py \
+	--board-name "$BOARD" --no-prompt -v full_erase
+python3 "$TT_Z_P_ROOT"/scripts/spi_flash.py \
+	--board-name "$BOARD" --no-prompt -v \
+	write_from_ihex "$PREFLASH_IHEX"
+
+# ---- Step 2: Flash assembly test FW to DMC via pyocd ----
+echo "=== Step 2: Flash assembly test firmware to DMC ==="
+MCUBOOT_ELF="$MCUBOOT_DIR/zephyr.elf"
+APP_HEX="$ASSEMBLY_FW_DIR/zephyr.signed.hex"
+
+echo "Flashing MCUBoot bootloader: $MCUBOOT_ELF"
+echo "Flashing assembly test app: $APP_HEX"
+
+if [ ! -f "$MCUBOOT_ELF" ]; then
+	echo "ERROR: MCUBoot ELF not found at $MCUBOOT_ELF"
+	exit 1
+fi
+if [ ! -f "$APP_HEX" ]; then
+	echo "ERROR: Assembly test app hex not found at $APP_HEX"
+	exit 1
+fi
+python3 "$TT_Z_P_ROOT"/scripts/dmc_flash.py --no-prompt -v \
+	flash "$APP_HEX" "$MCUBOOT_ELF"
+
+# ---- Step 3: DMC reset (simulate power-on) ----
+echo "=== Step 3: DMC reset after assembly flash ==="
+python3 "$TT_Z_P_ROOT"/scripts/dmc_reset.py
+
+# ---- Step 4: Verify PCIe enumeration (assembly test FW + preflash) ----
+echo "=== Step 4: Verify PCIe enumeration (assembly test FW) ==="
+verify_pcie_enumeration "assembly test FW"
+
+# ---- Step 5: Flash production FW via tt-flash ----
+echo "=== Step 5: Flash production firmware ==="
+FWBUNDLE=$(ls "$FWBUNDLE_DIR"/fw_pack*.fwbundle | head -1)
+echo "Using firmware bundle: $FWBUNDLE"
+tt-flash "$FWBUNDLE" --force
+
+# ---- Step 6: DMC reset (simulate cold boot after bootstrap) ----
+echo "=== Step 6: DMC reset after production flash ==="
+python3 "$TT_Z_P_ROOT"/scripts/dmc_reset.py
+
+# ---- Step 7: Verify PCIe enumeration (production FW) ----
+echo "=== Step 7: Verify PCIe enumeration (production FW) ==="
+verify_pcie_enumeration "production FW"
+
+echo "=== Manufacturing test completed successfully! ==="

--- a/scripts/dmc_flash.py
+++ b/scripts/dmc_flash.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+STM32 DMC internal flash programmer for Blackhole PCIe cards.
+
+Programs firmware files (HEX, ELF) to the STM32 DMC's internal flash
+via the SWD debug interface using pyocd.
+
+Examples:
+    python dmc_flash.py --no-prompt flash app.signed.hex mcuboot.elf
+    python dmc_flash.py --no-prompt --adapter-id 1234 flash app.hex
+"""
+
+import argparse
+import logging
+import os
+import sys
+from pathlib import Path
+
+from pyocd.flash.file_programmer import FileProgrammer
+
+import pyocd_utils
+
+logger = logging.getLogger(Path(__file__).stem)
+
+
+def cmd_flash(args):
+    """Program one or more firmware files to STM32 internal flash, then reset."""
+    for fw_file in args.files:
+        fw_path = Path(fw_file)
+        if not fw_path.is_file():
+            logger.error("Firmware file not found: %s", fw_path)
+            return os.EX_NOINPUT
+
+    session = pyocd_utils.get_session(
+        pyocd_config=None, adapter_id=args.adapter_id, no_prompt=args.no_prompt
+    )
+    session.open()
+    try:
+        for fw_file in args.files:
+            logger.info("Programming %s ...", fw_file)
+            FileProgrammer(session).program(fw_file)
+        logger.info("Resetting target...")
+        session.board.target.reset_and_halt()
+        session.board.target.resume()
+    finally:
+        session.close()
+
+    logger.info("Flash complete.")
+    return os.EX_OK
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="STM32 DMC internal flash programmer",
+        allow_abbrev=False,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    pyocd_utils.add_common_args(parser)
+
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    flash_parser = subparsers.add_parser(
+        "flash",
+        help="Program firmware file(s) to STM32 internal flash and reset",
+    )
+    flash_parser.add_argument(
+        "files",
+        nargs="+",
+        help="Firmware file(s) to program (.hex, .elf)",
+    )
+
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    level = logging.WARNING
+    if args.verbose >= 2:
+        level = logging.DEBUG
+    elif args.verbose >= 1:
+        level = logging.INFO
+    logging.basicConfig(level=level, format="%(name)s: %(levelname)s: %(message)s")
+
+    if args.command == "flash":
+        return cmd_flash(args)
+    else:
+        logger.error("Unknown command: %s", args.command)
+        return os.EX_USAGE
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/pyocd_utils.py
+++ b/scripts/pyocd_utils.py
@@ -112,6 +112,41 @@ def create_session(pyocd_config=None, adapter_id=None, no_prompt=False, target=N
     return session
 
 
+def add_common_args(parser, *, adapter_id=True, no_prompt=True, verbose=True):
+    """Add standard pyocd-related CLI arguments to an argparse parser.
+
+    Each flag can be individually disabled by passing ``False``.
+
+    Args:
+        parser:     The :class:`argparse.ArgumentParser` to extend.
+        adapter_id: Add ``--adapter-id`` flag.
+        no_prompt:  Add ``--no-prompt`` flag.
+        verbose:    Add ``-v``/``--verbose`` flag.
+    """
+    if adapter_id:
+        parser.add_argument(
+            "--adapter-id",
+            type=str,
+            default=None,
+            help="ST-Link adapter serial / unique ID",
+        )
+    if no_prompt:
+        parser.add_argument(
+            "--no-prompt",
+            action="store_true",
+            default=False,
+            help="Do not prompt for adapter selection; use the first available probe",
+        )
+    if verbose:
+        parser.add_argument(
+            "-v",
+            "--verbose",
+            action="count",
+            default=0,
+            help="Increase logging verbosity (repeat for more)",
+        )
+
+
 def get_session(pyocd_config=None, adapter_id=None, no_prompt=False, target=None):
     """Like :func:`create_session`, but retries once after an ST-Link
     USB reset if the initial connection fails.

--- a/scripts/set-p300-jtag.py
+++ b/scripts/set-p300-jtag.py
@@ -30,17 +30,7 @@ def parse_args():
         help="JTAG mux to configure: 'ARC' for ARC core, 'SYS' for system JTAG",
     )
     parser.add_argument("asic", type=int, choices=[0, 1], help="ASIC number (0 or 1)")
-    parser.add_argument(
-        "--adapter-id",
-        type=str,
-        help="Adapter ID for the ST-Link device used in recovery",
-    )
-    parser.add_argument(
-        "--no-prompt",
-        default=False,
-        help="Do not prompt for adapter if none is provided, use first available",
-        action="store_true",
-    )
+    pyocd_utils.add_common_args(parser, verbose=False)
     return parser.parse_args()
 
 

--- a/scripts/spi_flash.py
+++ b/scripts/spi_flash.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Standalone SPI flash utility for Blackhole PCIe cards.
+
+Erases or programs the external SPI EEPROM through the STM32 DMC's
+JTAG/SWD debug interface using pyocd. By default the script operates on
+all ASICs of a board. Use ``--asic-index`` to target a single ASIC
+(e.g. on p300 boards which have two).
+
+Examples:
+    python spi_flash.py --board-name p100a full_erase
+    python spi_flash.py --board-name p100a write_from_ihex preflash.ihex
+    python spi_flash.py --board-name p300a full_erase              # erases both ASICs
+    python spi_flash.py --board-name p300a --asic-index 0 full_erase   # left ASIC only
+    python spi_flash.py --board-name p300a write_from_ihex preflash.ihex
+"""
+
+import argparse
+import logging
+import os
+import sys
+import time
+from pathlib import Path
+
+from pyocd.flash.file_programmer import FileProgrammer
+from pyocd.flash.eraser import FlashEraser
+
+import pyocd_utils
+
+logger = logging.getLogger(Path(__file__).stem)
+
+
+# ---------------------------------------------------------------------------
+# Sub-commands
+# ---------------------------------------------------------------------------
+
+
+def _select_asics(board_metadata, board_name, asic_index):
+    """Return the list of (index, asic) pairs to operate on.
+
+    If *asic_index* is ``None`` all ASICs for the board are returned.
+    Otherwise only the requested ASIC is returned (with validation).
+    """
+    if board_name not in board_metadata:
+        logger.error(
+            "Unknown board name: %s. Supported: %s",
+            board_name,
+            list(board_metadata.keys()),
+        )
+        return None
+
+    asics = board_metadata[board_name]
+
+    if asic_index is not None:
+        if asic_index < 0 or asic_index >= len(asics):
+            logger.error(
+                "ASIC index %d out of range for board %s (has %d ASIC(s))",
+                asic_index,
+                board_name,
+                len(asics),
+            )
+            return None
+        return [(asic_index, asics[asic_index])]
+
+    return list(enumerate(asics))
+
+
+def cmd_full_erase(args):
+    """Erase the SPI flash on the specified board (all ASICs or one)."""
+    board_metadata = pyocd_utils.load_board_metadata()
+    selected = _select_asics(board_metadata, args.board_name, args.asic_index)
+    if selected is None:
+        return os.EX_DATAERR
+
+    for idx, asic in selected:
+        pyocd_config = pyocd_utils.PYOCD_FLM_PATH / asic["pyocd-config"]
+        logger.info("Erasing SPI flash on ASIC %d (%s)...", idx, asic["name"])
+
+        session = pyocd_utils.get_session(pyocd_config, args.adapter_id, args.no_prompt)
+        session.open()
+        try:
+            FlashEraser(session, FlashEraser.Mode.CHIP).erase()
+        finally:
+            session.close()
+
+        logger.info("ASIC %d SPI flash erased.", idx)
+        time.sleep(1)
+
+    logger.info(
+        "Full erase complete for board %s (%d ASIC(s)).",
+        args.board_name,
+        len(selected),
+    )
+    return os.EX_OK
+
+
+def cmd_write_from_ihex(args):
+    """Write an Intel HEX file to SPI flash on the specified board (all ASICs or one)."""
+    board_metadata = pyocd_utils.load_board_metadata()
+    selected = _select_asics(board_metadata, args.board_name, args.asic_index)
+    if selected is None:
+        return os.EX_DATAERR
+
+    ihex_file = Path(args.file)
+    if not ihex_file.is_file():
+        logger.error("Intel HEX file not found: %s", ihex_file)
+        return os.EX_NOINPUT
+
+    for idx, asic in selected:
+        pyocd_config = pyocd_utils.PYOCD_FLM_PATH / asic["pyocd-config"]
+        logger.info(
+            "Writing %s to SPI flash on ASIC %d (%s)...",
+            ihex_file,
+            idx,
+            asic["name"],
+        )
+
+        session = pyocd_utils.get_session(pyocd_config, args.adapter_id, args.no_prompt)
+        session.open()
+        try:
+            FileProgrammer(session).program(str(ihex_file), file_format="hex")
+        finally:
+            session.close()
+
+        logger.info("ASIC %d SPI flash programmed.", idx)
+        time.sleep(1)
+
+    logger.info(
+        "Write complete for board %s (%d ASIC(s)).",
+        args.board_name,
+        len(selected),
+    )
+    return os.EX_OK
+
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="SPI flash utility for Blackhole PCIe cards",
+        allow_abbrev=False,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "--board-name",
+        type=str,
+        required=True,
+        help="Board name as listed in board_metadata.yaml (e.g. p100a, p150a, p300a)",
+    )
+    parser.add_argument(
+        "--asic-index",
+        type=int,
+        default=None,
+        help="Operate on a single ASIC by index (0-based). "
+        "If omitted, all ASICs on the board are targeted.",
+    )
+    pyocd_utils.add_common_args(parser)
+
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    # full_erase
+    subparsers.add_parser(
+        "full_erase",
+        help="Erase the entire SPI flash (all ASICs unless --asic-index is given)",
+    )
+
+    # write_from_ihex
+    write_parser = subparsers.add_parser(
+        "write_from_ihex",
+        help="Write an Intel HEX file to SPI flash (all ASICs unless --asic-index is given)",
+    )
+    write_parser.add_argument(
+        "file",
+        type=str,
+        help="Path to the Intel HEX (.ihex) file to program",
+    )
+
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    level = logging.WARNING
+    if args.verbose >= 2:
+        level = logging.DEBUG
+    elif args.verbose >= 1:
+        level = logging.INFO
+    logging.basicConfig(level=level, format="%(name)s: %(levelname)s: %(message)s")
+
+    if args.command == "full_erase":
+        return cmd_full_erase(args)
+    elif args.command == "write_from_ihex":
+        return cmd_write_from_ihex(args)
+    else:
+        logger.error("Unknown command: %s", args.command)
+        return os.EX_USAGE
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tooling/blackhole_recovery/recover-blackhole.py
+++ b/scripts/tooling/blackhole_recovery/recover-blackhole.py
@@ -55,17 +55,12 @@ def parse_args():
         default="auto",
         help="Board ID to program into the board's EEPROM",
     )
-    parser.add_argument("--adapter-id", help="Adapter ID to use for pyocd")
     parser.add_argument(
         "--force",
         action="store_true",
         help="Forcibly recover the card, even if sanity checks pass",
     )
-    parser.add_argument(
-        "--no-prompt",
-        action="store_true",
-        help="Don't prompt for adapter if multiple are found",
-    )
+    pyocd_utils.add_common_args(parser, verbose=False)
     return parser.parse_args()
 
 


### PR DESCRIPTION
Add a manufacturing-test job to the HW Soak workflow that validates the full manufacturing flash and boot sequence on Blackhole boards:
      1. Erase SPI and flash preflash ihex
      2. Flash assembly test firmware (MCUBoot + app) to DMC via STM32Programmer
      3. Reset DMC and verify PCIe enumeration with assembly test FW
      4. Flash production firmware via tt-flash
      5. Reset DMC and verify PCIe enumeration with production FW