### PR TITLE
app: smc: pytest: correctly extract CMFW version

### DIFF
--- a/app/smc/pytest/e2e_smoke.py
+++ b/app/smc/pytest/e2e_smoke.py
@@ -1512,7 +1512,9 @@ def test_bindesc(arc_chip_dut, asic_id):
     """
     arc_chip = pyluwen.detect_chips()[asic_id]
     smc_bin = arc_chip_dut.device_config.app_build_dir / "zephyr/zephyr.bin"
-    smc_version = get_int_version_from_file(SCRIPT_DIR.parents[2] / "app/smc/VERSION")
+    smc_version = get_ttzp_version.get_ttzp_version_u32(
+        SCRIPT_DIR.parents[2] / "app/smc/VERSION"
+    )
     logger.info(f"Expected SMC version from file: 0x{smc_version:08x}")
     # Read version from running FW telemetry
     cmfw_version = read_telem(arc_chip, TAG_CM_FW_VERSION)


### PR DESCRIPTION
Extract CMFW version correctly, so the expected CMFW version will match
what firmware actually reports on RC builds.