### PR TITLE
west.yml: fetch libmctp

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -562,3 +562,10 @@ Tenstorrent Platforms:
   labels: []
   description: |
     Maintained upstream.
+
+"West project: libmctp":
+  status: odd fixes
+  files: []
+  labels: []
+  description: |
+    Maintained upstream.

--- a/west.yml
+++ b/west.yml
@@ -22,6 +22,7 @@ manifest:
         name-allowlist:
           - cmsis_6
           - hal_stm32
+          - libmctp
           - mbedtls
           - mcuboot
           - nanopb


### PR DESCRIPTION
Fetch libmctp. this is needed for eventual galaxy 2 work.

Tests:

`west update` does it's thing. Actually using mctp code in DMC or test applications will come later. 

Resolves:
SYS-4587