### PR TITLE
lib: bh_chip: Fix bus recovery type

### DIFF
--- a/include/tenstorrent/bh_arc.h
+++ b/include/tenstorrent/bh_arc.h
@@ -63,6 +63,7 @@ union cm2dmAckWire {
 struct bh_arc {
 	const struct smbus_dt_spec smbus;
 	const struct gpio_dt_spec enable;
+	const struct device *i2c_dev;
 };
 
 typedef struct cm2dmMessageRet {
@@ -85,6 +86,7 @@ int bharc_disable_i2cbus(const struct bh_arc *dev);
 
 #define BH_ARC_INIT(n)                                                                             \
 	{.smbus = SMBUS_DT_SPEC_GET(n),                                                            \
+	 .i2c_dev = DEVICE_DT_GET(DT_PHANDLE(DT_BUS(n), i2c)),                                     \
 	 .enable = COND_CODE_1(DT_PROP_HAS_IDX(n, gpios, 0),	({	\
 			.port = DEVICE_DT_GET(DT_GPIO_CTLR_BY_IDX(n, gpios, 0)),                   \
 			.pin = DT_GPIO_PIN_BY_IDX(n, gpios, 0),                                    \

--- a/lib/tenstorrent/bh_chip/bh_chip.c
+++ b/lib/tenstorrent/bh_chip/bh_chip.c
@@ -67,7 +67,7 @@ cm2dmMessageRet bh_chip_get_cm2dm_message(struct bh_chip *chip)
 		if (output.ret == -EIO && sys_timepoint_expired(recover_ratelimit)) {
 			recover_ratelimit = sys_timepoint_calc(K_MSEC(250));
 
-			i2c_recover_bus(chip->config.arc.smbus.bus);
+			i2c_recover_bus(chip->config.arc.i2c_dev);
 			smbus_uncancel(chip->config.arc.smbus.bus);
 		}
 	}

--- a/lib/tenstorrent/bh_chip/strapping.c
+++ b/lib/tenstorrent/bh_chip/strapping.c
@@ -27,7 +27,7 @@ void bh_chip_set_straps(struct bh_chip *chip)
 			if (ret < 0) {
 				printk("Failed to configure strap %s: %d", strap_ptr->port->name,
 				       ret);
-				i2c_recover_bus(chip->config.arc.smbus.bus);
+				i2c_recover_bus(chip->config.arc.i2c_dev);
 				ret = gpio_pin_configure_dt(strap_ptr, GPIO_OUTPUT_ACTIVE);
 				if (ret < 0) {
 					printk("Failed to configure strap after i2c recover %s: "


### PR DESCRIPTION
i2c_recover_bus expects a device of type i2c, not smbus.

Tests:

`native_sim` with `CONFIG_ASSERT` popped almost immediately due to this. This resolves the issue.