### PR TITLE
github: workflows: Update CI container

### DIFF
--- a/.github/workflows/hardware-long.yml
+++ b/.github/workflows/hardware-long.yml
@@ -51,7 +51,7 @@ jobs:
         config: ${{ fromJson(needs.gen-config.outputs.matrix-config) }}
     runs-on: ${{ matrix.config.runs-on }}
     container:
-      image: ghcr.io/jgrowdentt/tt-system-firmware/ci-image:zephyr-4.4
+      image: ghcr.io/tenstorrent/tt-system-firmware/ci-image:v19.11.0
       volumes:
         - /dev/hugepages-1G:/dev/hugepages-1G
         - /opt/tenstorrent/kmd-builds/:/opt/tenstorrent/kmd-builds/
@@ -115,7 +115,7 @@ jobs:
     needs: [gen-config, build-fw-artifact]
     runs-on: p150a-jtag
     container:
-      image: ghcr.io/jgrowdentt/tt-system-firmware/ci-image:zephyr-4.4
+      image: ghcr.io/tenstorrent/tt-system-firmware/ci-image:v19.11.0
       volumes:
         - /dev/hugepages-1G:/dev/hugepages-1G
         - /opt/tenstorrent/kmd-builds/:/opt/tenstorrent/kmd-builds/

--- a/.github/workflows/hardware-smoke.yml
+++ b/.github/workflows/hardware-smoke.yml
@@ -71,7 +71,7 @@ jobs:
         config: ${{ fromJson(needs.gen-config.outputs.matrix-config-bh) }}
     runs-on: ${{ matrix.config.runs-on }}
     container:
-      image: ghcr.io/jgrowdentt/tt-system-firmware/ci-image:zephyr-4.4
+      image: ghcr.io/tenstorrent/tt-system-firmware/ci-image:v19.11.0
       volumes:
         - /dev/hugepages-1G:/dev/hugepages-1G
         - /opt/tenstorrent/kmd-builds/:/opt/tenstorrent/kmd-builds/
@@ -162,7 +162,7 @@ jobs:
         config: ${{ fromJson(needs.gen-config.outputs.matrix-config-bh) }}
     runs-on: ${{ matrix.config.runs-on }}
     container:
-      image: ghcr.io/jgrowdentt/tt-system-firmware/ci-image:zephyr-4.4
+      image: ghcr.io/tenstorrent/tt-system-firmware/ci-image:v19.11.0
       volumes:
         - /dev/hugepages-1G:/dev/hugepages-1G
         - /opt/tenstorrent/kmd-builds/:/opt/tenstorrent/kmd-builds/
@@ -277,7 +277,7 @@ jobs:
         config: ${{ fromJson(needs.gen-config.outputs.matrix-config-wh) }}
     runs-on: ${{ matrix.config.runs-on }}
     container:
-      image: ghcr.io/jgrowdentt/tt-system-firmware/ci-image:zephyr-4.4
+      image: ghcr.io/tenstorrent/tt-system-firmware/ci-image:v19.11.0
       volumes:
         - /dev/hugepages-1G:/dev/hugepages-1G
         - /opt/tenstorrent/kmd-builds/:/opt/tenstorrent/kmd-builds/

--- a/.github/workflows/publish-tensix-disable.yml
+++ b/.github/workflows/publish-tensix-disable.yml
@@ -68,7 +68,7 @@ jobs:
         config: ${{ fromJson(needs.gen-config.outputs.matrix-config) }}
     runs-on: ${{ matrix.config.runs-on }}
     container:
-      image: ghcr.io/jgrowdentt/tt-system-firmware/ci-image:zephyr-4.4
+      image: ghcr.io/tenstorrent/tt-system-firmware/ci-image:v19.11.0
       volumes:
         - /dev/hugepages-1G:/dev/hugepages-1G
         - /opt/tenstorrent/kmd-builds/:/opt/tenstorrent/kmd-builds/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,7 +10,7 @@ variables:
 
 build-job:
   stage: build
-  image: ghcr.io/tenstorrent/tt-system-firmware/ci-image:v19.7.0
+  image: ghcr.io/tenstorrent/tt-system-firmware/ci-image:v19.11.0
   script:
     - cd /tt-zephyr/tt-system-firmware
     # Pull repo revision to run CI on


### PR DESCRIPTION
We can now use the real CI container from tt-system-firmware since the release was made.

Tests:

This PR

resolves: SYS-4582