### PR TITLE
drivers: Use DEVICE_API macro to define api

### DIFF
--- a/drivers/clock_control/clock_control_emul.c
+++ b/drivers/clock_control/clock_control_emul.c
@@ -109,7 +109,7 @@ static enum clock_control_status clock_control_emul_get_status(const struct devi
 	return data->clock_enabled[subsys_id] ? CLOCK_CONTROL_STATUS_ON : CLOCK_CONTROL_STATUS_OFF;
 }
 
-static const struct clock_control_driver_api clock_control_emul_api = {
+static DEVICE_API(clock_control, clock_control_emul_api) = {
 	.on = clock_control_emul_on,
 	.off = clock_control_emul_off,
 	.get_rate = clock_control_emul_get_rate,

--- a/drivers/clock_control/clock_control_tt_bh.c
+++ b/drivers/clock_control/clock_control_tt_bh.c
@@ -627,14 +627,14 @@ static int clock_control_tt_bh_init(const struct device *dev)
 	return 0;
 }
 
-static const struct clock_control_driver_api clock_control_tt_bh_api = {
-	.on = clock_control_tt_bh_on,
-	.off = clock_control_tt_bh_off,
-	.async_on = clock_control_tt_bh_async_on,
-	.get_rate = clock_control_tt_bh_get_rate,
-	.get_status = clock_control_tt_bh_get_status,
-	.set_rate = clock_control_tt_bh_set_rate,
-	.configure = clock_control_tt_bh_configure};
+static DEVICE_API(clock_control,
+		  clock_control_tt_bh_api) = {.on = clock_control_tt_bh_on,
+					      .off = clock_control_tt_bh_off,
+					      .async_on = clock_control_tt_bh_async_on,
+					      .get_rate = clock_control_tt_bh_get_rate,
+					      .get_status = clock_control_tt_bh_get_status,
+					      .set_rate = clock_control_tt_bh_set_rate,
+					      .configure = clock_control_tt_bh_configure};
 
 #define CLOCK_CONTROL_TT_BH_INIT(_inst)                                                            \
 	static struct clock_control_tt_bh_data clock_control_tt_bh_data_##_inst;                   \

--- a/drivers/clock_control/clock_control_tt_grendel.c
+++ b/drivers/clock_control/clock_control_tt_grendel.c
@@ -301,7 +301,7 @@ static int clock_control_tt_grendel_init(const struct device *dev)
 	return 0;
 }
 
-static const struct clock_control_driver_api clock_control_tt_grendel_api = {
+static DEVICE_API(clock_control, clock_control_tt_grendel_api) = {
 	.on = clock_control_tt_grendel_on,
 	.off = clock_control_tt_grendel_off,
 	.get_rate = clock_control_tt_grendel_get_rate,

--- a/drivers/dma/dma_arc_hs.c
+++ b/drivers/dma/dma_arc_hs.c
@@ -909,7 +909,7 @@ static void dma_arc_hs_isr(const struct device *dev)
 }
 #endif /* DT_ALL_INST_HAS_PROP_STATUS_OKAY(interrupts) */
 
-static const struct dma_driver_api dma_arc_hs_api = {
+static DEVICE_API(dma, dma_arc_hs_api) = {
 	.config = dma_arc_hs_config,
 	.start = dma_arc_hs_start,
 	.stop = dma_arc_hs_stop,

--- a/drivers/dma/dma_tt_bh_noc.c
+++ b/drivers/dma/dma_tt_bh_noc.c
@@ -517,7 +517,7 @@ static int tt_bh_dma_noc_stop(const struct device *dev, uint32_t channel)
 	return 0;
 }
 
-static const struct dma_driver_api tt_bh_dma_noc_api = {
+static DEVICE_API(dma, tt_bh_dma_noc_api) = {
 	.config = tt_bh_dma_noc_config,
 	.reload = NULL,
 	.start = tt_bh_dma_noc_start,

--- a/drivers/dma/dma_tt_grendel_smc.c
+++ b/drivers/dma/dma_tt_grendel_smc.c
@@ -208,7 +208,7 @@ static int dma_grendel_init(const struct device *dev)
 	return 0;
 }
 
-static const struct dma_driver_api dma_grendel_api = {
+static DEVICE_API(dma, dma_grendel_api) = {
 	.config = dma_grendel_config,
 	.reload = NULL,
 	.start = dma_grendel_start,

--- a/drivers/mbox/mbox_tt_grendel.c
+++ b/drivers/mbox/mbox_tt_grendel.c
@@ -211,7 +211,7 @@ static int tt_grendel_mbox_set_enabled(const struct device *dev, mbox_channel_id
 	return 0;
 }
 
-static const struct mbox_driver_api tt_grendel_mbox_api = {
+static DEVICE_API(mbox, tt_grendel_mbox_api) = {
 	.send = tt_grendel_mbox_send,
 	.mtu_get = tt_grendel_mbox_mtu_get,
 	.max_channels_get = tt_grendel_mbox_max_channels_get,

--- a/drivers/reset/reset_tt_bh.c
+++ b/drivers/reset/reset_tt_bh.c
@@ -115,7 +115,7 @@ static int tt_bh_reset_init(const struct device *dev)
 	return 0;
 }
 
-static const struct reset_driver_api tt_bh_reset_api = {
+static DEVICE_API(reset, tt_bh_reset_api) = {
 	.status = tt_bh_reset_status,
 	.line_assert = tt_bh_reset_line_assert,
 	.line_deassert = tt_bh_reset_line_deassert,

--- a/drivers/sensor/tenstorrent/pvt/pvt_tt_bh.c
+++ b/drivers/sensor/tenstorrent/pvt/pvt_tt_bh.c
@@ -501,7 +501,7 @@ static int pvt_tt_bh_init(const struct device *dev)
 	return 0;
 }
 
-static const struct sensor_driver_api pvt_tt_bh_driver_api = {
+static DEVICE_API(sensor, pvt_tt_bh_driver_api) = {
 	.attr_set = NULL,
 	.attr_get = pvt_tt_bh_attr_get,
 	.trigger_set = NULL,

--- a/drivers/smbus/target/smbus_target.c
+++ b/drivers/smbus/target/smbus_target.c
@@ -324,7 +324,7 @@ static int32_t smbus_write_requested(struct i2c_target_config *config)
 	return 0;
 }
 
-static const struct i2c_target_driver_api api_funcs = {
+static DEVICE_API(i2c_target, api_funcs) = {
 	.driver_register = smbus_target_register,
 	.driver_unregister = smbus_target_unregister,
 };


### PR DESCRIPTION
Runtime asserts on device compatability verify the API ptr range resides in a section populated by using the DEVICE_API macro. Failure to do so will cause
false detects of an incorrect API being used.

This is necessary for when we rebase on top of 4.4.0 <plus>