### PR TITLE
lib: bh_arc: change to u32 targ_freq_reason for portability

### DIFF
--- a/lib/tenstorrent/bh_arc/aiclk_ppm.h
+++ b/lib/tenstorrent/bh_arc/aiclk_ppm.h
@@ -67,8 +67,8 @@ union aiclk_targ_freq_info {
 		 * or @ref limit_reason_max_arb
 		 */
 		uint32_t arbiter: 16;
-		/** The reason for this target frequency */
-		enum targ_freq_reason reason: 16;
+		/** The reason for this target frequency (@ref targ_freq_reason) */
+		uint32_t reason: 16;
 	};
 };
 


### PR DESCRIPTION
bitfield enum handling is compiler dependent. Unfortunately, the STM compiler fails when trying to compile this due to the enumerated type, which it thinks is out of range.

Explicitly make it a fixed-width type, which makes the compilation well defined. Though order may still differ.

Tests:
Builds everything as normal.
Builds lib bharc on the STM.