### PR TITLE
lib: bh_arc: add gddr temperature readings to telemetry internal

### DIFF
--- a/doc/release/release-notes-19.12.md
+++ b/doc/release/release-notes-19.12.md
@@ -14,6 +14,7 @@ Major enhancements with this release include:
 
 ### Power & Performance Improvements
 - Enable process based V/F curve for p300c
+- Read GDDR temperatures more frequently as part of internal telemetry
 
 ## Grendel
 

--- a/lib/tenstorrent/bh_arc/fan_ctrl.c
+++ b/lib/tenstorrent/bh_arc/fan_ctrl.c
@@ -103,7 +103,8 @@ static void update_fan_speed(void)
 		alpha * telemetry_internal_data.asic_temperature + (1 - alpha) * max_asic_temp;
 
 	if (IS_ENABLED(CONFIG_TT_BH_ARC_FAN_CTRL_GDDR_TEMP)) {
-		max_gddr_temp = alpha * GetMaxGDDRTemp() + (1 - alpha) * max_gddr_temp;
+		max_gddr_temp = alpha * telemetry_internal_data.gddr_temps.max_temp +
+				(1 - alpha) * max_gddr_temp;
 	} else {
 		max_gddr_temp = 0;
 	}

--- a/lib/tenstorrent/bh_arc/gddr.c
+++ b/lib/tenstorrent/bh_arc/gddr.c
@@ -14,6 +14,8 @@
 #include "reg.h"
 #include "status_reg.h"
 
+#include <stddef.h>
+
 #include <tenstorrent/bh_power.h>
 #include <tenstorrent/msgqueue.h>
 #include <tenstorrent/post_code.h>
@@ -58,6 +60,7 @@ LOG_MODULE_REGISTER(gddr, CONFIG_TT_APP_LOG_LEVEL);
 static const struct device *const fwtable_dev = DEVICE_DT_GET(DT_NODELABEL(fwtable));
 
 static struct gddr_bist_info gddr_bist;
+static uint8_t gddr_telemetry_version_ok;
 
 struct gddr_bist_info get_gddr_bist_info(void)
 {
@@ -221,6 +224,57 @@ static uint32_t GetDramMask(void)
 		dram_mask &= tt_bh_fwtable_get_fw_table(fwtable_dev)->dram_table.dram_mask;
 	}
 	return dram_mask;
+}
+
+/* Read the top and bottom DRAM die temperatures (degrees Celsius) for a single GDDR instance. */
+static int read_gddr_temperature(uint8_t gddr_inst, struct gddr_inst_temp *temp)
+{
+	if (gddr_inst >= NUM_GDDR || temp == NULL) {
+		return -EINVAL;
+	}
+	if (!IS_BIT_SET(gddr_telemetry_version_ok, gddr_inst)) {
+		return -ENOTSUP;
+	}
+	/* dram_temperature_top and dram_temperature_bottom are adjacent uint16_t fields that */
+	/* share a single 32-bit word: [15:0] = top, [31:16] = bottom */
+	uint32_t temps = MriscL1Read32(
+		gddr_inst,
+		GDDR_TELEMETRY_TABLE_ADDR + offsetof(gddr_telemetry_table_t, dram_temperature_top));
+	temp->top = temps & 0xff;
+	temp->bottom = (temps >> 16) & 0xff;
+	return 0;
+}
+
+int get_gddr_temps(struct gddr_temps *temps)
+{
+	if (temps == NULL) {
+		return -EINVAL;
+	}
+
+	*temps = (struct gddr_temps){0};
+	uint32_t dram_mask = GetDramMask();
+
+	int ret = 0;
+
+	for (int i = 0; i < NUM_GDDR; i++) {
+		if (!IS_BIT_SET(dram_mask, i)) {
+			continue;
+		}
+
+		int rc = read_gddr_temperature(i, &temps->inst[i]);
+
+		if (rc < 0) {
+			LOG_WRN_ONCE("Failed to read GDDR %d temperature while updating telemetry",
+				     i);
+			ret = rc;
+			continue;
+		}
+
+		temps->max_temp =
+			MAX(temps->max_temp, MAX(temps->inst[i].top, temps->inst[i].bottom));
+	}
+
+	return ret;
 }
 
 static int check_mrisc_busy(uint8_t gddr_inst)
@@ -462,10 +516,24 @@ SYS_INIT_APP(InitMrisc);
 
 static int CheckGddrTraining(uint8_t gddr_inst, k_timepoint_t timeout)
 {
+	gddr_telemetry_version_ok &= ~BIT(gddr_inst);
+
 	do {
 		uint32_t poll_val = MriscRegRead32(gddr_inst, MRISC_INIT_STATUS);
 
 		if (poll_val == MRISC_INIT_FINISHED) {
+			uint32_t version =
+				MriscL1Read32(gddr_inst, GDDR_TELEMETRY_TABLE_ADDR +
+								 offsetof(gddr_telemetry_table_t,
+									  telemetry_table_version));
+
+			if (version != GDDR_TELEMETRY_TABLE_T_VERSION) {
+				LOG_ERR("%s[%d]: version mismatch: %d (expected %d)",
+					"GDDR telemetry table", gddr_inst, version,
+					GDDR_TELEMETRY_TABLE_T_VERSION);
+				return -ENOTSUP;
+			}
+			gddr_telemetry_version_ok |= BIT(gddr_inst);
 			return 0;
 		}
 		if (poll_val == MRISC_INIT_FAILED) {

--- a/lib/tenstorrent/bh_arc/gddr.h
+++ b/lib/tenstorrent/bh_arc/gddr.h
@@ -51,6 +51,30 @@
 
 int read_gddr_telemetry_table(uint8_t gddr_inst, gddr_telemetry_table_t *gddr_telemetry);
 
+/** @brief Top and bottom DRAM die temperatures for a single GDDR instance (degrees Celsius). */
+struct gddr_inst_temp {
+	uint8_t top;
+	uint8_t bottom;
+};
+
+/** @brief Per-instance GDDR die temperatures plus the max across all dies. */
+struct gddr_temps {
+	uint32_t max_temp;                    /* degC, max across all read dies */
+	struct gddr_inst_temp inst[NUM_GDDR]; /* per-instance top/bottom die temps */
+};
+
+/**
+ * @brief Read the DRAM die temperatures for all enabled GDDR instances.
+ *
+ * Disabled instances are left zeroed. Reads that fail are logged and skipped, leaving the
+ * corresponding entry zeroed while the remaining instances are still read.
+ *
+ * @param [out] temps Destination struct. Fully overwritten on entry.
+ * @return 0 if all enabled instances were read successfully. If one or more reads failed,
+ *         the last error code encountered is returned (the rest are still read).
+ */
+int get_gddr_temps(struct gddr_temps *temps);
+
 /** @brief BIST status bitmasks (one bit per GDDR instance). */
 struct gddr_bist_info {
 	uint8_t complete;

--- a/lib/tenstorrent/bh_arc/telemetry.c
+++ b/lib/tenstorrent/bh_arc/telemetry.c
@@ -231,7 +231,6 @@ static void UpdateEthTelemetry(void)
 
 static void UpdateGddrTelemetry(void)
 {
-	uint32_t temperature[NUM_GDDR / 2] = {0};
 	uint32_t corr_errs[NUM_GDDR / 2] = {0};
 	uint32_t uncorr_errs = 0;
 	uint32_t status = 0;
@@ -249,17 +248,7 @@ static void UpdateGddrTelemetry(void)
 			status |= (gddr_telemetry.training_complete << (i * 2)) |
 				  (gddr_telemetry.gddr_error << (i * 2 + 1));
 
-			/* DDR_x_y_TEMP:
-			 * [31:24] GDDR y top
-			 * [23:16] GDDR y bottom
-			 * [15:8]  GDDR x top
-			 * [7:0]   GDDR x bottom
-			 */
 			int shift_val = (i % 2) * 16;
-
-			temperature[i / 2] |=
-				((gddr_telemetry.dram_temperature_top & 0xff) << (8 + shift_val)) |
-				((gddr_telemetry.dram_temperature_bottom & 0xff) << shift_val);
 
 			/* GDDR_x_y_CORR_ERRS:
 			 * [31:24] GDDR y Corrected Write EDC errors
@@ -293,7 +282,6 @@ static void UpdateGddrTelemetry(void)
 
 	/* Update telemetry atomically after accumulation. */
 	for (int i = 0; i < NUM_GDDR / 2; i++) {
-		telemetry[TAG_GDDR_0_1_TEMP + i] = temperature[i];
 		telemetry[TAG_GDDR_0_1_CORR_ERRS + i] = corr_errs[i];
 	}
 	telemetry[TAG_GDDR_UNCORR_ERRS] = uncorr_errs;
@@ -301,19 +289,22 @@ static void UpdateGddrTelemetry(void)
 	telemetry[TAG_GDDR_SPEED] = speed;
 }
 
-int GetMaxGDDRTemp(void)
+/* Pack per-instance GDDR die temperatures into the host telemetry wire format. Each word holds
+ * one GDDR pair, with each die temperature stored as an 8-bit value using the same bit layout as
+ * TAG_GDDR_X_Y_TEMP.
+ */
+static void pack_gddr_temps(const struct gddr_temps *temps, uint32_t *packed)
 {
-	int max_gddr_temp = 0;
+	for (int i = 0; i < NUM_GDDR / 2; i++) {
+		packed[i] = 0;
+	}
 
 	for (int i = 0; i < NUM_GDDR; i++) {
 		int shift_val = (i % 2) * 16;
-		int gddr_temp = telemetry[TAG_GDDR_0_1_TEMP + i / 2];
 
-		max_gddr_temp = MAX(max_gddr_temp, (gddr_temp >> shift_val) & 0xFF);
-		max_gddr_temp = MAX(max_gddr_temp, (gddr_temp >> (shift_val + 8)) & 0xFF);
+		packed[i / 2] |= ((uint32_t)temps->inst[i].top << (8 + shift_val)) |
+				 ((uint32_t)temps->inst[i].bottom << shift_val);
 	}
-
-	return max_gddr_temp;
 }
 
 static void write_static_telemetry(uint32_t app_version)
@@ -462,7 +453,13 @@ static void update_telemetry(void)
 	telemetry[TAG_FAN_RPM] = fan_ctrl_en ? GetFanRPM() : 0xFFFFFFFFU;
 	UpdateEthTelemetry();
 	UpdateGddrTelemetry();
-	telemetry[TAG_MAX_GDDR_TEMP] = GetMaxGDDRTemp();
+	uint32_t gddr_packed[NUM_GDDR / 2];
+
+	pack_gddr_temps(&telemetry_internal_data.gddr_temps, gddr_packed);
+	for (int i = 0; i < NUM_GDDR / 2; i++) {
+		telemetry[TAG_GDDR_0_1_TEMP + i] = gddr_packed[i];
+	}
+	telemetry[TAG_MAX_GDDR_TEMP] = telemetry_internal_data.gddr_temps.max_temp;
 	telemetry[TAG_INPUT_POWER] = GetInputPower(); /* Input power - reported in W */
 	telemetry[TAG_TIMER_HEARTBEAT]++; /* Incremented every time the timer is called */
 	SetPostCode(POST_CODE_SRC_CMFW, POST_CODE_TELEMETRY_END);

--- a/lib/tenstorrent/bh_arc/telemetry.h
+++ b/lib/tenstorrent/bh_arc/telemetry.h
@@ -175,16 +175,44 @@
 /** @brief Fan RPM. 0xFFFFFFFF if fan control disabled. */
 #define TAG_FAN_RPM 41
 
-/** @brief GDDR 0 and 1 temperature. */
+/** @brief GDDR 0 and 1 temperature.
+ *
+ * Each die temperature is one byte in degrees Celsius, packed as:
+ * - [31:24] GDDR 1 top die
+ * - [23:16] GDDR 1 bottom die
+ * - [15:8]  GDDR 0 top die
+ * - [7:0]   GDDR 0 bottom die
+ */
 #define TAG_GDDR_0_1_TEMP 42
 
-/** @brief GDDR 2 and 3 temperature. */
+/** @brief GDDR 2 and 3 temperature.
+ *
+ * Each die temperature is one byte in degrees Celsius, packed as:
+ * - [31:24] GDDR 3 top die
+ * - [23:16] GDDR 3 bottom die
+ * - [15:8]  GDDR 2 top die
+ * - [7:0]   GDDR 2 bottom die
+ */
 #define TAG_GDDR_2_3_TEMP 43
 
-/** @brief GDDR 4 and 5 temperature. */
+/** @brief GDDR 4 and 5 temperature.
+ *
+ * Each die temperature is one byte in degrees Celsius, packed as:
+ * - [31:24] GDDR 5 top die
+ * - [23:16] GDDR 5 bottom die
+ * - [15:8]  GDDR 4 top die
+ * - [7:0]   GDDR 4 bottom die
+ */
 #define TAG_GDDR_4_5_TEMP 44
 
-/** @brief GDDR 6 and 7 temperature. */
+/** @brief GDDR 6 and 7 temperature.
+ *
+ * Each die temperature is one byte in degrees Celsius, packed as:
+ * - [31:24] GDDR 7 top die
+ * - [23:16] GDDR 7 bottom die
+ * - [15:8]  GDDR 6 top die
+ * - [7:0]   GDDR 6 bottom die
+ */
 #define TAG_GDDR_6_7_TEMP 45
 
 /** @brief GDDR 0 and 1 corrected errors. */
@@ -327,7 +355,6 @@
 void init_telemetry(uint32_t app_version);
 uint32_t ConvertFloatToTelemetry(float value);
 float ConvertTelemetryToFloat(int32_t value);
-int GetMaxGDDRTemp(void);
 void StartTelemetryTimer(void);
 void UpdateDmFwVersion(uint32_t bl_version, uint32_t app_version);
 void UpdateTelemetryNocTranslation(bool translation_enabled);

--- a/lib/tenstorrent/bh_arc/telemetry_internal.c
+++ b/lib/tenstorrent/bh_arc/telemetry_internal.c
@@ -5,6 +5,7 @@
  */
 
 #include "avs.h"
+#include "gddr.h"
 #include "telemetry_internal.h"
 #include "regulator.h"
 
@@ -53,6 +54,8 @@ void ReadTelemetryInternal(int64_t max_staleness, TelemetryInternalData *data)
 		internal_data.vcore_power =
 			internal_data.vcore_current * internal_data.vcore_voltage * 0.001f;
 		internal_data.asic_temperature = avg_tmp;
+
+		(void)get_gddr_temps(&internal_data.gddr_temps);
 
 		/* reftime was updated to the current uptime by the k_uptime_delta() call */
 		last_update_time = reftime;

--- a/lib/tenstorrent/bh_arc/telemetry_internal.h
+++ b/lib/tenstorrent/bh_arc/telemetry_internal.h
@@ -8,11 +8,14 @@
 
 #include <stdint.h>
 
+#include "gddr.h"
+
 typedef struct {
-	float vcore_voltage;    /* mV */
-	float vcore_power;      /* W */
-	float vcore_current;    /* A */
-	float asic_temperature; /* degC */
+	float vcore_voltage;          /* mV */
+	float vcore_power;            /* W */
+	float vcore_current;          /* A */
+	float asic_temperature;       /* degC */
+	struct gddr_temps gddr_temps; /* per-instance GDDR die temps + max across all dies, degC */
 } TelemetryInternalData;
 
 void ReadTelemetryInternal(int64_t max_staleness, TelemetryInternalData *data);

--- a/lib/tenstorrent/bh_arc/throttler.c
+++ b/lib/tenstorrent/bh_arc/throttler.c
@@ -375,7 +375,7 @@ void CalculateThrottlers(void)
 	}
 
 	UpdateThrottler(kThrottlerThm, telemetry_internal_data.asic_temperature);
-	UpdateThrottler(kThrottlerGDDRThm, GetMaxGDDRTemp());
+	UpdateThrottler(kThrottlerGDDRThm, telemetry_internal_data.gddr_temps.max_temp);
 
 	for (ThrottlerId i = 0; i < kThrottlerCount; i++) {
 		UpdateThrottlerArb(i);


### PR DESCRIPTION
Add gddr temperature readings to telemetry internal data structure by directly reading temperature registers from MRISC L1.

When tracing this change, `ReadTelemetryInternal` took 289-312 μs.
Whereas before this change `ReadTelemetryInternal` took 281-304μs.
Tracing just the added gddr temperature readings took ~6μs, aligning with the above measurements.

Resolves: SYS-4576