### PR TITLE
lib: bh_arc: Kconfig for ARC emulation

### DIFF
--- a/app/dmc/src/main.c
+++ b/app/dmc/src/main.c
@@ -40,7 +40,8 @@
 
 LOG_MODULE_REGISTER(main, CONFIG_TT_APP_LOG_LEVEL);
 
-BUILD_ASSERT(PARTITION_EXISTS(bmfw), "bmfw fixed-partition does not exist");
+BUILD_ASSERT(IS_ENABLED(CONFIG_TT_BH_ARC_EMUL) || PARTITION_EXISTS(bmfw),
+	     "bmfw fixed-partition does not exist");
 
 struct bh_chip BH_CHIPS[BH_CHIP_COUNT] = {DT_FOREACH_PROP_ELEM(DT_PATH(chips), chips, INIT_CHIP)};
 

--- a/lib/tenstorrent/bh_arc/Kconfig
+++ b/lib/tenstorrent/bh_arc/Kconfig
@@ -17,6 +17,14 @@ config TT_BH_ARC
 
 if TT_BH_ARC
 
+config TT_BH_ARC_EMUL
+	bool "BH ARC emulation"
+	default y if BOARD_NATIVE_SIM
+	help
+	  Generic flag that BH ARC is emulated.
+	  Enabled by default on native_sim and can be enabled on other
+	  boards that need emulated ARC behavior.
+
 config TT_BH_ARC_NUM_MSG_CODES
 	int "Number of message codes"
 	default 199

--- a/lib/tenstorrent/bh_arc/noc2axi.c
+++ b/lib/tenstorrent/bh_arc/noc2axi.c
@@ -62,9 +62,9 @@ typedef union {
 #define RING0_TLB_REG_OFFSET     0x1000
 #define AXI2NOC_RING_SEL_BIT     15
 
-#ifdef CONFIG_BOARD_NATIVE_SIM
+#ifdef CONFIG_TT_BH_ARC_EMUL
 #define NIU0_A_REG_SPACE_SIZE 0x10000
-/* Running within simulation. Fake out TLB register space */
+/* Running with emulated ARC behavior. Fake out TLB register space */
 static uint8_t fake_niu_reg_space[NIU0_A_REG_SPACE_SIZE];
 #define NIU_0_A_REG_MAP_BASE_ADDR ((uintptr_t)fake_niu_reg_space)
 #else

--- a/lib/tenstorrent/bh_arc/reg.h
+++ b/lib/tenstorrent/bh_arc/reg.h
@@ -8,7 +8,7 @@
 
 #include <stdint.h>
 
-#if CONFIG_BOARD_NATIVE_SIM
+#if CONFIG_TT_BH_ARC_EMUL
 uint32_t ReadReg(uint32_t addr);
 void WriteReg(uint32_t addr, uint32_t val);
 #else


### PR DESCRIPTION
Instead of using NATIVE_SIM, use BH_ARC_EMUL.
This allows boards other than native simulation to get access to the same emulation facilities built on native sim (i.e. the nucleo running DMC <-> lib_bharc)

tests:
Everything currently in tree should build and run the same as before