### PR TITLE
app: dmc: add dmc_command_code handler

### DIFF
--- a/app/dmc/src/main.c
+++ b/app/dmc/src/main.c
@@ -34,6 +34,7 @@
 #include <tenstorrent/tt_smbus_regs.h>
 
 #define RESET_UNIT_ARC_PC_CORE_0 0x80030C00
+#define RESET_UNIT_SCRATCH_0 0x80030060
 
 #define INITIAL_FAN_SPEED 35
 #define LED_BLINK_RATE_MS 400
@@ -43,6 +44,8 @@ LOG_MODULE_REGISTER(main, CONFIG_TT_APP_LOG_LEVEL);
 BUILD_ASSERT(FIXED_PARTITION_EXISTS(bmfw), "bmfw fixed-partition does not exist");
 
 static bool blink_led;
+static int bh_chip_log_tgt = BH_CHIP_PRIMARY_INDEX;
+static uint32_t jtag_dump_addr;
 
 struct bh_chip BH_CHIPS[BH_CHIP_COUNT] = {DT_FOREACH_PROP_ELEM(DT_PATH(chips), chips, INIT_CHIP)};
 
@@ -201,6 +204,95 @@ static bool process_led_blink_request(struct bh_chip *chip, uint8_t msg_id, uint
 	return false;
 }
 
+static bool process_dmc_command(struct bh_chip *chip, uint8_t msg_id, uint32_t msg_data)
+{
+	dmc_command_data cmd_data;
+
+	cmd_data.raw_data = msg_data;
+	switch (cmd_data.dmc_command_data.dmc_command_code) {
+	uint32_t chip_pc, chip_postcode;
+	uint8_t asic_idx, num_bytes, log_target;
+	uint32_t data[64]; /* Buffer for JTAG dump, max 256 bytes / 4 bytes per word */
+
+	case kDmcCmdDumpAsicState:
+		LOG_INF("Received DMC command to dump ASIC state");
+		ARRAY_FOR_EACH_PTR(BH_CHIPS, chip) {
+			LOG_INF("Dumping state for chip %p", chip);
+			LOG_INF("Telemetry heartbeat: %u", chip->data.telemetry_heartbeat);
+			LOG_INF("Auto reset timeout: %u", chip->data.auto_reset_timeout);
+			LOG_INF("Thermal trip count: %u", chip->data.therm_trip_count);
+			LOG_INF("PGOOD last trip time (ms): %lld", chip->data.pgood_last_trip_ms);
+			LOG_INF("PGOOD severe fault: %d", chip->data.pgood_severe_fault);
+			LOG_INF("Fan speed: %d%%", chip->data.fan_speed);
+			LOG_INF("CM2DM message sequence number: %d (valid: %d)",
+				chip->data.last_cm2dm_seq_num,
+				chip->data.last_cm2dm_seq_num_valid);
+			/* Read PC and postcode via JTAG */
+			jtag_setup(chip->config.jtag);
+			jtag_reset(chip->config.jtag);
+			jtag_axi_read32(chip->config.jtag, RESET_UNIT_ARC_PC_CORE_0,
+					&chip_pc);
+			jtag_axi_read32(chip->config.jtag, RESET_UNIT_SCRATCH_0,
+					&chip_postcode);
+			jtag_teardown(chip->config.jtag);
+			LOG_INF("Program counter 0x%08x", chip_pc);
+			LOG_INF("Postcode 0x%08x", chip_postcode);
+		}
+		break;
+	case kDmcCmdSetLogTarget:
+		log_target = cmd_data.dmc_command_data.arg0;
+		LOG_INF("Received DMC command to set log target to %d", log_target);
+		if (cmd_data.dmc_command_data.arg0 < BH_CHIP_COUNT) {
+			bh_chip_log_tgt = log_target;
+		} else {
+			LOG_WRN("Received DMC command to set log target to invalid ASIC index %d",
+				log_target);
+		}
+		break;
+	case kDmcCmdResetAsic:
+		asic_idx = cmd_data.dmc_command_data.arg0;
+		LOG_INF("Received DMC command to reset ASIC %d", asic_idx);
+		if (asic_idx < BH_CHIP_COUNT) {
+			bh_chip_cancel_bus_transfer_clear(&BH_CHIPS[asic_idx]);
+			bh_chip_reset_chip(&BH_CHIPS[asic_idx], true);
+		} else {
+			LOG_WRN("Received DMC command to reset invalid ASIC index %d", asic_idx);
+		}
+		break;
+	case kDmcCmdSetJtagDumpAddr:
+		jtag_dump_addr = (cmd_data.dmc_command_data.arg2 << 24) |
+				(cmd_data.dmc_command_data.arg1 << 16) |
+				(cmd_data.dmc_command_data.arg0 << 8);
+		LOG_INF("Received DMC command to set JTAG dump address to 0x%08x", jtag_dump_addr);
+		break;
+	case kDmcCmdDumpJtagData:
+		asic_idx = cmd_data.dmc_command_data.arg0;
+		num_bytes = cmd_data.dmc_command_data.arg1;
+		if (asic_idx < BH_CHIP_COUNT) {
+			LOG_INF("Received DMC command to dump %d bytes of JTAG data "
+				"from ASIC %d starting at 0x%08x",
+				num_bytes, asic_idx, jtag_dump_addr);
+			jtag_setup(BH_CHIPS[asic_idx].config.jtag);
+			jtag_reset(BH_CHIPS[asic_idx].config.jtag);
+			for (uint32_t offset = 0; offset < num_bytes; offset += 4) {
+				jtag_axi_read32(BH_CHIPS[asic_idx].config.jtag,
+						jtag_dump_addr + offset, &data[offset / 4]);
+			}
+			LOG_HEXDUMP_INF(data, num_bytes, "JTAG dump");
+			jtag_teardown(BH_CHIPS[asic_idx].config.jtag);
+		} else {
+			LOG_WRN("Received DMC command to dump JTAG data from invalid ASIC index %d",
+				asic_idx);
+		}
+		break;
+	default:
+		LOG_WRN("Received unknown DMC command code %d",
+			cmd_data.dmc_command_data.dmc_command_code);
+		break;
+	}
+	return false;
+}
+
 void process_cm2dm_message(struct bh_chip *chip)
 {
 	typedef bool (*msg_processor_t)(struct bh_chip *chip, uint8_t msg_id, uint32_t msg_data);
@@ -214,6 +306,7 @@ void process_cm2dm_message(struct bh_chip *chip)
 		[kCm2DmMsgIdAutoResetTimeoutUpdate] = process_auto_reset_timeout_update,
 		[kCm2DmMsgTelemHeartbeatUpdate] = process_heartbeat_update,
 		[kCm2DmMsgIdLedBlink] = process_led_blink_request,
+		[kCm2DmMsgCmd] = process_dmc_command,
 	};
 
 	for (uint32_t i = 0U; i < kCm2DmMsgCount; i++) {
@@ -542,7 +635,7 @@ static void send_logs_to_smc(void)
 	ret = log_backend_ringbuf_get_claim(&log_data, 32);
 	if (ret > 0) {
 		/* Write log data to the first BH chip */
-		if (bh_chip_write_logs(&BH_CHIPS[BH_CHIP_PRIMARY_INDEX], log_data, ret) == 0) {
+		if (bh_chip_write_logs(&BH_CHIPS[bh_chip_log_tgt], log_data, ret) == 0) {
 			/* Only finish the claim if the write was successful */
 			log_backend_ringbuf_finish_claim(ret);
 		} else {

--- a/include/tenstorrent/bh_arc.h
+++ b/include/tenstorrent/bh_arc.h
@@ -22,6 +22,7 @@ typedef enum {
 	kCm2DmMsgTelemHeartbeatUpdate = 6,
 	kCm2DmMsgIdForcedFanSpeedUpdate = 7,
 	kCm2DmMsgIdLedBlink = 8,
+	kCm2DmMsgCmd = 9,
 	kCm2DmMsgCount
 } Cm2DmMsgId;
 
@@ -30,6 +31,36 @@ typedef enum {
 	kCm2DmResetLevelAsic = 0,
 	kCm2DmResetLevelDmc = 3,
 } Cm2DmResetLevel;
+
+/* DMC command codes for TT_SMC_MSG_DMC_COMMAND */
+enum {
+	/* Dumps state of ASICs to logs. Useful to see if ASICs are alive */
+	kDmcCmdDumpAsicState = 0,
+	/* Sets the ASIC where the DMC will send its logs. ARG0 sets the target */
+	kDmcCmdSetLogTarget = 1,
+	/* Resets a specific ASIC. ARG0 sets the target */
+	kDmcCmdResetAsic = 2,
+	/* Set JTAG dump address. Address is encoded as
+	 * (arg2 << 24) | (arg1 << 16) | (arg0 << 8)
+	 */
+	kDmcCmdSetJtagDumpAddr = 3,
+	/* Dump data via JTAG from address specified by kDmcCmdSetJtagDumpAddr.
+	 * arg0 sets the ASIC to dump from arg1 sets the number of bytes to dump
+	 */
+	kDmcCmdDumpJtagData = 4,
+};
+
+/* DMC command code structure. Used for debugging purposes */
+typedef union dmcCommandData {
+	/* Used for TT_SMC_MSG_DMC_COMMAND */
+	struct {
+		uint8_t dmc_command_code;
+		uint8_t arg0;
+		uint8_t arg1;
+		uint8_t arg2;
+	} __packed dmc_command_data;
+	uint32_t raw_data;
+} dmc_command_data;
 
 typedef struct dmStaticInfo {
 	/*

--- a/include/tenstorrent/msgqueue.h
+++ b/include/tenstorrent/msgqueue.h
@@ -697,6 +697,21 @@ struct toggle_tensix_reset_rqst {
 	/** @brief The command code corresponding to @ref TT_SMC_MSG_TOGGLE_TENSIX_RESET */
 	uint8_t command_code;
 };
+/** @brief Host request for DMC command code
+ * @details Messages of this type are processed by @ref dmc_command_handler
+ */
+struct dmc_command_rqst {
+	/** @brief The command code corresponding to @ref TT_SMC_MSG_DMC_COMMAND */
+	uint8_t command_code;
+
+	/** @brief Three bytes of padding */
+	uint8_t pad[3];
+
+	/** @brief DMC command code to send to DMFW.
+	 * Format is given by @ref dmcCommandData
+	 */
+	uint32_t dmc_command_code;
+};
 
 /** @brief A tenstorrent host request*/
 union request {
@@ -799,6 +814,9 @@ union request {
 
 	/** @brief A generic counter request */
 	struct counter_rqst counter;
+
+	/** @brief A DMC command request */
+	struct dmc_command_rqst dmc_command;
 };
 
 /** @} */

--- a/include/tenstorrent/smc_msg.h
+++ b/include/tenstorrent/smc_msg.h
@@ -71,6 +71,8 @@ enum tt_smc_msg {
 	TT_SMC_MSG_SET_TDP_LIMIT = 0x22,
 	/** @brief @ref set_asic_host_fmax_rqst "Set ASIC fmax request" */
 	TT_SMC_MSG_SET_ASIC_HOST_FMAX = 0x23,
+	/** @brief @ref dmc_command_rqst "DMC command request" */
+	TT_SMC_MSG_DMC_COMMAND = 0x24,
 	/** @brief @ref get_freq_curve_from_voltage_rqst "Frequency Curve from Voltage Request"*/
 	TT_SMC_MSG_GET_FREQ_CURVE_FROM_VOLTAGE = 0x30,
 	/** @brief @ref aisweep_rqst "Start AICLK sweep request" */

--- a/lib/tenstorrent/bh_arc/cm2dm_msg.c
+++ b/lib/tenstorrent/bh_arc/cm2dm_msg.c
@@ -239,6 +239,28 @@ static uint8_t ping_dm_handler(const union request *request, struct response *re
 
 REGISTER_MESSAGE(TT_SMC_MSG_PING_DM, ping_dm_handler);
 
+
+/**
+ * @brief Handler to send command codes to DMC
+ *
+ * Handler for a host request to send command codes to the DMC. This request
+ * is used for debugging purposes, such as resetting a specific ASIC or
+ * collecting ASIC state information.
+ * @param[in] request The request, of type @ref dmc_command_rqst, with command code
+ *	@ref TT_SMC_MSG_DMC_COMMAND to send a command to the DMC. Note that
+ *	the command code format is given by @ref dmcCommandData, but the message
+ *	interface on the SMC treats it as a single uint32_t.
+ * @param[out] response The response to the host. Not currently used.
+ * @return 0
+ */
+static uint8_t dmc_command_handler(const union request *request, struct response *response)
+{
+	PostCm2DmMsg(kCm2DmMsgCmd, request->dmc_command.dmc_command_code);
+	return 0;
+}
+
+REGISTER_MESSAGE(TT_SMC_MSG_DMC_COMMAND, dmc_command_handler);
+
 static uint8_t set_watchdog_timeout(const union request *request, struct response *response)
 {
 	const struct device *wdt_dev = DEVICE_DT_GET_OR_NULL(DT_NODELABEL(wdt0));


### PR DESCRIPTION
Add a dmc_command_code handler, which supports parsing command codes
from the host. Commands are encoded within a uint32_t due to limitations
of the SMC <-> DMC interface.

These commands are primarily intended as a debug interface to issue
requests to the DMC when an ASIC is in an unknown state.