### PR TITLE
doc: release: 19.10: add draft release notes

### DIFF
--- a/doc/release/migration-guide-19.10.md
+++ b/doc/release/migration-guide-19.10.md
@@ -1,0 +1,7 @@
+# 19.10.0
+
+## Migration Guide
+
+> This is a working draft for the up-coming 19.10.0 release.
+
+This document lists recommended and required changes for those migrating from the previous v19.9.0 firmware release to the new 19.10.0 firmware release.

--- a/doc/release/release-notes-19.10.md
+++ b/doc/release/release-notes-19.10.md
@@ -1,0 +1,45 @@
+# v19.10.0
+
+> This is a working draft for the up-coming 19.10.0 release.
+
+We are pleased to announce the release of TT System Firmware version 19.10.0 🥳🎉.
+
+Major enhancements with this release include:
+
+## What's Changed
+
+## Wormhole
+
+## Blackhole
+
+## Grendel
+
+<!-- Subsections can break down improvements by (area or board) -->
+<!-- UL PCIe -->
+<!-- UL DDR -->
+<!-- UL Ethernet -->
+<!-- UL Telemetry -->
+<!-- UL Debug / Developer Features -->
+<!-- UL Drivers -->
+<!-- UL Libraries -->
+
+<!-- Performance Improvements, if applicable -->
+<!-- New and Experimental Features, if applicable -->
+<!-- External Project Collaboration Efforts, if applicable -->
+<!-- Stability Improvements, if applicable -->
+<!-- Security vulnerabilities fixed? -->
+<!-- API Changes, if applicable -->
+<!-- Removed APIs, H3 Deprecated APIs, H3 New APIs, if applicable -->
+<!-- New Samples, if applicable -->
+<!-- Other Notable Changes, if applicable -->
+<!-- New Boards, if applicable -->
+
+## Migration guide
+
+An overview of required and recommended changes to make when migrating from the previous v19.9.0 release can be found in [19.10 Migration Guide](https://github.com/tenstorrent/tt-system-firmware/tree/main/doc/release/migration-guide-19.10.md).
+
+## Full ChangeLog
+
+The full ChangeLog from the previous v19.9.0 release can be found at the link below.
+
+https://github.com/tenstorrent/tt-system-firmware/compare/v19.9.0...v19.10.0

--- a/scripts/generate-release-docs.py
+++ b/scripts/generate-release-docs.py
@@ -104,11 +104,17 @@ def generate_release_notes(
 
 > This is a working draft for the up-coming {next_version_base} release.
 
-We are pleased to announce the release of TT Zephyr Platforms firmware version {next_version_base} 🥳🎉.
+We are pleased to announce the release of TT System Firmware version {next_version_base} 🥳🎉.
 
 Major enhancements with this release include:
 
 ## What's Changed
+
+## Wormhole
+
+## Blackhole
+
+## Grendel
 
 <!-- Subsections can break down improvements by (area or board) -->
 <!-- UL PCIe -->


### PR DESCRIPTION
Update `generate-release-docs.py` to add a section for each ASIC and use the new repo name.

Add the draft release notes and migration guide for 19.10.