### PR TITLE
boards: tt_blackhole: Disable PWM on boards with no fan

### DIFF
--- a/boards/tenstorrent/tt_blackhole/tt_blackhole_tt_blackhole_dmc_p150b.overlay
+++ b/boards/tenstorrent/tt_blackhole/tt_blackhole_tt_blackhole_dmc_p150b.overlay
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2026 Tenstorrent AI ULC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	model = "Tenstorrent Blackhole P150B DMC board";
+	compatible = "tenstorrent,blackhole,p150b-dmc";
+};
+
+&max6639 {
+	status = "disabled";
+};

--- a/boards/tenstorrent/tt_blackhole/tt_blackhole_tt_blackhole_dmc_p150c.overlay
+++ b/boards/tenstorrent/tt_blackhole/tt_blackhole_tt_blackhole_dmc_p150c.overlay
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2026 Tenstorrent AI ULC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	model = "Tenstorrent Blackhole P150C DMC board";
+	compatible = "tenstorrent,blackhole,p150c-dmc";
+};
+
+&max6639 {
+	status = "disabled";
+};

--- a/boards/tenstorrent/tt_blackhole/tt_blackhole_tt_blackhole_dmc_p300b.overlay
+++ b/boards/tenstorrent/tt_blackhole/tt_blackhole_tt_blackhole_dmc_p300b.overlay
@@ -4,3 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include "tt_blackhole_tt_blackhole_dmc_p300a.overlay"
+
+&max6639 {
+	status = "disabled";
+};

--- a/boards/tenstorrent/tt_blackhole/tt_blackhole_tt_blackhole_dmc_p300c.overlay
+++ b/boards/tenstorrent/tt_blackhole/tt_blackhole_tt_blackhole_dmc_p300c.overlay
@@ -4,3 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include "tt_blackhole_tt_blackhole_dmc_p300a.overlay"
+
+&max6639 {
+	status = "disabled";
+};

--- a/lib/tenstorrent/bh_arc/telemetry.c
+++ b/lib/tenstorrent/bh_arc/telemetry.c
@@ -453,8 +453,13 @@ static void update_telemetry(void)
 					     * yet), lower 16 bits - current L2CPUCLK3
 					     */
 
-	telemetry[TAG_FAN_SPEED] = GetFanSpeed(); /* Target fan speed - reported in percentage */
-	telemetry[TAG_FAN_RPM] = GetFanRPM();     /* Actual fan RPM */
+	bool fan_ctrl_en = tt_bh_fwtable_get_fw_table(fwtable_dev)->feature_enable.fan_ctrl_en;
+
+	/*Target fan speed - reported in percentage */
+	telemetry[TAG_FAN_SPEED] = fan_ctrl_en ? GetFanSpeed() : 0xFFFFFFFFU;
+
+	/* Actual fan RPM */
+	telemetry[TAG_FAN_RPM] = fan_ctrl_en ? GetFanRPM() : 0xFFFFFFFFU;
 	UpdateEthTelemetry();
 	UpdateGddrTelemetry();
 	telemetry[TAG_MAX_GDDR_TEMP] = GetMaxGDDRTemp();

--- a/lib/tenstorrent/bh_arc/telemetry.h
+++ b/lib/tenstorrent/bh_arc/telemetry.h
@@ -142,7 +142,7 @@
 /** @brief L2CPU firmware version. */
 #define TAG_L2CPU_FW_VERSION 30
 
-/** @brief Fan speed as a percentage. */
+/** @brief Fan speed as a percentage. 0xFFFFFFFF if fan control disabled. */
 #define TAG_FAN_SPEED 31
 
 /** @brief Timer heartbeat counter. */
@@ -172,7 +172,7 @@
 /** @brief NOC translation status. */
 #define TAG_NOC_TRANSLATION 40
 
-/** @brief Fan RPM. */
+/** @brief Fan RPM. 0xFFFFFFFF if fan control disabled. */
 #define TAG_FAN_RPM 41
 
 /** @brief GDDR 0 and 1 temperature. */


### PR DESCRIPTION
Disable the fan controller on boards which don't have a fan.

SMC side, if the fan ctrl is off, return 0xffff_ffff in the telemetry values

resolves: SYS-3939