### PR TITLE
ci: release: save manufacturing artifacts

### DIFF
--- a/.github/workflows/build-fw.yml
+++ b/.github/workflows/build-fw.yml
@@ -344,6 +344,7 @@ jobs:
           name: preflash-fw
           path: |
             preflash*.ihex
+            preflash*.bin
 
   build-combined-fwbundle:
     runs-on: ubuntu-24.04

--- a/.github/workflows/build-fw.yml
+++ b/.github/workflows/build-fw.yml
@@ -282,7 +282,7 @@ jobs:
         shell: bash
         run: |
             mkdir assembly-test-preflash
-            cp build-assembly-test-${{ matrix.board }}/mcuboot/zephyr/zephyr.elf assembly-test-preflash/${{ matrix.board }}-bootloader-${{ steps.sanitize.outputs.sanitized_ref_name }}.elf
+            cp build-assembly-test-${{ matrix.board }}/mcuboot/zephyr/zephyr.hex assembly-test-preflash/${{ matrix.board }}-bootloader-${{ steps.sanitize.outputs.sanitized_ref_name }}.hex
             cp build-assembly-test-${{ matrix.board }}/dmc/zephyr/zephyr.signed.hex assembly-test-preflash/${{ matrix.board }}-app-${{ steps.sanitize.outputs.sanitized_ref_name }}.signed.hex
 
       - name: Upload firmware assets

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,6 +181,22 @@ jobs:
         with:
           name: tt-system-firmware-${{ steps.set_vars.outputs.VERSION }}.spdx
 
+      - name: Download assembly firmware artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: assembly-fw-*
+
+      - name: Download assembly test artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: assembly-test-*
+
+      - name: Download preflash firmware
+        uses: actions/download-artifact@v4
+        with:
+          name: preflash-fw
+          path: preflash-fw
+
       - name: Download Debian Package
         uses: actions/download-artifact@v4
         with:
@@ -206,7 +222,15 @@ jobs:
           done
           tar zcf fw-pack-${{ github.ref_name }}-recovery.tar.gz -C firmware-recovery-${{ github.ref_name }} .
 
-          zip -r -9 tt-system-firmware-${{ steps.set_vars.outputs.VERSION }}.zip ${BOARD_REVS[@]}
+          ASSEMBLY_FW_DIRS=(assembly-fw-*)
+          zip -r -9 tt-system-firmware-${{ steps.set_vars.outputs.VERSION }}.zip ${BOARD_REVS[@]} ${ASSEMBLY_FW_DIRS[@]}
+
+          # Package manufacturing artifacts (assembly test collateral + preflash firmware)
+          VERSION=${{ steps.set_vars.outputs.VERSION }}
+          mkdir manufacturing-artifacts
+          cp -r assembly-test-*/. manufacturing-artifacts/
+          cp -r preflash-fw/. manufacturing-artifacts/
+          tar zcf manufacturing-artifacts-${VERSION}.tar.gz -C manufacturing-artifacts .
 
       - name: Create Release
         uses: softprops/action-gh-release@v2
@@ -223,3 +247,4 @@ jobs:
             *.deb
             tt-system-firmware-${{ steps.set_vars.outputs.VERSION }}.zip
             tt-system-firmware-${{ steps.set_vars.outputs.VERSION }}.spdx
+            manufacturing-artifacts-${{ steps.set_vars.outputs.VERSION }}.tar.gz

--- a/scripts/build-preflash.sh
+++ b/scripts/build-preflash.sh
@@ -64,4 +64,5 @@ echo "Build completed successfully"
 echo "Generating preflash.ihex..."
 YAML_PATH="$TTZP_BASE/boards/tenstorrent/tt_blackhole/bootfs/preflash-bootfs.yaml"
 $SCRIPT_DIR/tt_boot_fs.py mkfs "$YAML_PATH" "preflash-$RELEASE.ihex" --build-dir "$BUILD_DIR" --hex
+objcopy -I ihex -O binary "preflash-$RELEASE.ihex" "preflash-$RELEASE.bin"
 echo "preflash.ihex-$RELEASE generated successfully"


### PR DESCRIPTION
- Save assembly test and preflash FWs as release artifacts
- Save mcuboot as intel hex to match assembly FW
- Generate preflash as binary in addition to intel hex

resolves: SYS-2396, SYS-3821