### PR TITLE
tensix_reset: log coord before reset to debug ci failures

### DIFF
--- a/app/smc/pytest/e2e_stress.py
+++ b/app/smc/pytest/e2e_stress.py
@@ -500,6 +500,7 @@ def test_tensix_reset_then_burnin(arc_chip_dut, asic_id):
     # Set high power after the message to allow NOC read/write to function properly.
     arc_chip.set_power_state("low")
     for noc_x, noc_y in all_tiles:
+        logger.info(f"Resetting ({noc_x},{noc_y})")
         response = arc_chip.arc_msg(
             TT_SMC_MSG_TOGGLE_SINGLE_TENSIX_RESET,
             arg0=noc_x | (noc_y << 8),


### PR DESCRIPTION
Log the NOC coordinate of the tensix before reset to catch intermittent CI failures.