### PR TITLE
loudbox_ci: lower prefil chunck size to avoid exceeding dram

### DIFF
--- a/.github/workflows/metal.yml
+++ b/.github/workflows/metal.yml
@@ -125,6 +125,25 @@ jobs:
             INSERT="    pytest tests/didt/test_resnet_conv.py::test_resnet_conv -k \"all\" --didt-workload-iterations 100 --determinism-check-interval 0"
             sed -i "/$SEARCH/a$INSERT" dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
           fi
+
+          # On loudbox the upstream script hardcodes data_parallel_devices=8, which
+          # replicates the 70B weights on every P150 and OOMs. Force data_parallel=1
+          # so the 8-device mesh is used as a single tensor-parallel group instead.
+          if [ "${{ matrix.config.board }}" == "loudbox" ]; then
+            sed -i 's/--data_parallel "\$data_parallel_devices"/--data_parallel 1/g' \
+              dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
+            sed -i 's/-k "performance and ci-32" --data_parallel 1 --timeout 1200/-k "performance and ci-32" --data_parallel 1 --timeout 3600/' \
+              dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
+
+            # Bump every Llama-3.3-70B entry in trace_region_config.py to 128 MiB.
+            # tt_metal's conftest reads this dict and overrides the parametrized
+            # trace_region_size; the configured 80MB / 84MB values are too tight
+            # for the TP=8 / batch=32 / ci-32 trace on loudbox.
+            sed -i -E '/"Llama-3\.3-70B":/,/},/ s/(":[[:space:]]+)[0-9]+/\1134217728/' \
+              models/tt_transformers/demo/trace_region_config.py
+            sed -n '/"Llama-3\.3-70B":/,/},/p' models/tt_transformers/demo/trace_region_config.py
+          fi
+
           # Patch tests to remove determinism checks, which are only reliable
           # on metal CI fleets
           sed -i 's/--determinism-check-interval 1/--determinism-check-interval 0/g' \


### PR DESCRIPTION
Lower prefil chunck size to 32 to avoid Llama-3.3-70B  exceeding DRAM memory limit.