### PR TITLE
app: dmc: shuffle BH specific settings into relevant configuration

### DIFF
--- a/app/dmc/boards/tt_blackhole_tt_blackhole_dmc.conf
+++ b/app/dmc/boards/tt_blackhole_tt_blackhole_dmc.conf
@@ -12,7 +12,11 @@ CONFIG_SPI_STM32_INTERRUPT=y
 
 # enable sensor
 CONFIG_SENSOR=y
+# Set i2c timeout
+CONFIG_I2C_TRANSFER_TIMEOUT_MS=64
 
+CONFIG_BOOTLOADER_MCUBOOT=y
+CONFIG_MCUBOOT_SIGNATURE_KEY_FILE="bootloader/mcuboot/root-rsa-2048.pem"
 # To debug firmware updates
 #CONFIG_LOG=y
 #CONFIG_LOG_PRINTK=y

--- a/app/dmc/prj.conf
+++ b/app/dmc/prj.conf
@@ -28,10 +28,6 @@ CONFIG_FLASH_MAP=y
 CONFIG_STREAM_FLASH=y
 CONFIG_REBOOT=y
 
-# We always expect MCUBoot to be the primary bootloader
-CONFIG_BOOTLOADER_MCUBOOT=y
-CONFIG_MCUBOOT_SIGNATURE_KEY_FILE="bootloader/mcuboot/root-rsa-2048.pem"
-
 # Disable printing the default Zephyr boot banner
 CONFIG_BOOT_BANNER=n
 # Print the Tenstorrent boot banner + git version on startup
@@ -52,8 +48,6 @@ CONFIG_LOG_BACKEND_RINGBUF=y
 CONFIG_LOG_BACKEND_RINGBUF_BUFFER_SIZE=3072
 # Overwrite old messages when the buffer is full
 CONFIG_LOG_BACKEND_RINGBUF_MODE_OVERWRITE=y
-# Set i2c timeout
-CONFIG_I2C_TRANSFER_TIMEOUT_MS=64
 
 # Binary descriptors for firmware version
 CONFIG_BINDESC=y


### PR DESCRIPTION
Some KCONFIG settings aren't specific to the DMC application, but the board the DMC application is run on. Account for this by moving the KCONFIGs to the scope where they should go.