### PR TITLE
fwtable: p300c: default to pcie gen4 speed

### DIFF
--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300C_L/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300C_L/fw_table.txt
@@ -57,7 +57,7 @@ pci0_property_table {
 }
 
 pci1_property_table {
-  max_pcie_speed: 0
+  max_pcie_speed: 4
   pcie_bar0_size: 512
   pcie_bar2_size: 1
   pcie_bar4_size: 32768

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300C_R/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300C_R/fw_table.txt
@@ -48,7 +48,7 @@ chip_harvesting_table {
 }
 
 pci0_property_table {
-  max_pcie_speed: 0
+  max_pcie_speed: 4
   pcie_bar0_size: 512
   pcie_bar2_size: 1
   pcie_bar4_size: 32768

--- a/doc/release/release-notes-19.11.md
+++ b/doc/release/release-notes-19.11.md
@@ -14,6 +14,9 @@ Major enhancements with this release include:
 
 ## Blackhole
 
+### PCIe
+
+- For P300C boards, update PCIe speed to Gen4 to improve QB2 PCIe stability (SYS-4229).
 
 ## Grendel
 


### PR DESCRIPTION
Increase PCIe stability on QB2 system by setting P300C default PCIe speed capability to gen4.

resolves: SYS-4229