### PR TITLE
manufacturing_led: fix board fault led behaviour

### DIFF
--- a/app/dmc/src/main.c
+++ b/app/dmc/src/main.c
@@ -42,7 +42,7 @@ LOG_MODULE_REGISTER(main, CONFIG_TT_APP_LOG_LEVEL);
 
 BUILD_ASSERT(FIXED_PARTITION_EXISTS(bmfw), "bmfw fixed-partition does not exist");
 
-static bool blink_led;
+static bool smc_led_blink_req;
 
 struct bh_chip BH_CHIPS[BH_CHIP_COUNT] = {DT_FOREACH_PROP_ELEM(DT_PATH(chips), chips, INIT_CHIP)};
 
@@ -57,7 +57,6 @@ static const struct device *const max6639_pwm_dev =
 	DEVICE_DT_GET_OR_NULL(DT_NODELABEL(max6639_pwm));
 static const struct device *const max6639_sensor_dev =
 	DEVICE_DT_GET_OR_NULL(DT_NODELABEL(max6639_sensor));
-static const struct gpio_dt_spec red_led = GPIO_DT_SPEC_GET(DT_NODELABEL(led0), gpios);
 
 /* No mechanism for getting bl version... yet */
 static dmStaticInfo static_info = {.version = 1, .bl_version = 0, .app_version = APPVERSION};
@@ -197,7 +196,7 @@ static bool process_heartbeat_update(struct bh_chip *chip, uint8_t msg_id, uint3
 
 static bool process_led_blink_request(struct bh_chip *chip, uint8_t msg_id, uint32_t msg_data)
 {
-	blink_led = msg_data;
+	smc_led_blink_req = msg_data;
 	return false;
 }
 
@@ -570,10 +569,15 @@ static void blink_led_expired(struct k_timer *timer)
 {
 	ARG_UNUSED(timer);
 
-	if (blink_led) {
-		gpio_pin_toggle_dt(&red_led);
-	} else {
-		gpio_pin_set_dt(&red_led, 0);
+	static bool blinky_state;
+
+	if (smc_led_blink_req) {
+		gpio_pin_toggle_dt(&board_fault_led);
+		blinky_state = true;
+	} else if (blinky_state) {
+		/* When the blinky state has been turned off, turn the LED off once. */
+		gpio_pin_set_dt(&board_fault_led, 0);
+		blinky_state = false;
 	}
 }
 static K_TIMER_DEFINE(blink_led_timer, blink_led_expired, NULL);
@@ -671,15 +675,18 @@ int main(void)
 
 	printk("DMFW VERSION " APP_VERSION_STRING "\n");
 
+	/* For manufacturing, keep the red LED solid on so it can be visually inspected.
+	 * Don't start the blink timer to prevent it from overriding this state.
+	 */
 	if (IS_ENABLED(CONFIG_TT_ASSEMBLY_TEST) && board_fault_led.port != NULL) {
 		gpio_pin_set_dt(&board_fault_led, 1);
+	} else {
+		k_timer_start(&blink_led_timer, K_MSEC(LED_BLINK_RATE_MS),
+			      K_MSEC(LED_BLINK_RATE_MS));
 	}
 
 	k_timer_start(&shared_20ms_event_timer, K_MSEC(20), K_MSEC(20));
 	k_timer_start(&board_power_update_timer, K_MSEC(1), K_MSEC(1));
-	k_timer_start(&blink_led_timer, K_MSEC(LED_BLINK_RATE_MS), K_MSEC(LED_BLINK_RATE_MS));
-
-	gpio_pin_configure_dt(&red_led, GPIO_OUTPUT_ACTIVE);
 
 	while (true) {
 		uint32_t events = tt_event_wait(TT_EVENT_ANY, K_FOREVER);

--- a/boards/tenstorrent/tt_blackhole/tt_blackhole_tt_blackhole_dmc.dts
+++ b/boards/tenstorrent/tt_blackhole/tt_blackhole_tt_blackhole_dmc.dts
@@ -53,13 +53,6 @@
 			gpios = <&gpiox2 5 GPIO_ACTIVE_HIGH>;
 		};
 	};
-
-	leds: leds {
-		compatible = "gpio-leds";
-		led0: led_0 {
-			gpios = <&gpioc 15 GPIO_ACTIVE_HIGH>;
-		};
-	};
 };
 
 / {

--- a/doc/release/release-notes-19.8.md
+++ b/doc/release/release-notes-19.8.md
@@ -97,6 +97,10 @@ Major enhancements with this release include:
 - Enhanced device initialization with configurable init/deinit function pointers
 - Improved firmware bundle tooling with better diff support for unsigned bootfs entries
 
+### Bug Fixes
+
+- Fixed red LED not staying on for manufacturing test (SYS-3844).
+
 <!-- Security vulnerabilities fixed? -->
 <!-- Other Notable Changes, if applicable -->
 <!-- New Boards, if applicable -->


### PR DESCRIPTION
Manufacturing test requires the board fault LED to be solid on. The commit that introduced a SMC message to blink the LED, accidentally overrode this behavior causing the board fault LED to blink instead of staying solid.

Fix this bug so that the board fault LED is solid on for manufacturing, but for non manufacturing builds still allow the SMC to blink.

Also remove the "led0" node from devicetree as it's the same as the board fault led.

resolves SYS-3844