### PR TITLE
lib: bh_arc: Apply doppler throttler when aiclk rails

### DIFF
--- a/lib/tenstorrent/bh_arc/throttler.c
+++ b/lib/tenstorrent/bh_arc/throttler.c
@@ -14,6 +14,7 @@
 #include <tenstorrent/msgqueue.h>
 #include "cm2dm_msg.h"
 #include <zephyr/drivers/misc/bh_fwtable.h>
+#include <zephyr/tracing/tracing.h>
 #include "telemetry_internal.h"
 #include "telemetry.h"
 #include "noc2axi.h"
@@ -165,6 +166,7 @@ static void BroadcastKernelThrottleState(void)
 	const uint8_t kNocTlb = 1;
 
 	if (tensixes_enabled) {
+		sys_trace_named_event("kernel_throttle", throttle_counter & 1, 0);
 		NOC2AXITensixBroadcastTlbSetup(kNocRing, kNocTlb, kKernelThrottleAddress,
 					       kNoc2AxiOrderingStrict);
 		NOC2AXIWrite32(kNocRing, kNocTlb, kKernelThrottleAddress, throttle_counter);

--- a/lib/tenstorrent/bh_arc/throttler.c
+++ b/lib/tenstorrent/bh_arc/throttler.c
@@ -345,6 +345,7 @@ static void UpdateDoppler(const TelemetryInternalData *telemetry)
 void CalculateThrottlers(void)
 {
 	TelemetryInternalData telemetry_internal_data;
+	enum aiclk_arb_min arb;
 
 	ReadTelemetryInternal(1, &telemetry_internal_data);
 
@@ -355,6 +356,20 @@ void CalculateThrottlers(void)
 		UpdateThrottler(kThrottlerFastTDC, telemetry_internal_data.vcore_current);
 		UpdateThrottler(kThrottlerTDC, telemetry_internal_data.vcore_current);
 		UpdateThrottler(kThrottlerBoardPower, GetInputPower());
+
+		float current_power = telemetry_internal_data.vcore_power;
+		float tdp_limit = throttler[kThrottlerTDP].limit;
+
+		bool start_nops = GetAiclkTarg() == GetAiclkFmin() && current_power > tdp_limit;
+		bool stop_nops = GetAiclkTarg() == get_aiclk_effective_arb_min(&arb) &&
+				 current_power < tdp_limit;
+
+		bool new_kernel_nops_enabled = ((kernel_nops_enabled || start_nops) && !stop_nops);
+
+		if (new_kernel_nops_enabled != kernel_nops_enabled) {
+			kernel_nops_enabled = new_kernel_nops_enabled;
+			SendKernelThrottlingMessage(kernel_nops_enabled);
+		}
 	}
 
 	UpdateThrottler(kThrottlerThm, telemetry_internal_data.asic_temperature);


### PR DESCRIPTION
Apply the doppler nops in the case where we go above the TDP limit, and our AICLK is as low as possible.

At the 1/0 white marker, doppler nops were enabled as a response to me artificially limiting the TDP limit to 60.

At the 0/0 white marker, doppler nops were disabled as a response to me restoring the TDP limit to 150.

The other changes necessary to make this trace were 

- disable doppler on the p150
- TDP trace

<img width="3412" height="990" alt="image" src="https://github.com/user-attachments/assets/004e208b-54c0-414e-990f-6152f69b3e05" />

resolves: SYS-4495
