### PR TITLE
resolves: SYS-3958 Add host-controllable minimum frequency floor for AICLK

### DIFF
--- a/app/smc/pytest/e2e_smoke.py
+++ b/app/smc/pytest/e2e_smoke.py
@@ -97,8 +97,12 @@ TT_SMC_MSG_READ_PD = 0x1C
 TT_SMC_MSG_READ_VM = 0x1D
 TT_SMC_MSG_SET_TDP_LIMIT = 0x22
 TT_SMC_MSG_SET_ASIC_HOST_FMAX = 0x23
+TT_SMC_MSG_CHARACTERISATION = 0xC6
 TT_SMC_MSG_COUNTER = 0x35
 TT_SMC_MSG_TOGGLE_GDDR_RESET = 0xB6
+
+# Characterization submessage IDs
+TT_SUB_MSG_SET_HOST_REQUESTED_FMIN = 0x1
 
 # Telemetry tags
 TAG_TDP = 7
@@ -1401,6 +1405,104 @@ def test_set_asic_host_fmax(arc_chip_dut, asic_id):
         [TT_SMC_MSG_SET_ASIC_HOST_FMAX, 100, 0, 0, 0, 0, 0, 0]
     )
     assert response[0] != 0, "Expected error for out-of-range fmax (too low)"
+
+
+def test_set_characterisation_host_fmin(arc_chip_dut, asic_id):
+    """
+    Validates that the SET_HOST_REQUESTED_FMIN characterization message works.
+
+    Sets a host fmin of 600 MHz, which should be within the valid range
+    [AICLK_FMIN_MIN=200, AICLK_FMIN_MAX=1400] on all boards.
+    Verifies that the request succeeds.
+    """
+    arc_chip = pyluwen.detect_chips()[asic_id]
+
+    NEW_HOST_FMIN = 600  # MHz
+
+    # Positive case: set a valid host fmin
+    response = arc_chip.as_bh().arc_msg_buf(
+        [
+            TT_SMC_MSG_CHARACTERISATION | TT_SUB_MSG_SET_HOST_REQUESTED_FMIN << 8,
+            NEW_HOST_FMIN,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        ]
+    )
+    assert response[0] == 0, f"Failed to set host fmin to {NEW_HOST_FMIN} MHz"
+    logger.info(f"Successfully set host fmin to {NEW_HOST_FMIN} MHz")
+
+
+def test_restore_characterisation_host_fmin(arc_chip_dut, asic_id):
+    """
+    Validates that restoring default (disabling) the host fmin floor works.
+
+    Uses the restore mechanism (value=1) to disable the host-requested
+    minimum frequency floor.
+    """
+    arc_chip = pyluwen.detect_chips()[asic_id]
+
+    # Positive case: restore default (disables the fmin floor)
+    response = arc_chip.as_bh().arc_msg_buf(
+        [
+            TT_SMC_MSG_CHARACTERISATION | TT_SUB_MSG_SET_HOST_REQUESTED_FMIN << 8,
+            1,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        ]
+    )
+    assert response[0] == 0, "Failed to restore default host fmin"
+    logger.info("Successfully restored default host fmin (disabled)")
+
+
+def test_characterisation_host_fmin_out_of_range(arc_chip_dut, asic_id):
+    """
+    Validates that out-of-range fmin values are rejected.
+
+    Checks boundaries:
+    - Value too high (9999 MHz > 1400): expect error
+    - Value too low (100 MHz < 200): expect error
+    """
+    arc_chip = pyluwen.detect_chips()[asic_id]
+
+    # Negative case: value too high
+    response = arc_chip.as_bh().arc_msg_buf(
+        [
+            TT_SMC_MSG_CHARACTERISATION,
+            TT_SUB_MSG_SET_HOST_REQUESTED_FMIN,
+            0,
+            0,
+            9999,
+            0,
+            0,
+            0,
+        ]
+    )
+    assert response[0] != 0, "Expected error for out-of-range fmin (too high)"
+    logger.info("Correctly rejected fmin value 9999 (too high)")
+
+    # Negative case: value too low
+    response = arc_chip.as_bh().arc_msg_buf(
+        [
+            TT_SMC_MSG_CHARACTERISATION,
+            TT_SUB_MSG_SET_HOST_REQUESTED_FMIN,
+            0,
+            0,
+            100,
+            0,
+            0,
+            0,
+        ]
+    )
+    assert response[0] != 0, "Expected error for out-of-range fmin (too low)"
+    logger.info("Correctly rejected fmin value 100 (too low)")
 
 
 def test_bindesc(arc_chip_dut, asic_id):

--- a/include/tenstorrent/msgqueue.h
+++ b/include/tenstorrent/msgqueue.h
@@ -725,6 +725,42 @@ struct set_asic_host_fmax_rqst {
 	uint8_t restore_default: 1;
 };
 
+/** @brief Characterization submessage to set host-requested minimum frequency floor
+ * @details Payload is a single uint32_t with two interpretations:
+ * - Value == 1: Restore default (disable host fmin floor)
+ * - Value in [200, 1400]: Set frequency to this value in MHz
+ */
+struct characterisation_set_fmin_submsg {
+	/** @brief Either 1 (restore) or frequency in MHz (200-1400) */
+	uint32_t value;
+};
+
+/** @brief Union of all possible characterization submessage payloads */
+union characterisation_submsg_data {
+	/** @brief Set host-requested minimum frequency floor */
+	struct characterisation_set_fmin_submsg fmin_value;
+	/* add to this union to define more sub-message payloads */
+	/** @brief Generic fallback for raw access */
+	uint8_t raw_data[4];
+};
+
+/** @brief Generic characterization message for internal SMC use
+ * @warning This is an internal interface. Direct use is not recommended
+ *          unless implementing new characterization features.
+ * @details Uses submsg_ID to dispatch to specific operations.
+ *          Messages of this type are processed by @ref characterisation_handler
+ */
+struct characterisation_msg_rqst {
+	/** @brief The command code corresponding to @ref TT_SMC_MSG_CHARACTERISATION */
+	uint8_t command_code;
+	/** @brief Submessage ID identifying which payload structure is active */
+	uint8_t submsg_ID;
+	/** @brief Two bytes of padding */
+	uint8_t pad[2];
+	/** @brief The submessage payload (interpretation depends on submsg_ID) */
+	union characterisation_submsg_data submsg_data;
+};
+
 /** @brief Host request to reinitialize Tensix NOC programming and tile configuration
  * @details Messages of this type are processed by @ref ReinitTensix.
  *
@@ -910,6 +946,9 @@ union request {
 
 	/** @brief A set ASIC host fmax request */
 	struct set_asic_host_fmax_rqst set_asic_host_fmax;
+
+	/** @brief A set ASIC host fmin request */
+	struct characterisation_msg_rqst characterisation_msg;
 
 	/** @brief A report scratch-only request */
 	struct report_scratch_only_rqst report_scratch_only;

--- a/include/tenstorrent/smc_msg.h
+++ b/include/tenstorrent/smc_msg.h
@@ -159,6 +159,15 @@ enum tt_smc_msg {
 
 	/** @brief @ref led_blink_rqst "Toggle red LED on the board" */
 	TT_SMC_MSG_BLINKY = 0xC5,
+
+	/** @brief @ref characterisation_rqst "Generic characterization message" */
+	TT_SMC_MSG_CHARACTERISATION = 0xC6,
+};
+
+/** @brief Enumeration of characterization submessage IDs */
+enum char_submsg_ids {
+	/** @brief Set host-requested minimum frequency (AICLK) */
+	TT_SUB_MSG_SET_HOST_REQUESTED_FMIN = 0x1,
 };
 
 /** @} */

--- a/lib/tenstorrent/bh_arc/Kconfig
+++ b/lib/tenstorrent/bh_arc/Kconfig
@@ -19,7 +19,7 @@ if TT_BH_ARC
 
 config TT_BH_ARC_NUM_MSG_CODES
 	int "Number of message codes"
-	default 198
+	default 199
 	help
 	  The number of message codes
 

--- a/lib/tenstorrent/bh_arc/aiclk_ppm.c
+++ b/lib/tenstorrent/bh_arc/aiclk_ppm.c
@@ -31,10 +31,10 @@ LOG_MODULE_REGISTER(aiclk_ppm, CONFIG_TT_APP_LOG_LEVEL);
 static const struct device *const pll_dev_0 = DEVICE_DT_GET_OR_NULL(DT_NODELABEL(pll0));
 
 /* Bounds checks for FMAX and FMIN (in MHz) */
-#define AICLK_FMAX_MAX 1400.0F
-#define AICLK_FMAX_MIN 800.0F
-#define AICLK_FMIN_MAX 800.0F
-#define AICLK_FMIN_MIN 200.0F
+#define AICLK_FMAX_MAX        1400.0F
+#define AICLK_FMAX_MIN        800.0F
+#define AICLK_FMIN_MAX        1400.0F
+#define AICLK_FMIN_MIN        200.0F
 #define AICLK_RESET_SAFE_FREQ 250.0F
 
 /* aiclk control mode */
@@ -55,6 +55,7 @@ typedef struct {
 	uint32_t boot_freq;   /* in MHz */
 	uint32_t fmax;        /* in MHz */
 	uint32_t fmin;        /* in MHz */
+	uint32_t host_requested_fmin; /* Host-requested minimum frequency floor, 0 = disabled */
 	uint32_t forced_freq; /* in MHz, a value of zero means disabled. */
 	bool reset_safe;      /* cap to reset-safe frequency after forced frequency is applied */
 	uint32_t sweep_en;    /* a value of one means enabled, otherwise disabled. */
@@ -137,10 +138,15 @@ void CalculateTargAiclk(void)
 		}
 	}
 
-	/* Make sure target is not below Fmin */
+	/* Make sure target is not below Fmin or host-requested minimum */
 	/* (it will not be above Fmax, since we calculated the max limits last) */
-	if (aiclk_ppm.targ_freq < aiclk_ppm.fmin) {
-		aiclk_ppm.targ_freq = aiclk_ppm.fmin;
+	uint32_t effective_fmin_floor = aiclk_ppm.fmin;
+
+	if (aiclk_ppm.host_requested_fmin > 0) {
+		effective_fmin_floor = MAX(effective_fmin_floor, aiclk_ppm.host_requested_fmin);
+	}
+	if (aiclk_ppm.targ_freq < effective_fmin_floor) {
+		aiclk_ppm.targ_freq = effective_fmin_floor;
 		info.reason = limit_reason_fmin;
 		info.arbiter = 0U;
 	}
@@ -490,6 +496,52 @@ static uint8_t set_arb_host_fmax_handler(const union request *request, struct re
 	return 0;
 }
 
+/** @brief Handles the characterization submessage for setting host minimum frequency floor
+ * @param[in] fmin_value The submessage data of type @ref characterisation_set_fmin_submsg
+ * @param[out] response The response to the host
+ * @return 0 for success, 1 for invalid input
+ */
+static uint8_t handle_char_set_host_fmin(const struct characterisation_set_fmin_submsg fmin_value,
+					 struct response *response)
+{
+	uint32_t new_fmin = fmin_value.value;
+
+	/* Check for restore flag */
+	if (new_fmin == 1) {
+		aiclk_ppm.host_requested_fmin = 0;
+		LOG_INF("host fmin floor disabled");
+		return 0;
+	}
+
+	/* Reject if outside valid range [AICLK_FMIN_MIN, AICLK_FMIN_MAX] */
+	if (new_fmin > (uint32_t)AICLK_FMIN_MAX || new_fmin < (uint32_t)AICLK_FMIN_MIN) {
+		return 1;
+	}
+
+	aiclk_ppm.host_requested_fmin = new_fmin;
+	LOG_INF("host fmin floor set to %u MHz", new_fmin);
+	return 0;
+}
+
+/** @brief Dispatcher for characterization submessages
+ * @param[in] request The characterization request with submsg_ID
+ * @param[out] response The response to the host
+ * @return 0 for success, 1 for invalid input or unknown submessage
+ */
+static uint8_t characterisation_handler(const union request *request, struct response *response)
+{
+	switch (request->characterisation_msg.submsg_ID) {
+	case TT_SUB_MSG_SET_HOST_REQUESTED_FMIN:
+		return handle_char_set_host_fmin(
+			request->characterisation_msg.submsg_data.fmin_value, response);
+
+	default:
+		LOG_WRN("Unknown characterization submessage ID: 0x%02x",
+			request->characterisation_msg.submsg_ID);
+		return 1;
+	}
+}
+
 uint8_t throttler_counter_handler(const union request *request, struct response *response)
 {
 	switch (request->counter.command) {
@@ -532,3 +584,4 @@ REGISTER_MESSAGE(TT_SMC_MSG_GET_AICLK, get_aiclk_handler);
 REGISTER_MESSAGE(TT_SMC_MSG_AISWEEP_START, SweepAiclkHandler);
 REGISTER_MESSAGE(TT_SMC_MSG_AISWEEP_STOP, SweepAiclkHandler);
 REGISTER_MESSAGE(TT_SMC_MSG_SET_ASIC_HOST_FMAX, set_arb_host_fmax_handler);
+REGISTER_MESSAGE(TT_SMC_MSG_CHARACTERISATION, characterisation_handler);


### PR DESCRIPTION
Implement TT_SMC_MSG_SET_ASIC_HOST_FMIN to allow the host to set a minimum frequency floor that takes precedence over the hardware fmin. This provides a mechanism for the host to prevent the AICLK from dropping below a specified threshold, similar to the existing host_fmax arbiter but for the minimum frequency.

Changes:
- Add set_asic_host_fmin_rqst message structure and handler
- Add host_requested_fmin field to AiclkPPM state
- Update CalculateTargAiclk to enforce host-requested minimum
- Expand AICLK_FMIN_MAX from 800 to 1400 MHz to allow full range
- Support restore_default flag to disable the host-requested floor