### PR TITLE
lib: bh_arc: tt_shell: add msgqueue command

### DIFF
--- a/lib/tenstorrent/bh_arc/tt_shell.c
+++ b/lib/tenstorrent/bh_arc/tt_shell.c
@@ -6,16 +6,35 @@
 
 #include <zephyr/logging/log.h>
 #include <zephyr/shell/shell.h>
+#include <errno.h>
+#include <limits.h>
 #include <stdlib.h>
 
 #include <tenstorrent/bh_power.h>
+#include <tenstorrent/msgqueue.h>
 
 #include "telemetry.h"
 #include "smbus_target.h"
 #include "gddr.h"
 #include "asic_state.h"
 #include "noc_init.h"
+
 LOG_MODULE_REGISTER(tt_shell, CONFIG_LOG_DEFAULT_LEVEL);
+
+static int parse_u32_arg(const char *arg, uint32_t *value)
+{
+	char *endptr;
+	unsigned long parsed;
+
+	errno = 0;
+	parsed = strtoul(arg, &endptr, 0);
+	if (errno != 0 || endptr == arg || *endptr != '\0' || parsed > UINT32_MAX) {
+		return -EINVAL;
+	}
+
+	*value = (uint32_t)parsed;
+	return 0;
+}
 
 static int l2cpu_enable_handler(const struct shell *sh, size_t argc, char **argv)
 {
@@ -148,12 +167,51 @@ static int telem_handler(const struct shell *sh, size_t argc, char **argv)
 	return 0;
 }
 
+static int msg_handler(const struct shell *sh, size_t argc, char **argv)
+{
+	union request request = {0};
+	struct response response = {0};
+	uint32_t parsed;
+	int ret;
+
+	for (size_t i = 1; i < argc; ++i) {
+		ret = parse_u32_arg(argv[i], &parsed);
+		if (ret != 0) {
+			shell_error(sh, "Invalid u32 value: %s", argv[i]);
+			return ret;
+		}
+
+		request.data[i - 1U] = parsed;
+	}
+
+	ret = msgqueue_request_push(0, &request);
+	if (ret != 0) {
+		shell_error(sh, "Failed to queue request (%d)", ret);
+		return ret;
+	}
+
+	process_message_queues();
+
+	ret = msgqueue_response_pop(0, &response);
+	if (ret != 0) {
+		shell_error(sh, "Failed to read response (%d)", ret);
+		return ret;
+	}
+
+	for (size_t i = 0; i < RESPONSE_MSG_LEN; ++i) {
+		shell_print(sh, "rsp[%u] = 0x%08x", (unsigned int)i, response.data[i]);
+	}
+
+	return 0;
+}
+
 SHELL_STATIC_SUBCMD_SET_CREATE(
 	sub_tt_commands, SHELL_CMD_ARG(mrisc_power, NULL, "[off|on]", mrisc_power_handler, 2, 0),
 	SHELL_CMD_ARG(tensix_power, NULL, "[off|on]", tensix_enable_handler, 2, 0),
 	SHELL_CMD_ARG(l2cpu_power, NULL, "[off|on]", l2cpu_enable_handler, 2, 0),
 	SHELL_CMD_ARG(asic_state, NULL, "[|0|3]", asic_state_handler, 1, 1),
 	SHELL_CMD_ARG(telem, NULL, "<Telemetry Index> [|x|f|d]", telem_handler, 2, 1),
+	SHELL_CMD_ARG(msg, NULL, "<cmd> [data1 ... data7]", msg_handler, 2, 7),
 	SHELL_SUBCMD_SET_END);
 
 SHELL_CMD_REGISTER(tt, &sub_tt_commands, "Tensorrent commands", NULL);


### PR DESCRIPTION
Add a generic msgqueue command. This is useful for situations where we have shell but don't have a link to CSM; e.g. native sim/nucleo DMC with emulated SMC.

Tests

On device:
```
jg-dev:~$ tt msg 0xc0
rsp[0] = 0x00000000
rsp[1] = 0x00000001
rsp[2] = 0x00000000
rsp[3] = 0x00000000
rsp[4] = 0x00000000
rsp[5] = 0x00000000
rsp[6] = 0x00000000
rsp[7] = 0x00000000
```
Also works in native_sim/nucleo DMC with emulated SMC.

resolves: SYS-4594
