### PR TITLE
lib: bh_arc: eth: add a message for toggling eth tile reset

### DIFF
--- a/app/smc/pytest/e2e_smoke.py
+++ b/app/smc/pytest/e2e_smoke.py
@@ -105,6 +105,10 @@ TT_SMC_MSG_SET_ASIC_HOST_FMAX = 0x23
 TT_SMC_MSG_CHARACTERISATION = 0xC6
 TT_SMC_MSG_COUNTER = 0x35
 TT_SMC_MSG_TOGGLE_GDDR_RESET = 0xB6
+TT_SMC_MSG_TOGGLE_ETH_RESET = 0xB0
+
+# ETH toggle reset (eth_tile_reset_rqst) — response[1] uses eth_reset_err from ARC
+ETH_RESET_ERR_INVALID_MASK = 1
 
 # Characterization submessage IDs
 TT_SUB_MSG_SET_HOST_REQUESTED_FMIN = 0x1
@@ -121,6 +125,8 @@ TAG_HOST_AICLK_LIMIT = 70
 NUM_PD = 16
 NUM_VM = 8
 NUM_TS = 8
+
+NUM_ETH = 14
 
 
 def read_telem(arc_chip, telem_idx):
@@ -1245,25 +1251,127 @@ def test_eth_live_status(arc_chip_dut, asic_id):
     """
     Validates that the Ethernet live status reflects correct heartbeat status.
 
-    Reads TAG_ETH_LIVE_STATUS from telemetry and checks that the heartbeat
-    bitmask (lower 16 bits) matches the enabled ETH bitmask (TAG_ENABLED_ETH),
-    since every enabled ETH tile should be posting a heartbeat.
+    Polls TAG_ETH_LIVE_STATUS every second until the heartbeat bitmask (lower 16
+    bits) matches TAG_ENABLED_ETH. Fails if the condition is not met within 75 s.
     """
+    # ETH FW can take up to 60 seconds to start its heartbeat.
+    # How long we actually have to wait depends on the board type and
+    # how long it has been since the ASIC was reset.
+    # Running this test before eth_toggle_reset_* tests reduces the amount of waiting time.
+    TIMEOUT_S = 75.0
+    POLL_INTERVAL_S = 1.0
+
     arc_chip = pyluwen.detect_chips()[asic_id]
-
-    eth_live_status = read_telem(arc_chip, TAG_ETH_LIVE_STATUS)
     eth_enabled = read_telem(arc_chip, TAG_ENABLED_ETH)
+    start = time.monotonic()
 
-    heartbeat_status = eth_live_status & 0xFFFF
+    while True:
+        elapsed = time.monotonic() - start
+        eth_live_status = read_telem(arc_chip, TAG_ETH_LIVE_STATUS)
+        heartbeat_status = eth_live_status & 0xFFFF
 
-    logger.info(
-        f"ETH enabled: {eth_enabled:#06x}, heartbeat status: {heartbeat_status:#06x}"
+        logger.debug(
+            f"[{elapsed:.1f}s] ETH enabled: {eth_enabled:#06x}, "
+            f"heartbeat status: {heartbeat_status:#06x}"
+        )
+
+        if heartbeat_status == eth_enabled:
+            logger.info(
+                f"Heartbeat matched eth_enabled after {elapsed:.1f}s "
+                f"({heartbeat_status:#06x})"
+            )
+            return
+
+        if elapsed >= TIMEOUT_S:
+            pytest.fail(
+                f"Heartbeat status {heartbeat_status:#06x} did not match "
+                f"eth_enabled {eth_enabled:#06x} within {TIMEOUT_S:.0f}s"
+            )
+
+        time.sleep(POLL_INTERVAL_S)
+
+
+def send_eth_toggle_reset(arc_chip, eth_inst_mask, no_fw_reload=False, timeout=None):
+    """Send TT_SMC_MSG_TOGGLE_ETH_RESET (eth_tile_reset_rqst).
+
+    eth_inst_mask: bit N selects ETH instance N.
+    no_fw_reload: when True, sets data[2] bit 0 to skip SPI FW reload and ReleaseEthReset.
+    """
+    msg = [
+        TT_SMC_MSG_TOGGLE_ETH_RESET,
+        eth_inst_mask,
+        1 if no_fw_reload else 0,
+        0,
+        0,
+        0,
+        0,
+        0,
+    ]
+    if timeout is not None:
+        return arc_chip.as_bh().arc_msg_buf(msg, timeout=timeout)
+    return arc_chip.as_bh().arc_msg_buf(msg)
+
+
+def test_eth_toggle_reset_invalid_mask(arc_chip_dut, asic_id):
+    """Reject ETH reset bitmask with bits outside the supported instance range."""
+    arc_chip = pyluwen.detect_chips()[asic_id]
+    bad_mask = 1 << 15
+    response = send_eth_toggle_reset(arc_chip, bad_mask)
+    assert response[0] != 0, "expected non-zero exit for invalid ETH instance mask"
+    assert response[1] == ETH_RESET_ERR_INVALID_MASK, (
+        f"expected ETH_RESET_ERR_INVALID_MASK ({ETH_RESET_ERR_INVALID_MASK}), got {response[1]}"
     )
 
-    assert heartbeat_status == eth_enabled, (
-        f"Heartbeat status {heartbeat_status:#06x} does not match "
-        f"eth_enabled {eth_enabled:#06x}"
+
+def test_eth_toggle_reset_noop_mask(arc_chip_dut, asic_id):
+    """Zero bitmask is a no-op and must return success."""
+    arc_chip = pyluwen.detect_chips()[asic_id]
+    response = send_eth_toggle_reset(arc_chip, 0)
+    assert response[0] == 0, (
+        f"expected success, got status={response[0]} detail={response[1]}"
     )
+    assert response[1] == 0
+
+
+def test_eth_toggle_reset_individual(arc_chip_dut, asic_id):
+    """Reset all individual ETH instances."""
+    arc_chip = pyluwen.detect_chips()[asic_id]
+    eth_enabled = arc_chip.get_telemetry().enabled_eth
+
+    logger.info("Individually reset each ETH instance without SPI FW reload")
+    for eth_inst in range(NUM_ETH):
+        response = send_eth_toggle_reset(arc_chip, 1 << eth_inst, no_fw_reload=True)
+        assert response[0] == 0, (
+            f"ETH {eth_inst}: expected success, got status={response[0]} detail={response[1]}"
+        )
+        assert response[1] == (1 << eth_inst) & eth_enabled
+
+    logger.info("Individually reset each ETH instance with SPI FW reload")
+    for eth_inst in range(NUM_ETH):
+        response = send_eth_toggle_reset(arc_chip, 1 << eth_inst)
+        assert response[0] == 0, (
+            f"ETH {eth_inst}: expected success, got status={response[0]} detail={response[1]}"
+        )
+        assert response[1] == (1 << eth_inst) & eth_enabled
+
+
+def test_eth_toggle_reset_all(arc_chip_dut, asic_id):
+    """Reset all ETH instances"""
+    arc_chip = pyluwen.detect_chips()[asic_id]
+    eth_enabled = arc_chip.get_telemetry().enabled_eth
+    logger.info("Reset all ETH instances without SPI FW reload")
+    response = send_eth_toggle_reset(arc_chip, (1 << NUM_ETH) - 1, no_fw_reload=True)
+    assert response[0] == 0, (
+        f"expected success, got status={response[0]} detail={response[1]}"
+    )
+    assert response[1] == eth_enabled
+
+    logger.info("Reset all ETH instances with SPI FW reload")
+    response = send_eth_toggle_reset(arc_chip, (1 << NUM_ETH) - 1)
+    assert response[0] == 0, (
+        f"expected success, got status={response[0]} detail={response[1]}"
+    )
+    assert response[1] == eth_enabled
 
 
 def test_gddr_reset(arc_chip_dut, asic_id):

--- a/app/smc/pytest/e2e_smoke.py
+++ b/app/smc/pytest/e2e_smoke.py
@@ -88,6 +88,10 @@ ARC_START_TIME_REG_ADDR = 0x80030440
 ARC_HANG_PC_REG_ADDR = 0x80030454
 TELEMETRY_DATA_REG_ADDR = 0x80030430
 
+# ETH tile registers
+# Using this as a scratch register to verify ETH tile reset
+TRISC0_RESET_PC_ADDR = 0xFFB12228
+
 # ARC messages
 TT_SMC_MSG_REINIT_TENSIX = 0x20
 TT_SMC_MSG_FORCE_AICLK = 0x33
@@ -1312,6 +1316,45 @@ def send_eth_toggle_reset(arc_chip, eth_inst_mask, no_fw_reload=False, timeout=N
     return arc_chip.as_bh().arc_msg_buf(msg)
 
 
+def eth_id_to_noc0_coords(eth_inst) -> tuple[int, int]:
+    PHYS_X_TO_NOC0 = [0, 1, 16, 2, 15, 3, 14, 4, 13, 5, 12, 6, 11, 7, 10, 8, 9]
+
+    x = PHYS_X_TO_NOC0[eth_inst + 1]
+    y = 1  # All ETH tiles are on the same row
+
+    return x, y
+
+
+def set_eth_scratch_pre_reset(arc_chip, eth_inst_mask):
+    """
+    Write a sentinel value to the scratch register for the given ETH instances.
+    This is used to verify that the ETH tile was reset.
+    Avoid writing to harvested ETH tiles, since that will hang the NOC.
+    """
+    for eth_inst in range(NUM_ETH):
+        if not (1 << eth_inst) & eth_inst_mask:
+            continue
+
+        x, y = eth_id_to_noc0_coords(eth_inst)
+        arc_chip.noc_write32(
+            noc_id=0, x=x, y=y, addr=TRISC0_RESET_PC_ADDR, data=0xA5A5A5A5
+        )
+
+
+def check_eth_scratch_post_reset(arc_chip, eth_inst_mask):
+    """
+    Verify that the scratch register for the given ETH instances was cleared after reset.
+    Avoid reading from harvested ETH tiles, since that will hang the NOC.
+    """
+    for eth_inst in range(NUM_ETH):
+        if not (1 << eth_inst) & eth_inst_mask:
+            continue
+
+        x, y = eth_id_to_noc0_coords(eth_inst)
+        scratch = arc_chip.noc_read32(noc_id=0, x=x, y=y, addr=TRISC0_RESET_PC_ADDR)
+        assert scratch == 0, f"ETH {eth_inst} scratch register not cleared after reset"
+
+
 def test_eth_toggle_reset_invalid_mask(arc_chip_dut, asic_id):
     """Reject ETH reset bitmask with bits outside the supported instance range."""
     arc_chip = pyluwen.detect_chips()[asic_id]
@@ -1340,19 +1383,23 @@ def test_eth_toggle_reset_individual(arc_chip_dut, asic_id):
 
     logger.info("Individually reset each ETH instance without SPI FW reload")
     for eth_inst in range(NUM_ETH):
+        set_eth_scratch_pre_reset(arc_chip, (1 << eth_inst) & eth_enabled)
         response = send_eth_toggle_reset(arc_chip, 1 << eth_inst, no_fw_reload=True)
         assert response[0] == 0, (
             f"ETH {eth_inst}: expected success, got status={response[0]} detail={response[1]}"
         )
         assert response[1] == (1 << eth_inst) & eth_enabled
+        check_eth_scratch_post_reset(arc_chip, (1 << eth_inst) & eth_enabled)
 
     logger.info("Individually reset each ETH instance with SPI FW reload")
     for eth_inst in range(NUM_ETH):
+        set_eth_scratch_pre_reset(arc_chip, (1 << eth_inst) & eth_enabled)
         response = send_eth_toggle_reset(arc_chip, 1 << eth_inst)
         assert response[0] == 0, (
             f"ETH {eth_inst}: expected success, got status={response[0]} detail={response[1]}"
         )
         assert response[1] == (1 << eth_inst) & eth_enabled
+        check_eth_scratch_post_reset(arc_chip, (1 << eth_inst) & eth_enabled)
 
 
 def test_eth_toggle_reset_all(arc_chip_dut, asic_id):
@@ -1360,18 +1407,22 @@ def test_eth_toggle_reset_all(arc_chip_dut, asic_id):
     arc_chip = pyluwen.detect_chips()[asic_id]
     eth_enabled = arc_chip.get_telemetry().enabled_eth
     logger.info("Reset all ETH instances without SPI FW reload")
+    set_eth_scratch_pre_reset(arc_chip, ((1 << NUM_ETH) - 1) & eth_enabled)
     response = send_eth_toggle_reset(arc_chip, (1 << NUM_ETH) - 1, no_fw_reload=True)
     assert response[0] == 0, (
         f"expected success, got status={response[0]} detail={response[1]}"
     )
     assert response[1] == eth_enabled
+    check_eth_scratch_post_reset(arc_chip, ((1 << NUM_ETH) - 1) & eth_enabled)
 
     logger.info("Reset all ETH instances with SPI FW reload")
+    set_eth_scratch_pre_reset(arc_chip, ((1 << NUM_ETH) - 1) & eth_enabled)
     response = send_eth_toggle_reset(arc_chip, (1 << NUM_ETH) - 1)
     assert response[0] == 0, (
         f"expected success, got status={response[0]} detail={response[1]}"
     )
     assert response[1] == eth_enabled
+    check_eth_scratch_post_reset(arc_chip, ((1 << NUM_ETH) - 1) & eth_enabled)
 
 
 def test_gddr_reset(arc_chip_dut, asic_id):

--- a/include/tenstorrent/msgqueue.h
+++ b/include/tenstorrent/msgqueue.h
@@ -572,12 +572,15 @@ enum gddr_reset_err {
 
 /** @brief Host request to reset and reinitialize one or more ETH tiles
  *
- * The handler performs the appropriate sequencing to reset and reinitialize the requested
- * ethernet tiles.
+ * The handler performs the appropriate sequencing to reset and (optionally)
+ * restart ERISC FW on the requested ethernet tiles.
  *
  * Request: @c eth_inst_mask is a bitmask of ETH instance indices (bit N selects ETH N).
  * Bits for harvested instances are silently dropped. An empty effective mask returns success
- * (no-op).
+ * (no-op). When @c no_fw_reload is 1, SPI FW/cfg reload and @c ReleaseEthReset are skipped.
+ *
+ * Wire layout as @c uint32_t data[8]: @c data[1] = @c eth_inst_mask; @c data[2] bit 0 =
+ * @c no_fw_reload.
  *
  * On failure, response @c data[0] exit code is 1 @c data[1] contains @ref eth_reset_err.
  * On success, response @c data[0] exit code is 0 and @c data[1] is the bitmask of the
@@ -592,6 +595,9 @@ struct eth_tile_reset_rqst {
 
 	/** @brief Bitmask of ETH instances to reset (bit N -> ETH N) */
 	uint32_t eth_inst_mask;
+
+	/** @brief If 1, tile/RISC reset only; skip SPI FW/cfg reload and ReleaseEthReset */
+	uint8_t no_fw_reload: 1;
 };
 
 /** @brief Error codes in response data[1] for @ref TT_SMC_MSG_TOGGLE_ETH_RESET */

--- a/include/tenstorrent/msgqueue.h
+++ b/include/tenstorrent/msgqueue.h
@@ -570,6 +570,42 @@ enum gddr_reset_err {
 	GDDR_RESET_ERR_POWERDOWN = 6,
 };
 
+/** @brief Host request to reset and reinitialize one or more ETH tiles
+ *
+ * The handler performs the appropriate sequencing to reset and reinitialize the requested
+ * ethernet tiles.
+ *
+ * Request: @c eth_inst_mask is a bitmask of ETH instance indices (bit N selects ETH N).
+ * Bits for harvested instances are silently dropped. An empty effective mask returns success
+ * (no-op).
+ *
+ * On failure, response @c data[0] exit code is 1 @c data[1] contains @ref eth_reset_err.
+ * On success, response @c data[0] exit code is 0 and @c data[1] is the bitmask of the
+ * successfully reset tiles.
+ */
+struct eth_tile_reset_rqst {
+	/** @brief Command code @ref TT_SMC_MSG_TOGGLE_ETH_RESET */
+	uint8_t command_code;
+
+	/** @brief Padding */
+	uint8_t pad[3];
+
+	/** @brief Bitmask of ETH instances to reset (bit N -> ETH N) */
+	uint32_t eth_inst_mask;
+};
+
+/** @brief Error codes in response data[1] for @ref TT_SMC_MSG_TOGGLE_ETH_RESET */
+enum eth_reset_err {
+	ETH_RESET_ERR_INVALID_MASK = 1,
+	ETH_RESET_ERR_CABLE_FAULT = 2,
+	ETH_RESET_ERR_NO_FLASH = 3,
+	ETH_RESET_ERR_FW_LOOKUP = 4,
+	ETH_RESET_ERR_FW_LOAD = 5,
+	ETH_RESET_ERR_CFG_LOOKUP = 6,
+	ETH_RESET_ERR_CFG_SIZE = 7,
+	ETH_RESET_ERR_CFG_LOAD = 8,
+};
+
 /** @brief Host request to trigger a chip reset
  * @details Messages of this type are processed by @ref reset_dm_handler.
  *
@@ -928,6 +964,9 @@ union request {
 
 	/** @brief A GDDR reset request */
 	struct gddr_reset_rqst gddr_reset;
+
+	/** @brief An ETH tile reset request */
+	struct eth_tile_reset_rqst eth_tile_reset;
 
 	/** @brief A temperature sensor read request */
 	struct read_ts_rqst read_ts;

--- a/include/tenstorrent/msgqueue.h
+++ b/include/tenstorrent/msgqueue.h
@@ -575,15 +575,14 @@ enum gddr_reset_err {
  * The handler performs the appropriate sequencing to reset and (optionally)
  * restart ERISC FW on the requested ethernet tiles.
  *
- * Request: @c eth_inst_mask is a bitmask of ETH instance indices (bit N selects ETH N).
+ * Request: @ref eth_inst_mask is a bitmask of ETH instance indices (bit N selects ETH N).
  * Bits for harvested instances are silently dropped. An empty effective mask returns success
- * (no-op). When @c no_fw_reload is 1, SPI FW/cfg reload and @c ReleaseEthReset are skipped.
+ * (no-op). Only bits 0-13 are valid, setting other bits will return the error
+ * @ref ETH_RESET_ERR_INVALID_MASK.
+ * When `no_fw_reload` is 1, SPI FW/cfg reload and `ReleaseEthReset` are skipped.
  *
- * Wire layout as @c uint32_t data[8]: @c data[1] = @c eth_inst_mask; @c data[2] bit 0 =
- * @c no_fw_reload.
- *
- * On failure, response @c data[0] exit code is 1 @c data[1] contains @ref eth_reset_err.
- * On success, response @c data[0] exit code is 0 and @c data[1] is the bitmask of the
+ * On failure, response `data[0]` exit code is 1 and `data[1]` contains @ref eth_reset_err.
+ * On success, response `data[0]` exit code is 0 and `data[1]` is the bitmask of the
  * successfully reset tiles.
  */
 struct eth_tile_reset_rqst {

--- a/include/tenstorrent/smc_msg.h
+++ b/include/tenstorrent/smc_msg.h
@@ -136,6 +136,9 @@ enum tt_smc_msg {
 	/** @brief @ref toggle_tensix_reset_rqst "Toggle Tensix reset request" */
 	TT_SMC_MSG_TOGGLE_TENSIX_RESET = 0xAF,
 
+	/** @brief @ref eth_tile_reset_rqst "Toggle ETH tile reset request" */
+	TT_SMC_MSG_TOGGLE_ETH_RESET = 0xB0,
+
 	/** @brief @ref gddr_reset_rqst "Toggle GDDR reset request" */
 	TT_SMC_MSG_TOGGLE_GDDR_RESET = 0xB6,
 

--- a/lib/tenstorrent/bh_arc/eth.c
+++ b/lib/tenstorrent/bh_arc/eth.c
@@ -14,8 +14,11 @@
 #include "noc2axi.h"
 #include "reg.h"
 #include "serdes_eth.h"
+#include "aiclk_ppm.h"
 
+#include <tenstorrent/msgqueue.h>
 #include <tenstorrent/post_code.h>
+#include <tenstorrent/smc_msg.h>
 #include <tenstorrent/spi_flash_buf.h>
 #include <tenstorrent/sys_init_defines.h>
 #include <tenstorrent/tt_boot_fs.h>
@@ -26,6 +29,7 @@
 #include <zephyr/drivers/dma.h>
 #include <zephyr/drivers/dma/dma_tt_bh_noc.h>
 #include <zephyr/drivers/dma/dma_arc_hs.h>
+#include <zephyr/device.h>
 
 LOG_MODULE_REGISTER(eth, CONFIG_TT_APP_LOG_LEVEL);
 
@@ -528,6 +532,134 @@ static void EthInit(void)
 		saved_heartbeat[eth_inst] = 0;
 	}
 }
+
+static void assert_eth_risc_soft_reset(uint32_t eth_inst, uint32_t ring)
+{
+	const uint32_t kAllRiscSoftReset = 0x47800;
+	uint8_t x, y;
+
+	GetEthNocCoords(eth_inst, ring, &x, &y);
+	NOC2AXITlbSetup(ring, ETH_SETUP_TLB, x, y, ETH_RISC_DEBUG_SOFT_RESET_0);
+	NOC2AXIWrite32(ring, ETH_SETUP_TLB, ETH_RISC_DEBUG_SOFT_RESET_0, kAllRiscSoftReset);
+}
+
+static uint8_t toggle_eth_reset_handler(const union request *req, struct response *rsp)
+{
+	const uint32_t ring = 0;
+	const uint32_t valid_bits = (1U << MAX_ETH_INSTANCES) - 1U;
+	uint32_t requested = req->eth_tile_reset.eth_inst_mask;
+	int rc;
+
+	if (!IS_ENABLED(CONFIG_ARC)) {
+		return 0;
+	}
+
+	if (requested & ~valid_bits) {
+		rsp->data[1] = ETH_RESET_ERR_INVALID_MASK;
+		return 1;
+	}
+
+	uint32_t mask = requested & tile_enable.eth_enabled;
+
+	if (mask == 0) {
+		rsp->data[1] = 0;
+		return 0;
+	}
+
+	if (is_cable_fault_mode()) {
+		rsp->data[1] = ETH_RESET_ERR_CABLE_FAULT;
+		return 1;
+	}
+
+	if (flash == NULL || !device_is_ready(flash)) {
+		rsp->data[1] = ETH_RESET_ERR_NO_FLASH;
+		return 1;
+	}
+
+	tt_boot_fs_fd fw_fd;
+	tt_boot_fs_fd cfg_fd;
+
+	rc = tt_boot_fs_find_fd_by_tag(flash, ETH_FW_TAG, &fw_fd);
+	if (rc < 0) {
+		rsp->data[1] = ETH_RESET_ERR_FW_LOOKUP;
+		return 1;
+	}
+
+	rc = tt_boot_fs_find_fd_by_tag(flash, ETH_FW_CFG_TAG, &cfg_fd);
+	if (rc < 0) {
+		rsp->data[1] = ETH_RESET_ERR_CFG_LOOKUP;
+		return 1;
+	}
+
+	if (cfg_fd.flags.f.image_size > SCRATCHPAD_SIZE) {
+		rsp->data[1] = ETH_RESET_ERR_CFG_SIZE;
+		return 1;
+	}
+
+	SetAiclkResetSafe(true);
+
+	RESET_UNIT_ETH_RESET_reg_u eth_reset = {.val = ReadReg(RESET_UNIT_ETH_RESET_REG_ADDR)};
+
+	/* Assert tile and risc reset */
+	eth_reset.f.eth_reset_n &= ~mask;
+	eth_reset.f.eth_risc_reset_n &= ~mask;
+	WriteReg(RESET_UNIT_ETH_RESET_REG_ADDR, eth_reset.val);
+
+	/* Deassert tile reset */
+	eth_reset.f.eth_reset_n |= mask;
+	WriteReg(RESET_UNIT_ETH_RESET_REG_ADDR, eth_reset.val);
+
+	/* Assert RISC soft reset via NOC for each tile. */
+	for (uint8_t eth_inst = 0; eth_inst < MAX_ETH_INSTANCES; eth_inst++) {
+		if (IS_BIT_SET(mask, eth_inst)) {
+			assert_eth_risc_soft_reset(eth_inst, ring);
+		}
+	}
+
+	/* Deassert risc reset */
+	eth_reset.f.eth_risc_reset_n |= mask;
+	WriteReg(RESET_UNIT_ETH_RESET_REG_ADDR, eth_reset.val);
+
+	SetAiclkResetSafe(false);
+
+	/* Reload ERISC FW */
+	uint8_t buf[SCRATCHPAD_SIZE] __aligned(4);
+
+	for (uint8_t eth_inst = 0; eth_inst < MAX_ETH_INSTANCES; eth_inst++) {
+		if (!IS_BIT_SET(mask, eth_inst)) {
+			continue;
+		}
+
+		rc = LoadEthFw(eth_inst, ring, buf, sizeof(buf), fw_fd.spi_addr,
+			       fw_fd.flags.f.image_size);
+		if (rc < 0) {
+			rsp->data[1] = ETH_RESET_ERR_FW_LOAD;
+			return 1;
+		}
+
+		rc = LoadEthFwCfg(eth_inst, ring, buf, tile_enable.eth_enabled, cfg_fd.spi_addr,
+				  cfg_fd.flags.f.image_size);
+		if (rc < 0) {
+			rsp->data[1] = ETH_RESET_ERR_CFG_LOAD;
+			return 1;
+		}
+	}
+
+	/* Start ERISC FW */
+	for (uint8_t eth_inst = 0; eth_inst < MAX_ETH_INSTANCES; eth_inst++) {
+		if (!IS_BIT_SET(mask, eth_inst)) {
+			continue;
+		}
+
+		ReleaseEthReset(eth_inst, ring);
+		saved_heartbeat[eth_inst] = 0;
+	}
+
+	rsp->data[1] = mask;
+	return 0;
+}
+
+REGISTER_MESSAGE(TT_SMC_MSG_TOGGLE_ETH_RESET, toggle_eth_reset_handler);
 
 static int eth_init(void)
 {

--- a/lib/tenstorrent/bh_arc/eth.c
+++ b/lib/tenstorrent/bh_arc/eth.c
@@ -548,6 +548,7 @@ static uint8_t toggle_eth_reset_handler(const union request *req, struct respons
 	const uint32_t ring = 0;
 	const uint32_t valid_bits = (1U << MAX_ETH_INSTANCES) - 1U;
 	uint32_t requested = req->eth_tile_reset.eth_inst_mask;
+	const bool skip_fw = req->eth_tile_reset.no_fw_reload != 0;
 	int rc;
 
 	if (!IS_ENABLED(CONFIG_ARC)) {
@@ -571,29 +572,31 @@ static uint8_t toggle_eth_reset_handler(const union request *req, struct respons
 		return 1;
 	}
 
-	if (flash == NULL || !device_is_ready(flash)) {
-		rsp->data[1] = ETH_RESET_ERR_NO_FLASH;
-		return 1;
-	}
-
 	tt_boot_fs_fd fw_fd;
 	tt_boot_fs_fd cfg_fd;
 
-	rc = tt_boot_fs_find_fd_by_tag(flash, ETH_FW_TAG, &fw_fd);
-	if (rc < 0) {
-		rsp->data[1] = ETH_RESET_ERR_FW_LOOKUP;
-		return 1;
-	}
+	if (!skip_fw) {
+		if (flash == NULL || !device_is_ready(flash)) {
+			rsp->data[1] = ETH_RESET_ERR_NO_FLASH;
+			return 1;
+		}
 
-	rc = tt_boot_fs_find_fd_by_tag(flash, ETH_FW_CFG_TAG, &cfg_fd);
-	if (rc < 0) {
-		rsp->data[1] = ETH_RESET_ERR_CFG_LOOKUP;
-		return 1;
-	}
+		rc = tt_boot_fs_find_fd_by_tag(flash, ETH_FW_TAG, &fw_fd);
+		if (rc < 0) {
+			rsp->data[1] = ETH_RESET_ERR_FW_LOOKUP;
+			return 1;
+		}
 
-	if (cfg_fd.flags.f.image_size > SCRATCHPAD_SIZE) {
-		rsp->data[1] = ETH_RESET_ERR_CFG_SIZE;
-		return 1;
+		rc = tt_boot_fs_find_fd_by_tag(flash, ETH_FW_CFG_TAG, &cfg_fd);
+		if (rc < 0) {
+			rsp->data[1] = ETH_RESET_ERR_CFG_LOOKUP;
+			return 1;
+		}
+
+		if (cfg_fd.flags.f.image_size > SCRATCHPAD_SIZE) {
+			rsp->data[1] = ETH_RESET_ERR_CFG_SIZE;
+			return 1;
+		}
 	}
 
 	SetAiclkResetSafe(true);
@@ -622,37 +625,38 @@ static uint8_t toggle_eth_reset_handler(const union request *req, struct respons
 
 	SetAiclkResetSafe(false);
 
-	/* Reload ERISC FW */
-	uint8_t buf[SCRATCHPAD_SIZE] __aligned(4);
+	if (!skip_fw) {
+		uint8_t buf[SCRATCHPAD_SIZE] __aligned(4);
 
-	for (uint8_t eth_inst = 0; eth_inst < MAX_ETH_INSTANCES; eth_inst++) {
-		if (!IS_BIT_SET(mask, eth_inst)) {
-			continue;
+		for (uint8_t eth_inst = 0; eth_inst < MAX_ETH_INSTANCES; eth_inst++) {
+			if (!IS_BIT_SET(mask, eth_inst)) {
+				continue;
+			}
+
+			rc = LoadEthFw(eth_inst, ring, buf, sizeof(buf), fw_fd.spi_addr,
+				       fw_fd.flags.f.image_size);
+			if (rc < 0) {
+				rsp->data[1] = ETH_RESET_ERR_FW_LOAD;
+				return 1;
+			}
+
+			rc = LoadEthFwCfg(eth_inst, ring, buf, tile_enable.eth_enabled,
+					  cfg_fd.spi_addr, cfg_fd.flags.f.image_size);
+			if (rc < 0) {
+				rsp->data[1] = ETH_RESET_ERR_CFG_LOAD;
+				return 1;
+			}
 		}
 
-		rc = LoadEthFw(eth_inst, ring, buf, sizeof(buf), fw_fd.spi_addr,
-			       fw_fd.flags.f.image_size);
-		if (rc < 0) {
-			rsp->data[1] = ETH_RESET_ERR_FW_LOAD;
-			return 1;
-		}
+		/* Start ERISC FW */
+		for (uint8_t eth_inst = 0; eth_inst < MAX_ETH_INSTANCES; eth_inst++) {
+			if (!IS_BIT_SET(mask, eth_inst)) {
+				continue;
+			}
 
-		rc = LoadEthFwCfg(eth_inst, ring, buf, tile_enable.eth_enabled, cfg_fd.spi_addr,
-				  cfg_fd.flags.f.image_size);
-		if (rc < 0) {
-			rsp->data[1] = ETH_RESET_ERR_CFG_LOAD;
-			return 1;
+			ReleaseEthReset(eth_inst, ring);
+			saved_heartbeat[eth_inst] = 0;
 		}
-	}
-
-	/* Start ERISC FW */
-	for (uint8_t eth_inst = 0; eth_inst < MAX_ETH_INSTANCES; eth_inst++) {
-		if (!IS_BIT_SET(mask, eth_inst)) {
-			continue;
-		}
-
-		ReleaseEthReset(eth_inst, ring);
-		saved_heartbeat[eth_inst] = 0;
 	}
 
 	rsp->data[1] = mask;


### PR DESCRIPTION
Add an SMC msg that toggles the ethernet tile reset. This is useful for two purposes:
1. eth tests were previously directly toggling eth reset directly, but
   this now causes issues with SMC FW's eth telemetry polling. Having
   SMC do the reset ensures these processes do not interfere.
2. There may be cases where an individual ethernet tile needs to be
    reset to recover the link.

resolves: SYS-4052