### PR TITLE
ci_smoke: skip on long test label

### DIFF
--- a/.github/workflows/hardware-long.yml
+++ b/.github/workflows/hardware-long.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch: {}
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event.label.name || 'default' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/hardware-smoke.yml
+++ b/.github/workflows/hardware-smoke.yml
@@ -21,7 +21,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event.label.name || 'default' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/hardware-smoke.yml
+++ b/.github/workflows/hardware-smoke.yml
@@ -26,6 +26,7 @@ concurrency:
 
 jobs:
   gen-config:
+    if: github.event.action != 'labeled' || github.event.label.name == 'wh-tests'
     runs-on: ubuntu-24.04
     outputs:
       matrix-config-bh: ${{ steps.gen-config.outputs.matrix-config-bh }}
@@ -45,7 +46,7 @@ jobs:
           echo "matrix-config-wh=$MATRIX_CONFIG_WH" | tee -a $GITHUB_OUTPUT
 
   detect-changes:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && (github.event.action != 'labeled' || github.event.label.name == 'wh-tests')
     runs-on: ubuntu-24.04
     permissions:
       pull-requests: read
@@ -61,7 +62,7 @@ jobs:
 
   hardware-smoke-test:
     name: BH Hardware Smoke Test on ${{ matrix.config.board }}
-    if: github.event_name != 'schedule'
+    if: github.event_name != 'schedule' && github.event.action != 'labeled'
     needs: [gen-config]
     env:
       ASIC_ID: 0
@@ -154,7 +155,7 @@ jobs:
 
   smoke-e2e-test:
     name: BH Smoke E2E Test on ${{ matrix.config.board }}
-    if: github.event_name != 'schedule'
+    if: github.event_name != 'schedule' && github.event.action != 'labeled'
     needs: [gen-config]
     strategy:
       fail-fast: false

--- a/.github/workflows/metal.yml
+++ b/.github/workflows/metal.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch: {}
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event.label.name || 'default' }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
This PR changes the way labels cause previous unrelated tests to rerun. This has two commits,

1. Adding any label event (metal or stress) to a PR causes smoke to rerun, wasting CI cycles. Skip smoke tests on labelled events.

2. If you add the Metal test tag after Soak ran, it will cancel the Soak workflow even if Soak originally passed. Include the label name in the concurrency group so different labels get different groups and can't conflict with each other.