### PR TITLE
Init Voltage PPM: Make VDD_MIN/MAX configurable via SPI FW table

### DIFF
--- a/lib/tenstorrent/bh_arc/voltage.c
+++ b/lib/tenstorrent/bh_arc/voltage.c
@@ -7,15 +7,16 @@
 #include <zephyr/sys/util.h>
 #include <tenstorrent/smc_msg.h>
 #include <tenstorrent/msgqueue.h>
+#include <zephyr/drivers/misc/bh_fwtable.h>
 
 #include "voltage.h"
 #include "regulator.h"
 #include "dvfs.h"
 
 /* TODO: Get these from SPI parameters */
-#define VDD_MIN  700
-#define VDD_MAX  900
 #define VDD_BOOT 750
+
+static const struct device *const fwtable_dev = DEVICE_DT_GET(DT_NODELABEL(fwtable));
 
 VoltageArbiter voltage_arbiter;
 
@@ -55,8 +56,8 @@ void CalculateTargVoltage(void)
 
 int InitVoltagePPM(void)
 {
-	voltage_arbiter.vdd_min = VDD_MIN;
-	voltage_arbiter.vdd_max = VDD_MAX;
+	voltage_arbiter.vdd_min = tt_bh_fwtable_get_fw_table(fwtable_dev)->chip_limits.vdd_min;
+	voltage_arbiter.vdd_max = tt_bh_fwtable_get_fw_table(fwtable_dev)->chip_limits.vdd_max;
 
 	/* disable forcing of VDD */
 	voltage_arbiter.forced_voltage = 0;
@@ -77,7 +78,8 @@ int InitVoltagePPM(void)
 
 uint8_t ForceVdd(uint32_t voltage)
 {
-	if ((voltage > VDD_MAX || voltage < VDD_MIN) && (voltage != 0)) {
+	if ((voltage > voltage_arbiter.vdd_max || voltage < voltage_arbiter.vdd_min) &&
+	    (voltage != 0)) {
 		return 1;
 	}
 

--- a/lib/tenstorrent/bh_arc/voltage.c
+++ b/lib/tenstorrent/bh_arc/voltage.c
@@ -13,8 +13,12 @@
 #include "regulator.h"
 #include "dvfs.h"
 
-/* TODO: Get these from SPI parameters */
-#define VDD_BOOT 750
+#define VDD_BOOT            750
+/* Bound checks for VDD_MAX and VDD_MIN (in mV) */
+#define VDD_MAX_UPPER_LIMIT 900U
+#define VDD_MAX_LOWER_LIMIT 700U
+#define VDD_MIN_UPPER_LIMIT 900U
+#define VDD_MIN_LOWER_LIMIT 650U
 
 static const struct device *const fwtable_dev = DEVICE_DT_GET(DT_NODELABEL(fwtable));
 
@@ -56,8 +60,12 @@ void CalculateTargVoltage(void)
 
 int InitVoltagePPM(void)
 {
-	voltage_arbiter.vdd_min = tt_bh_fwtable_get_fw_table(fwtable_dev)->chip_limits.vdd_min;
-	voltage_arbiter.vdd_max = tt_bh_fwtable_get_fw_table(fwtable_dev)->chip_limits.vdd_max;
+	voltage_arbiter.vdd_min =
+		CLAMP(tt_bh_fwtable_get_fw_table(fwtable_dev)->chip_limits.vdd_min,
+		      VDD_MIN_LOWER_LIMIT, VDD_MIN_UPPER_LIMIT);
+	voltage_arbiter.vdd_max =
+		CLAMP(tt_bh_fwtable_get_fw_table(fwtable_dev)->chip_limits.vdd_max,
+		      VDD_MAX_LOWER_LIMIT, VDD_MAX_UPPER_LIMIT);
 
 	/* disable forcing of VDD */
 	voltage_arbiter.forced_voltage = 0;

--- a/tests/lib/tenstorrent/bh_arc/src/msgqueue.c
+++ b/tests/lib/tenstorrent/bh_arc/src/msgqueue.c
@@ -21,6 +21,7 @@
 #include "aiclk_ppm.h"
 
 #include "reg_mock.h"
+#include "voltage.h"
 
 /* Custom fake for ReadReg to simulate timer progression */
 #define RESET_UNIT_REFCLK_CNT_LO_REG_ADDR         0x800300E0
@@ -515,6 +516,9 @@ ZTEST(msgqueue, test_msg_type_read_eeprom_no_flash)
 
 ZTEST(msgqueue, test_msg_type_force_vdd)
 {
+	voltage_arbiter.vdd_min = 700;
+	voltage_arbiter.vdd_max = 900;
+
 	/* Force a valid voltage */
 	req.force_vdd.command_code = TT_SMC_MSG_FORCE_VDD;
 	req.force_vdd.forced_voltage = 800;


### PR DESCRIPTION
Replace hardcoded voltage limits with values read from FW table at initialization. This allows users to program voltage limits via update_spi_data_table.py without reflashing firmware.