### PR TITLE
lib: bh_arc: change noc2axi port used for gddr0 from 0 to 2

### DIFF
--- a/doc/release/release-notes-19.12.md
+++ b/doc/release/release-notes-19.12.md
@@ -19,6 +19,10 @@ Major enhancements with this release include:
 ### Telemetry
 - Carve out a region of memory for Metal runtime telemetry and publish its address and size via `SCRATCH_RAM[22:23]`.
 
+### GDDR
+- Change NOC endpoint used to load GDDR0 MRISC from 0 to 2 (NOC node 0-11)
+- Report the NOC endpoint each GDDR instance loads MRISC on in telemetry at `TAG_GDDR_MRISC_NOC2AXI_PORT`
+
 ## Grendel
 
 <!-- Subsections can break down improvements by (area or board) -->

--- a/lib/tenstorrent/bh_arc/gddr.c
+++ b/lib/tenstorrent/bh_arc/gddr.c
@@ -49,7 +49,7 @@ static const struct device *dma_noc = DEVICE_DT_GET(DT_NODELABEL(dma1));
  * gddr0 runs its MRISC FW on noc2axi port 2 (NoC 0-11) instead of the default
  * port 0 (NoC 0-0); all other GDDR instances stay on the default port.
  */
-static inline uint8_t MriscFwNoc2AxiPort(uint8_t gddr_inst)
+uint8_t get_gddr_mrisc_noc2axi_port(uint8_t gddr_inst)
 {
 	return (gddr_inst == 0) ? 2 : MRISC_FW_NOC2AXI_PORT;
 }
@@ -86,7 +86,7 @@ static uint32_t GetGddrSpeedFromCfg(uint8_t *fw_cfg_image)
 
 static void GetGddrMriscNocCoords(uint8_t gddr_inst, uint8_t noc_id, uint8_t *x, uint8_t *y)
 {
-	GetGddrNocCoords(gddr_inst, MriscFwNoc2AxiPort(gddr_inst), noc_id, x, y);
+	GetGddrNocCoords(gddr_inst, get_gddr_mrisc_noc2axi_port(gddr_inst), noc_id, x, y);
 }
 
 static volatile void *SetupMriscL1Tlb(uint8_t gddr_inst)

--- a/lib/tenstorrent/bh_arc/gddr.c
+++ b/lib/tenstorrent/bh_arc/gddr.c
@@ -42,8 +42,18 @@ static const struct device *const arc_dma_dev = DEVICE_DT_GET_OR_NULL(DT_NODELAB
 #endif
 static const struct device *dma_noc = DEVICE_DT_GET(DT_NODELABEL(dma1));
 
-/* This is the noc2axi instance we want to run the MRISC FW on */
+/* This is the default noc2axi instance we want to run the MRISC FW on */
 #define MRISC_FW_NOC2AXI_PORT 0
+
+/*
+ * gddr0 runs its MRISC FW on noc2axi port 2 (NoC 0-11) instead of the default
+ * port 0 (NoC 0-0); all other GDDR instances stay on the default port.
+ */
+static inline uint8_t MriscFwNoc2AxiPort(uint8_t gddr_inst)
+{
+	return (gddr_inst == 0) ? 2 : MRISC_FW_NOC2AXI_PORT;
+}
+
 #define MRISC_SETUP_TLB       13
 #define MRISC_L1_ADDR         (1ULL << 37)
 #define MRISC_REG_ADDR        (1ULL << 40)
@@ -74,11 +84,16 @@ static uint32_t GetGddrSpeedFromCfg(uint8_t *fw_cfg_image)
 	return fw_cfg_dw[1];
 }
 
+static void GetGddrMriscNocCoords(uint8_t gddr_inst, uint8_t noc_id, uint8_t *x, uint8_t *y)
+{
+	GetGddrNocCoords(gddr_inst, MriscFwNoc2AxiPort(gddr_inst), noc_id, x, y);
+}
+
 static volatile void *SetupMriscL1Tlb(uint8_t gddr_inst)
 {
 	uint8_t x, y;
 
-	GetGddrNocCoords(gddr_inst, MRISC_FW_NOC2AXI_PORT, 0, &x, &y);
+	GetGddrMriscNocCoords(gddr_inst, 0, &x, &y);
 	NOC2AXITlbSetup(0, MRISC_SETUP_TLB, x, y, MRISC_L1_ADDR);
 	return GetTlbWindowAddr(0, MRISC_SETUP_TLB, MRISC_L1_ADDR);
 }
@@ -87,7 +102,7 @@ static uint32_t MriscL1Read32(uint8_t gddr_inst, uint32_t addr)
 {
 	uint8_t x, y;
 
-	GetGddrNocCoords(gddr_inst, MRISC_FW_NOC2AXI_PORT, 0, &x, &y);
+	GetGddrMriscNocCoords(gddr_inst, 0, &x, &y);
 	NOC2AXITlbSetup(0, MRISC_SETUP_TLB, x, y, MRISC_L1_ADDR);
 	return NOC2AXIRead32(0, MRISC_SETUP_TLB, MRISC_L1_ADDR + addr);
 }
@@ -96,7 +111,7 @@ static void MriscL1Write32(uint8_t gddr_inst, uint32_t addr, uint32_t val)
 {
 	uint8_t x, y;
 
-	GetGddrNocCoords(gddr_inst, MRISC_FW_NOC2AXI_PORT, 0, &x, &y);
+	GetGddrMriscNocCoords(gddr_inst, 0, &x, &y);
 	NOC2AXITlbSetup(0, MRISC_SETUP_TLB, x, y, MRISC_L1_ADDR);
 	NOC2AXIWrite32(0, MRISC_SETUP_TLB, MRISC_L1_ADDR + addr, val);
 }
@@ -105,7 +120,7 @@ static uint32_t MriscRegRead32(uint8_t gddr_inst, uint32_t addr)
 {
 	uint8_t x, y;
 
-	GetGddrNocCoords(gddr_inst, MRISC_FW_NOC2AXI_PORT, 0, &x, &y);
+	GetGddrMriscNocCoords(gddr_inst, 0, &x, &y);
 	NOC2AXITlbSetup(0, MRISC_SETUP_TLB, x, y, MRISC_REG_ADDR + addr);
 	return NOC2AXIRead32(0, MRISC_SETUP_TLB, MRISC_REG_ADDR + addr);
 }
@@ -114,7 +129,7 @@ static void MriscRegWrite32(uint8_t gddr_inst, uint32_t addr, uint32_t val)
 {
 	uint8_t x, y;
 
-	GetGddrNocCoords(gddr_inst, MRISC_FW_NOC2AXI_PORT, 0, &x, &y);
+	GetGddrMriscNocCoords(gddr_inst, 0, &x, &y);
 	NOC2AXITlbSetup(0, MRISC_SETUP_TLB, x, y, MRISC_REG_ADDR + addr);
 	NOC2AXIWrite32(0, MRISC_SETUP_TLB, MRISC_REG_ADDR + addr, val);
 }
@@ -152,7 +167,7 @@ static void ReleaseMriscReset(uint8_t gddr_inst)
 	const uint32_t kSoftReset0Addr = 0xFFB121B0;
 	uint8_t x, y;
 
-	GetGddrNocCoords(gddr_inst, MRISC_FW_NOC2AXI_PORT, 0, &x, &y);
+	GetGddrMriscNocCoords(gddr_inst, 0, &x, &y);
 	NOC2AXITlbSetup(0, MRISC_SETUP_TLB, x, y, kSoftReset0Addr);
 
 	volatile uint32_t *soft_reset_0 = GetTlbWindowAddr(0, MRISC_SETUP_TLB, kSoftReset0Addr);

--- a/lib/tenstorrent/bh_arc/gddr.c
+++ b/lib/tenstorrent/bh_arc/gddr.c
@@ -443,7 +443,8 @@ static int InitMrisc(void)
 	/* Load MRISC (DRAM RISC) FW to all DRAMs in the middle NOC node */
 
 	for (uint8_t gddr_inst = 0; gddr_inst < NUM_GDDR; gddr_inst++) {
-		for (uint8_t noc2axi_port = 0; noc2axi_port < 3; noc2axi_port++) {
+		for (uint8_t noc2axi_port = 0; noc2axi_port < NUM_MRISC_NOC2AXI_PORT;
+		     noc2axi_port++) {
 			SetAxiEnable(gddr_inst, noc2axi_port, true);
 		}
 	}

--- a/lib/tenstorrent/bh_arc/gddr.h
+++ b/lib/tenstorrent/bh_arc/gddr.h
@@ -75,6 +75,14 @@ struct gddr_temps {
  */
 int get_gddr_temps(struct gddr_temps *temps);
 
+/**
+ * @brief Get the noc2axi port MRISC FW is loaded on for a GDDR instance.
+ *
+ * @param [in] gddr_inst GDDR controller instance (0 - @ref NUM_GDDR - 1).
+ * @return noc2axi port index (0, 1 or 2).
+ */
+uint8_t get_gddr_mrisc_noc2axi_port(uint8_t gddr_inst);
+
 /** @brief BIST status bitmasks (one bit per GDDR instance). */
 struct gddr_bist_info {
 	uint8_t complete;

--- a/lib/tenstorrent/bh_arc/reset.c
+++ b/lib/tenstorrent/bh_arc/reset.c
@@ -119,7 +119,8 @@ static int AssertSoftResets(void)
 	for (uint8_t gddr_inst = 0; gddr_inst < NUM_GDDR; gddr_inst++) {
 		/* Skip harvested GDDR tiles */
 		if (tile_enable.gddr_enabled & BIT(gddr_inst)) {
-			for (uint8_t noc_node_inst = 0; noc_node_inst < 3; noc_node_inst++) {
+			for (uint8_t noc_node_inst = 0; noc_node_inst < NUM_MRISC_NOC2AXI_PORT;
+			     noc_node_inst++) {
 				uint8_t x, y;
 
 				GetGddrNocCoords(gddr_inst, noc_node_inst, kNocRing, &x, &y);

--- a/lib/tenstorrent/bh_arc/telemetry.c
+++ b/lib/tenstorrent/bh_arc/telemetry.c
@@ -174,6 +174,7 @@ static struct telemetry_table telemetry_table = {
 		[64] = {TAG_AICLK_PPM_INFO, TELEM_OFFSET(TAG_AICLK_PPM_INFO)},
 		[65] = {TAG_HOST_AICLK_LIMIT, TELEM_OFFSET(TAG_HOST_AICLK_LIMIT)},
 		[66] = {TAG_SMBUS_ERRORS, TELEM_OFFSET(TAG_SMBUS_ERRORS)},
+		[67] = {TAG_GDDR_MRISC_NOC2AXI_PORT, TELEM_OFFSET(TAG_GDDR_MRISC_NOC2AXI_PORT)},
 	},
 };
 /* clang-format on */
@@ -311,6 +312,23 @@ static void pack_gddr_temps(const struct gddr_temps *temps, uint32_t *packed)
 	}
 }
 
+static uint32_t get_gddr_mrisc_endpoints(void)
+{
+	uint32_t packed = 0U;
+
+	for (uint8_t i = 0; i < NUM_GDDR; i++) {
+		uint8_t port = 0xF; /* Default to disabled/harvested */
+
+		if (IS_BIT_SET(tile_enable.gddr_enabled, i)) {
+			port = get_gddr_mrisc_noc2axi_port(i);
+		}
+
+		packed |= (uint32_t)port << (i * 4);
+	}
+
+	return packed;
+}
+
 static void write_static_telemetry(uint32_t app_version)
 {
 	telemetry_table.version = TELEMETRY_VERSION; /* v0.1.0 - Only update when redefining the
@@ -377,6 +395,8 @@ static void write_static_telemetry(uint32_t app_version)
 	 */
 
 	telemetry[TAG_ASIC_LOCATION] = tt_bh_fwtable_get_asic_location(fwtable_dev);
+
+	telemetry[TAG_GDDR_MRISC_NOC2AXI_PORT] = get_gddr_mrisc_endpoints();
 }
 
 static void update_telemetry(void)

--- a/lib/tenstorrent/bh_arc/telemetry.h
+++ b/lib/tenstorrent/bh_arc/telemetry.h
@@ -345,12 +345,22 @@
 /** @brief Number of SMBUS target errors observed. */
 #define TAG_SMBUS_ERRORS 71
 
+/**
+ * @brief noc2axi port MRISC FW is loaded on for each GDDR instance.
+ *
+ * Each nibble represents the noc2axi port (0, 1 or 2) that MRISC FW is loaded on
+ * for a GDDR instance. Nibble i corresponds to GDDR instance i, with instance 0
+ * in the least significant nibble. A nibble value of 0xF indicates the instance is
+ * disabled/harvested.
+ */
+#define TAG_GDDR_MRISC_NOC2AXI_PORT 72
+
 /** @} */ /* end of telemetry_tag group */
 
 /* Not a real tag, signifies the last tag in the list.
  * MUST be incremented if new tags are defined.
  */
-#define TAG_COUNT 72
+#define TAG_COUNT 73
 
 /* Telemetry tags are at offset `tag` in the telemetry buffer */
 #define TELEM_OFFSET(tag) (tag)


### PR DESCRIPTION
Change the endpoint used for gddr0 from 0 to 2 (NOC node 0-11). Also add telemetry table entry (`TAG_GDDR_MRISC_NOC2AXI_PORT`) for noc2axi port MRISC fw is loaded on for each GDDR instance.

resolves: SYS-4204