### PR TITLE
ci: build new container with updated SDK

### DIFF
--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -1,7 +1,7 @@
 # Image to run tt-system-firmware CI tests.
 # Includes python dependencies and base copy of repos
 
-ARG ZEP_CONTAINER=v0.28.2
+ARG ZEP_CONTAINER=v0.29.1
 FROM ghcr.io/zephyrproject-rtos/zephyr-build:${ZEP_CONTAINER} AS base
 
 USER root


### PR DESCRIPTION
Build a new container using the latest Zephyr SDK, so we can use Zephyr 4.4

resolves: SYS-3947