### PR TITLE
add script to create RC, and update release process documentation

### DIFF
--- a/doc/release/release-process.rst
+++ b/doc/release/release-process.rst
@@ -12,146 +12,222 @@ Release Procedure
 The following steps are required to be followed by firmware release engineers when creating a new
 Tenstorrent firmware release.
 
-Release Checklist
-=================
+High Level Process
+==================
 
-Create an issue with the title ``Release Checklist v1.2.3``. If the issue does not already exist,
-then create it using the previous release checklist as a template. The checklist will list the
-steps required before tagging a final release.
+The release process consists of the following high level steps:
 
-Tagging
-=======
+1. Create a release branch from main, and increment the version on main to the next minor version
+
+2. Create a release candiate (RC) from the release branch and post it to GitHub.
+
+3. Announce the RC via internal channels, providing a link to the GitHub release page.
+
+4. Sync with qualification team to kick off qualification testing on the RC.
+
+5. Backport any critical fixes to the release branch.
+
+6. Create new RCs as needed until the RC is validated by the qualification team.
+
+7. Once the final RC has been validated, create a final release and post it to GitHub.
+
+8. Announce the release via internal channels, providing a link to the GitHub release page.
+
+
+Signed Tags and Immutable Releases
+==================================
+
+Tenstorrent firmware uses signed tags and immutable releases to ensure the
+integrity of each release. In order to create a signed tag, you must have a
+signing key configured in Git. You can verify that your signing key is
+configured correctly by running the following commands
+
+.. code-block:: shell
+
+   # Path to signing key should be returned
+   git config --global user.signingkey
+   # Should return "ssh". GPG keys are supported,
+   # but the process is not documented in this guide.
+   git config --global gpg.format
+   # Provide github CLI with access to the signing keys in your account
+   gh auth refresh -h github.com -s admin:ssh_signing_key
+   # Check that you have a signing key available (type MUST be signing)
+   gh ssh-key list
+   # Check that the signing key you are using matches the key in your account
+   cat $(git config --global user.signingkey).pub
+
+You can verify that a tag has been signed correctly by running ``git show`` for
+the tag, which should show a signature block in the output (look for the ``BEGIN
+PGP SIGNATURE`` or ``BEGIN SSH SIGNATURE`` marker in the output):
+
+For example:
+
+.. code-block:: shell
+
+   tag v19.7.0
+   Tagger: Scott Lindsay <slindsay@tenstorrent.com>
+   Date:   Wed Mar 11 18:43:17 2026 -0400
+
+   tt-system-firmware 19.7.0
+   -----BEGIN PGP SIGNATURE-----
+
+GitHub will show a "Verified" badge for tags that have been signed with a key
+that is associated with a GitHub account, and the signature is valid. For
+more details, see here:
+`GitHub Docs - About commit signature verification <https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification>`_.
+
+RC Process
+==========
+
+Firmware follows a release candidate (RC) process. The RC process is used to
+allow for testing and validation of firmware before a final release is made.
+Each RC is tagged and posted to GitHub as a pre-release, and the final release
+is tagged and posted to GitHub as a stable release.
+
+To start the RC process, perform the following steps:
+
+1. Create a release branch from main with the name ``vX.Y-branch`` where X and Y
+   are the major and minor version numbers of the release.
+
+2. Update the MINOR version field, and set the EXTRAVERSION field to "rc1" in
+   the release branch. For example, if the release branch is ``v19.9-branch``, then
+   the MINOR version should be set to 9 and the EXTRAVERSION field should be set to
+   "rc1". This step can be performed using the command
+   ``./scripts/update_versions.sh rc``.
+
+3. Tag the release branch with the first RC tag, following the format ``vX.Y.Z-rc1``
+   where X, Y and Z are the major, minor and patch version numbers of the release,
+   For example, if the release branch is ``v19.9-branch``, then the first RC tag
+   should be ``v19.9.0-rc1``. The tag can be created with the command
+   ``git tag -s vX.Y.Z-rc1 -m "tt-system-firmware vX.Y.Z-rc1"``, where
+   X, Y and Z are the major, minor and patch version numbers of the release.
+
+4. Push the release branch and RC tag to GitHub. This will start the CI process
+   for the release from the tag. Once this is complete, follow
+   `Posting Release to GitHub`_ steps to post the RC to GitHub as a published
+   pre-release.
+
+5. Post a PR incrementing the next minor version on main, and merge after CI is
+   successful. For example, if the release branch is ``v19.9-branch``, then the
+   version on main should be incremented to 19.10. This step can be performed
+   using the command ``./scripts/update_versions.sh post-branch``, then
+   creating a PR with the commits it creates.
+
+Automated RC Creation
+*********************
 
 .. note::
 
-    This section uses an script to generate commits. Always check that the commits are correct.
+   The steps below require the GitHub CLI tool to be installed and
+   authenticated. You can verify that you are authenticated by running
+   ``gh auth status`` and checking that you have access to the repository.
+   Installation instructions for the GitHub CLI can be found here:
+   `GitHub CLI - Installation <https://github.com/cli/cli#installation>`_
 
-.. important::
+These steps can be automated using the ``scripts/create_release_candidate.sh``
+script, which will create the release branch, increment the version on main, tag
+the RC, and push the changes to GitHub. For example:
 
-    Any changes to ``app/*/VERSION`` files is required to take place prior to the release process.
+.. code-block:: shell
 
-1. Run ``scripts/update_versions.sh rc`` to increment the minor version of the FW, SMC and DMC,
-   and to set ``EXTRAVERSION = rc1``. Major version bumps or RC2 candidates must be done manually.
+   # You can specify a different remote (i.e. a personal fork) in order to test
+   # the script without pushing to the main tt-system-firmware repository.  You
+   # can also specify the --dry-run flag to create all relevant branches and
+   # tags locally without pushing to GitHub.
+   ./scripts/create-release-candidate.sh git@github.com:tenstorrent/tt-zephyr-platforms.git
 
-   Below is an example of how each ``VERSION`` file should look after the script ran.
 
-   .. code-block:: shell
+RC Backports and Validation
+===========================
 
-       VERSION_MAJOR = 19
-       VERSION_MINOR = 4
-       PATCHLEVEL =
-       VERSION_TWEAK = 0
-       EXTRAVERSION = rc1
+Once the RC is posted to GitHub, it is the responsibility of the release manager
+to work with the qualification team to validate the RC. During the RC process,
+the following changes are candidates for backporting to the release branch:
 
-2. Post a PR with the updated ``VERSION`` files and merge after CI is successful.
+.. Note::
 
-3. Tag and push the version, using an annotated tag:
+   No changes (except version increments) should be made to the release branch
+   without also being made to main.
 
-   .. code-block:: shell
+* Critical bug fixes that are required for the RC to pass qualification testing.
+  These should be backported to the release branch and included in the next RC.
 
-       git tag -s -m "tt-system-firmware 1.2.3-rc1" v1.2.3-rc1
+* Documentation updates for features included in the release. These do not
+  require creation of a new RC for validation.
 
-4. Verify that the tag has been
-   `signed correctly <https://docs.github.com/en/authentication/managing-commit-signature-verification/telling-git-about-your-signing-key>`_,
-   ``git show`` for the tag must contain a signature (look for the ``BEGIN PGP SIGNATURE`` or
-   ``BEGIN SSH SIGNATURE`` marker in the output):
+* Features, at the discretion of the release manager and qualification team.
 
-   .. code-block:: shell
+Backports should be made via PRs against the release branch. Any change that is
+not documentation updates should trigger a new RC to be created for validation.
 
-       git show v1.2.3-rc1
+Additional RC Process
+*********************
 
-5. Push the tag:
+To create a new RC for validation after the first RC, follow these steps:
 
-   .. code-block:: shell
+1. Update the EXTRAVERSION field in the release branch to the next RC version
+   (e.g. "rc2", "rc3", etc). This step can be performed using the command
+   ``./scripts/update_versions.sh update-rc``.
 
-       git push git@github.com:tenstorrent/tt-system-firmware.git v1.2.3-rc1
+2. Create a PR to the release branch with the change, and merge after CI is
+   successful.
 
-Lastly, for final releases,
+3. Tag the release branch with the new RC tag, following the format
+   ``vX.Y.Z-rcN`` where X, Y and Z are the major, minor and patch version numbers
+   of the release, and N is the RC version number. For example, if the release
+   branch is ``v19.9-branch`` and this is the second RC, then the new RC tag should
+   be ``v19.9.0-rc2``. The tag can be created with the command
+   ``git tag -s vX.Y.Z-rcN -m "tt-system-firmware vX.Y.Z-rcN"``, where X, Y and Z are
+   the major, minor and patch version numbers of the release, and N is the RC version number.
 
-6. Run ``scripts/update_versions.sh pre-release`` to set ``EXTRAVERSION`` back to blank. Post a PR
-   and merge after CI is successful.
+4. Push the new RC tag to GitHub. This will start the CI process for the release
+   from the new RC tag. Once this is complete, follow `Posting Release to GitHub`_
+   steps to post the new RC to GitHub as a published pre-release.
 
-7. Find the generated
-   `draft release <https://github.com/tenstorrent/tt-system-firmware/releases>`_, edit the release
-   notes, and publish the release. It is recommended to copy the contents of
-   ``doc/release/release-notes-1.2.3.md`` into the release-notes area.
 
-8. Run ``scripts/update_versions.sh post-release`` to set ``PATCHLEVEL`` back to ``99``. Post a PR
-   and merge after CI is successful.
+Final Release Process
+=====================
 
-9. Announce the release via official Tenstorrent channels and provide a link to the
-   GitHub release page.
+Once a final RC has been validated by the qualification team, the release
+manager can create the final release. To create the final release, follow these
+steps:
 
-10. Run ``scripts/generate-release-docs.py`` to generate the release notes and migration guide files for the next release.
-    Post a PR with the generated files and merge after CI is successful.
+1. Update the EXTRAVERSION field in the release branch to be empty. This step can
+   be performed using the command ``./scripts/update_versions.sh pre-release``.
 
-Publishing a Combined Firmware Bundle to ``tt-firmware``
-********************************************************
+2. Tag the release branch with the final release tag, following the format
+   ``vX.Y.Z`` where X, Y and Z are the major, minor and patch version numbers of
+   the release. For example, if the release branch is ``v19.9-branch``, then the
+   final release tag should be ``v19.9.0``. The tag can be created with the command
+   ``git tag -s vX.Y.Z -m "tt-system-firmware vX.Y.Z"``, where X, Y and Z are the
+   major, minor and patch version numbers of the release.
 
-Make a pull request to `tt-firmware <https://github.com/tenstorrent/tt-firmware>`_ with the new
-combined firmware bundle and accompanying required changes.
+3. Push the release branch and final release tag to GitHub. This will start the CI process
+   for the release from the final release tag. Once this is complete, follow
+   `Posting Release to GitHub`_ steps to post the final release to GitHub as
+   a published stable release.
 
-As part of the pull request:
+Posting Release to GitHub
+=========================
 
-1. Clone the ``tt-firmware`` repository (if it has not already been cloned).
+Once Github actions creates a draft release at `GitHub Releases
+<https://github.com/tenstorrent/tt-system-firmware/releases>`_,
 
-   .. code-block:: shell
+1. Edit the release. If the release is an RC, mark the release as a pre-release.
 
-       if [ ! -d ~/tt-firmware ]; then
-         git clone git@github.com:tenstorrent/tt-firmware.git ~/tt-firmware
-         cd ~/tt-firmware
-       fi
+2. Verify the release includes a verified tag. There should be a green
+   "Verified" badge next to the tag in the release, indicating that the tag is
+   signed with a key that is associated with a GitHub account, and the signature is
+   valid. If the tag is not verified, do not publish the release and investigate
+   the issue.
 
-2. Create a branch to make modifications for the release.
+3. For final releases, copy the contents of the associated release notes template
+   (e.g. ``doc/release/release-notes-19.9.md``) into the release notes area.
 
-   .. code-block:: shell
+5. Publish the release. **Note**- since we use immutable releases, once a release
+   is published, it cannot be edited.
 
-       git checkout -b release-v1.2.3
-
-3. Download the ``fw_pack-<version>.fwbundle`` file in the associated `release <https://github.com/tenstorrent/tt-system-firmware/releases>`_.
-
-   .. code-block:: shell
-
-       wget https://github.com/tenstorrent/tt-system-firmware/releases/download/v1.2.3/fw_pack-1.2.3.fwbundle
-
-4. Change the ``latest.fwbundle`` symbolic link to point to the new firmware bundle and remove the
-   older version, staging the files for commit.
-
-   .. code-block:: shell
-
-       git rm -f $(readlink latest.fwbundle) latest.fwbundle
-       ln -sf fw_pack-1.2.3.fwbundle latest.fwbundle
-       git add *.fwbundle
-
-5. Edit the ``README.md`` file following the existing structure. Update the "Available Firmware"
-   and "Release Notes" sections, staging the file for commit.
-
-   .. code-block:: shell
-
-       $EDITOR README.md
-       git add README.md
-
-6. Make a signed commit (``git commit -s``) for the changes using the commit subject and body below.
-
-   .. code-block::
-
-       release: fw bundle v1.2.3
-
-       Release FW Bundle v1.2.3
-
-       Signed-off-by: Your Name <your@email.com>
-
-7. Create a pull request for the changes. After the PR has been merged, refresh the ``main`` branch,
-   and tag the release with a signed commit.
-
-   .. code-block:: shell
-
-       git checkout main
-       git pull
-       git tag -s -m "tt-firmware 1.2.3" v1.2.3
-       git push git@github.com:tenstorrent/tt-firmware.git v1.2.3
-
-8. Create a new ``tt-firmware``
-   `release from the new tag <https://github.com/tenstorrent/tt-firmware/releases/new>`_ by
-   copying the contents of ``doc/release/release-notes-1.2.3.md`` into the release notes for
-   the new ``tt-firmware`` release.
+6. Announce the release candidate via internal channels, providing a link to the
+   GitHub release page. Release notes are not required for RCs, but it
+   is recommended to link the draft release notes template for the release (e.g.
+   ``doc/release/release-notes-19.9.md``) in the RC announcement

--- a/scripts/create-release-candidate.sh
+++ b/scripts/create-release-candidate.sh
@@ -1,0 +1,302 @@
+#!/bin/bash
+
+# Copyright (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+# Release Automation Script
+# This script automates the release process using gh CLI
+
+set -e  # Exit on any error
+
+# Color codes for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Find the base directory of the repo
+PROJECT_ROOT=$(cd $(dirname $0); git rev-parse --show-toplevel)
+test -f ${PROJECT_ROOT}/scripts/$(basename $0) || { echo "cannot find project root"; exit 1; }
+
+# Function to print colored output
+print_status() {
+    echo -e "${GREEN}[INFO]${NC} $1"
+}
+
+print_warning() {
+    echo -e "${YELLOW}[WARN]${NC} $1"
+}
+
+print_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+print_step() {
+    echo -e "${BLUE}[STEP]${NC} $1"
+}
+
+# Function to extract version info from VERSION file
+extract_version_info() {
+    local version_file=$1
+    if [[ ! -f "$version_file" ]]; then
+        print_error "VERSION file not found: $version_file"
+        exit 1
+    fi
+
+    VERSION_MAJOR=$(grep "VERSION_MAJOR" "$version_file" | awk '{print $3}')
+    VERSION_MINOR=$(grep "VERSION_MINOR" "$version_file" | awk '{print $3}')
+    PATCHLEVEL=$(grep "PATCHLEVEL" "$version_file" | awk '{print $3}')
+    VERSION_TWEAK=$(grep "VERSION_TWEAK" "$version_file" | awk '{print $3}')
+    EXTRAVERSION=$(grep "EXTRAVERSION" "$version_file" | awk '{print $3}')
+
+    print_status "Extracted version info from $version_file:"
+    print_status "  VERSION_MAJOR: $VERSION_MAJOR"
+    print_status "  VERSION_MINOR: $VERSION_MINOR"
+    print_status "  PATCHLEVEL: $PATCHLEVEL"
+    print_status "  VERSION_TWEAK: $VERSION_TWEAK"
+    print_status "  EXTRAVERSION: '$EXTRAVERSION'"
+}
+
+check_gh_cli() {
+    if ! command -v gh &> /dev/null; then
+        print_error "gh CLI could not be found. Please install it first."
+        exit 1
+    fi
+
+    if ! gh auth status &> /dev/null; then
+        print_error "gh CLI is not authenticated. Please run 'gh auth login' first."
+        exit 1
+    fi
+
+    print_status "gh CLI is installed and authenticated"
+}
+
+# Check if we're in a git repository
+check_git_repo() {
+    if ! git rev-parse --git-dir > /dev/null 2>&1; then
+        print_error "Not in a git repository"
+        exit 1
+    fi
+
+    print_status "In git repository"
+}
+
+main() {
+    if [[ $# -ne 1 ]]; then
+        print_error "Repository URL is required as an argument"
+        show_help
+        exit 1
+    fi
+    local repo_url=$1
+    # If "git@" is not in the URL, error out
+    if [[ ! $repo_url =~ ^git@github\.com:(.*)/(.*)\.git ]]; then
+        print_error "Only SSH repository URLs supported, e.g. git@github.com/owner/repo.git"
+        exit 1
+    fi
+    REPO_OWNER="${BASH_REMATCH[1]}"
+    REPO_NAME="${BASH_REMATCH[2]}"
+    cd $PROJECT_ROOT
+
+    print_step "Starting release automation process"
+
+    # Preliminary checks
+    check_gh_cli
+    check_git_repo
+
+    # Ensure we're on the main branch and up to date
+    print_step "Ensuring we're on main branch and up to date"
+    git checkout main
+    git pull origin main
+
+    # Extract version info
+    extract_version_info "VERSION"
+
+    MAIN_VERSION_MAJOR=$VERSION_MAJOR
+    MAIN_VERSION_MINOR=$((VERSION_MINOR + 1)) # Bump version minor for release branch
+
+    # Create release branch name
+    POST_RELEASE_BRANCH="release/post-${MAIN_VERSION_MAJOR}-${MAIN_VERSION_MINOR}"
+    print_step "Creating post release branch: $POST_RELEASE_BRANCH"
+
+    git checkout -b "$POST_RELEASE_BRANCH"
+
+    # Set the new minor version in DMC, SMC, and main VERSION files with individual commits
+    print_step "Bumping minor version in DMC, SMC, and main VERSION files"
+    $PROJECT_ROOT/scripts/update_versions.sh post-branch
+
+    extract_version_info "app/dmc/VERSION"
+    DMC_VERSION="$VERSION_MAJOR.$VERSION_MINOR.$PATCHLEVEL"
+    extract_version_info "app/smc/VERSION"
+    SMC_VERSION="$VERSION_MAJOR.$VERSION_MINOR.$PATCHLEVEL"
+    extract_version_info "VERSION"
+    MAIN_VERSION="$VERSION_MAJOR.$VERSION_MINOR.$PATCHLEVEL"
+
+    FORK_ACCOUNT=$(gh auth status --json hosts  --jq .hosts | jq -r '.["github.com"][0]["login"]')
+    FORK_URL="${repo_url/github.com:*\//github.com:$FORK_ACCOUNT/}"
+
+    # Move back to main branch for version branch creation
+    git checkout main
+
+    # Create version branch
+    VERSION_BRANCH="v${MAIN_VERSION_MAJOR}.${MAIN_VERSION_MINOR}-branch"
+    print_step "Creating version branch: $VERSION_BRANCH"
+
+    git checkout -b "$VERSION_BRANCH"
+
+    print_step "Creating RC"
+
+    # Set RC version for DMC, SMC, and main VERSION files
+    $PROJECT_ROOT/scripts/update_versions.sh rc
+
+    extract_version_info "app/dmc/VERSION"
+    DMC_FINAL_VERSION="$VERSION_MAJOR.$VERSION_MINOR.$PATCHLEVEL-$EXTRAVERSION"
+    extract_version_info "app/smc/VERSION"
+    SMC_FINAL_VERSION="$VERSION_MAJOR.$VERSION_MINOR.$PATCHLEVEL-$EXTRAVERSION"
+    extract_version_info "VERSION"
+    MAIN_FINAL_VERSION="$VERSION_MAJOR.$VERSION_MINOR.$PATCHLEVEL-$EXTRAVERSION"
+    # Create and push signed tag
+    TAG_NAME="v$MAIN_FINAL_VERSION"
+    print_step "Creating signed tag: $TAG_NAME"
+
+    git tag -s "$TAG_NAME" -m "$REPO_NAME $TAG_NAME"
+
+    if [[ -n "$DRY_RUN" ]]; then
+        print_warning "Dry run mode enabled, skipping all pushes to $repo_url and $FORK_URL"
+    else
+        print_step "Pushing post release branch to fork: $FORK_URL"
+        git push -u "$FORK_URL" "$POST_RELEASE_BRANCH"
+
+        # Create PR for release branch
+        print_step "Creating PR for post release branch"
+        PR_TITLE="Post release $MAIN_VERSION_MAJOR.$MAIN_VERSION_MINOR"
+        PR_BODY="Post release PR with version bumps:
+- DMC version bumped to $DMC_VERSION
+- SMC version bumped to $SMC_VERSION
+- Main version bumped to $MAIN_VERSION"
+
+        PR_URL=$(gh pr create --title "$PR_TITLE" --body "$PR_BODY" --base main \
+            --repo "$REPO_OWNER/$REPO_NAME" --head $FORK_ACCOUNT:$POST_RELEASE_BRANCH)
+        print_status "Created PR: $PR_URL"
+
+        print_step "Pushing version branch to $repo_url"
+        git push -u $repo_url "$VERSION_BRANCH"
+
+        # Push the tag
+        print_step "Pushing tag $TAG_NAME to $repo_url"
+        git push -u $repo_url "$TAG_NAME"
+    fi
+
+    print_status "Release process completed successfully!"
+    print_status "Summary:"
+    print_status "  - Release branch created: $RELEASE_BRANCH"
+    print_status "  - PR created: $PR_URL"
+    print_status "  - Version branch created: $VERSION_BRANCH"
+    print_status "  - Tag created: $TAG_NAME"
+    print_status "  - DMC final version: $DMC_FINAL_VERSION"
+    print_status "  - SMC final version: $SMC_FINAL_VERSION"
+    print_status "  - Main final version: $MAIN_FINAL_VERSION"
+
+    if [[ $DRY_RUN ]]; then
+        print_warning "Dry run mode enabled, skipping RC process"
+        exit 0
+    fi
+
+    # Now wait for the release tag to generate a draft release
+    MESSAGE="Tag $TAG_NAME created. Would you like to wait for \
+the draft release to be generated and then edit it? (y/n): "
+    echo -n "$MESSAGE"
+    read -r response
+    if [[ ! "$response" =~ ^[Yy]$ ]]; then
+        WARNING="Skipping waiting for draft release. \
+You will need to publish the release manually from the GitHub UI."
+        print_warning "$WARNING"
+        exit 0
+    fi
+
+    # Wait for the draft release to be generated
+    while True; do
+
+        STATUS="Checking for draft release for tag $TAG_NAME... \
+Release generation can take up to 30 minutes after pushing the tag."
+        print_status "$STATUS"
+        # This command can fail with a non-zero exit code if the release is not found
+        set +e
+        DRAFT_RELEASE_URL=$(gh release view "$TAG_NAME" --repo "$REPO_OWNER/$REPO_NAME" --json url --jq '.url')
+        if [[ -n "$DRAFT_RELEASE_URL" ]]; then
+            print_status "Draft release found: $DRAFT_RELEASE_URL"
+            print_status "Please open the draft release URL and verify the release information!"
+            set -e
+            break
+        else
+            print_status "Draft release not found yet. Waiting 60 seconds before checking again..."
+            sleep 60
+        fi
+    done
+
+    echo "WARNING: Once you publish the RC release, you will not be able to make any changes to it"
+    echo "Please make sure the following is correct before publishing:"
+    echo "  - Release title is correct (should be $TAG_NAME)"
+    echo "  - Release features a verified tag (look for the green 'Verified' badge next to the tag name)"
+    echo "  - CI has passed on the tag commit"
+    echo -n "Have you verified the draft release information and are ready to publish it? (y/n): "
+    read -r publish_response
+    if [[ ! "$publish_response" =~ ^[Yy]$ ]]; then
+        print_warning "Release not published. Please publish the release manually from the GitHub UI when ready."
+        exit 0
+    fi
+    # Publish the release using gh CLI
+    print_step "Publishing release $TAG_NAME"
+    gh release edit "$TAG_NAME" --repo "$REPO_OWNER/$REPO_NAME" --draft=false --prerelease=true
+    print_status "Release $TAG_NAME published successfully!"
+}
+
+# Help function
+show_help() {
+    echo "Release Automation Script"
+    echo ""
+    echo "This script automates the release process by:"
+    echo "  1. Creating a release branch (release/MAJOR-MINOR)"
+    echo "  2. Bumping VERSION_MINOR in DMC, SMC, and main VERSION files"
+    echo "  3. Creating individual commits for each version bump"
+    echo "  4. Creating a PR for the version bumps to be merged into main"
+    echo "  5. Creating a version branch (vMAJOR.MINOR-branch)"
+    echo "  6. Setting EXTRAVERSION to 'rc1' for DMC, SMC, and main VERSION files"
+    echo "  7. Bumping PATCHLEVEL for DMC, SMC, and main VERSION files, with individual commits"
+    echo "  8. Pushing the version branch and creating a signed tag (vMAJOR.MINOR.TWEAK)"
+    echo "  9. Waiting for the draft release to be generated and prompting the user to edit and publish it"
+    echo ""
+    echo "Prerequisites:"
+    echo "  - gh CLI installed and authenticated"
+    echo "  - Git repository with proper remote setup"
+    echo "  - SSH key configured for signed tags"
+    echo ""
+    echo "Usage:"
+    echo "  $0 REPO_URL   Run the release process for specified repository"
+    echo "  $0 --help     Show this help message"
+    echo "  $0 --dry-run REPO_URL Run through the process without pushing changes"
+    echo ""
+    echo "Repository URL format:"
+    echo "  git@github.com:owner/repo.git"
+    echo ""
+}
+
+# Parse command line arguments
+case "${1:-}" in
+    --help|-h)
+        show_help
+        exit 0
+        ;;
+    --dry-run)
+        export DRY_RUN=true
+        main "$2"
+        ;;
+    -*)
+        print_error "Unknown option: $1"
+        show_help
+        exit 1
+        ;;
+    *)
+        main "$1"
+        ;;
+esac


### PR DESCRIPTION
Add a script to create a release candidate. This script has the
following steps:
- bumps MINOR version for repo, SMC, and DMC and pushes PR to main with
  these changes
- bumps MINOR version and sets rc1 for repo, SMC, and DMC and pushes
  release branch with these changes
- creates signed tag for RC branch and pushes tag
- Optionally waits for the release to be published and allows the user to finalize it from the commandline

Completely rework the release process documentation to reflect our new release process