### PR TITLE
bh_arc: dvfs: add gddrio East/West to DVFS and add to telemetry

### DIFF
--- a/lib/tenstorrent/bh_arc/regulator.c
+++ b/lib/tenstorrent/bh_arc/regulator.c
@@ -42,8 +42,9 @@
 #define READ_VOUT_DATA_BYTE_SIZE       2
 #define READ_IOUT                      0x8C
 #define READ_IOUT_DATA_BYTE_SIZE       2
-#define READ_IOUT_DIRECT_MASK          0x3FFF /* 14-bit raw IOUT field */
+#define READ_IOUT_DIRECT_MASK          0x3FFF  /* 14-bit raw IOUT field */
 #define GDDRIO_IOUT_LSB_A              0.0625f /* 62.5 mA per LSB */
+#define GDDR_IO_RAIL_VOLTAGE           1.35f   /* V - fixed IO rail supply */
 #define READ_POUT                      0x96
 #define READ_POUT_DATA_BYTE_SIZE       2
 #define OPERATION                      0x1
@@ -123,6 +124,18 @@ float GetGddrEastIoCurrent(void)
 	I2CReadBytes(PMBUS_MST_ID, READ_IOUT, PMBUS_CMD_BYTE_SIZE, (uint8_t *)&iout,
 		     READ_IOUT_DATA_BYTE_SIZE, PMBUS_FLIP_BYTES);
 	return ConvertGddrIoCurrentToFloat(iout);
+}
+
+/* The function returns the GDDR west IO rail power in W. */
+float GetGddrWestIoPower(void)
+{
+	return GetGddrWestIoCurrent() * GDDR_IO_RAIL_VOLTAGE;
+}
+
+/* The function returns the GDDR east IO rail power in W. */
+float GetGddrEastIoPower(void)
+{
+	return GetGddrEastIoCurrent() * GDDR_IO_RAIL_VOLTAGE;
 }
 
 /* The function returns the core power in W. */

--- a/lib/tenstorrent/bh_arc/regulator.c
+++ b/lib/tenstorrent/bh_arc/regulator.c
@@ -42,6 +42,8 @@
 #define READ_VOUT_DATA_BYTE_SIZE       2
 #define READ_IOUT                      0x8C
 #define READ_IOUT_DATA_BYTE_SIZE       2
+#define READ_IOUT_DIRECT_MASK          0x3FFF /* 14-bit raw IOUT field */
+#define GDDRIO_IOUT_LSB_A              0.0625f /* 62.5 mA per LSB */
 #define READ_POUT                      0x96
 #define READ_POUT_DATA_BYTE_SIZE       2
 #define OPERATION                      0x1
@@ -84,6 +86,12 @@ static float ConvertLinear11ToFloat(uint16_t value)
 	return ldexp(mantissa, exponent);
 }
 
+/* GDDR IO regulators report READ_IOUT as a direct 14-bit value, 62.5 mA/LSB. */
+static float ConvertGddrIoCurrentToFloat(uint16_t value)
+{
+	return (value & READ_IOUT_DIRECT_MASK) * GDDRIO_IOUT_LSB_A;
+}
+
 /* The function returns the core current in A. */
 float GetVcoreCurrent(void)
 {
@@ -93,6 +101,28 @@ float GetVcoreCurrent(void)
 	I2CReadBytes(PMBUS_MST_ID, READ_IOUT, PMBUS_CMD_BYTE_SIZE, (uint8_t *)&iout,
 		     READ_IOUT_DATA_BYTE_SIZE, PMBUS_FLIP_BYTES);
 	return ConvertLinear11ToFloat(iout);
+}
+
+/* The function returns the GDDR west IO rail current in A. */
+float GetGddrWestIoCurrent(void)
+{
+	I2CInit(I2CMst, GDDRIO_WEST_ADDR, I2CFastMode, PMBUS_MST_ID);
+	uint16_t iout;
+
+	I2CReadBytes(PMBUS_MST_ID, READ_IOUT, PMBUS_CMD_BYTE_SIZE, (uint8_t *)&iout,
+		     READ_IOUT_DATA_BYTE_SIZE, PMBUS_FLIP_BYTES);
+	return ConvertGddrIoCurrentToFloat(iout);
+}
+
+/* The function returns the GDDR east IO rail current in A. */
+float GetGddrEastIoCurrent(void)
+{
+	I2CInit(I2CMst, GDDRIO_EAST_ADDR, I2CFastMode, PMBUS_MST_ID);
+	uint16_t iout;
+
+	I2CReadBytes(PMBUS_MST_ID, READ_IOUT, PMBUS_CMD_BYTE_SIZE, (uint8_t *)&iout,
+		     READ_IOUT_DATA_BYTE_SIZE, PMBUS_FLIP_BYTES);
+	return ConvertGddrIoCurrentToFloat(iout);
 }
 
 /* The function returns the core power in W. */

--- a/lib/tenstorrent/bh_arc/regulator.h
+++ b/lib/tenstorrent/bh_arc/regulator.h
@@ -40,4 +40,6 @@ float GetVcorePower(void);
 void SwitchVoutControl(enum VoltageCmdSource source);
 float GetGddrWestIoCurrent(void);
 float GetGddrEastIoCurrent(void);
+float GetGddrWestIoPower(void);
+float GetGddrEastIoPower(void);
 #endif

--- a/lib/tenstorrent/bh_arc/regulator.h
+++ b/lib/tenstorrent/bh_arc/regulator.h
@@ -38,4 +38,6 @@ void set_gddr_vddr(PcbType board_type, uint32_t voltage_in_mv);
 float GetVcoreCurrent(void);
 float GetVcorePower(void);
 void SwitchVoutControl(enum VoltageCmdSource source);
+float GetGddrWestIoCurrent(void);
+float GetGddrEastIoCurrent(void);
 #endif

--- a/lib/tenstorrent/bh_arc/telemetry.c
+++ b/lib/tenstorrent/bh_arc/telemetry.c
@@ -175,6 +175,8 @@ static struct telemetry_table telemetry_table = {
 		[65] = {TAG_HOST_AICLK_LIMIT, TELEM_OFFSET(TAG_HOST_AICLK_LIMIT)},
 		[66] = {TAG_SMBUS_ERRORS, TELEM_OFFSET(TAG_SMBUS_ERRORS)},
 		[67] = {TAG_GDDR_MRISC_NOC2AXI_PORT, TELEM_OFFSET(TAG_GDDR_MRISC_NOC2AXI_PORT)},
+		[68] = {TAG_GDDR_WEST_IO_POWER, TELEM_OFFSET(TAG_GDDR_WEST_IO_POWER)},
+		[69] = {TAG_GDDR_EAST_IO_POWER, TELEM_OFFSET(TAG_GDDR_EAST_IO_POWER)},
 	},
 };
 /* clang-format on */
@@ -486,6 +488,10 @@ static void update_telemetry(void)
 	telemetry[TAG_MAX_GDDR_TEMP] = telemetry_internal_data.gddr_temps.max_temp;
 	telemetry[TAG_INPUT_POWER] = GetInputPower(); /* Input power - reported in W */
 	telemetry[TAG_SMBUS_ERRORS] = smbus_target_get_error_count(smbus_target_dev);
+	/* reported in W, truncated to uint32_t */
+	telemetry[TAG_GDDR_WEST_IO_POWER] = telemetry_internal_data.gddr_io_power_west;
+	/* reported in W, truncated to uint32_t */
+	telemetry[TAG_GDDR_EAST_IO_POWER] = telemetry_internal_data.gddr_io_power_east;
 	telemetry[TAG_TIMER_HEARTBEAT]++; /* Incremented every time the timer is called */
 	SetPostCode(POST_CODE_SRC_CMFW, POST_CODE_TELEMETRY_END);
 }

--- a/lib/tenstorrent/bh_arc/telemetry.h
+++ b/lib/tenstorrent/bh_arc/telemetry.h
@@ -355,12 +355,26 @@
  */
 #define TAG_GDDR_MRISC_NOC2AXI_PORT 72
 
+/**
+ * @brief GDDR west IO rail power in watts.
+ *
+ * Derived from the west IO rail current and the fixed 1.35 V rail supply.
+ */
+#define TAG_GDDR_WEST_IO_POWER 73
+
+/**
+ * @brief GDDR east IO rail power in watts.
+ *
+ * Derived from the east IO rail current and the fixed 1.35 V rail supply.
+ */
+#define TAG_GDDR_EAST_IO_POWER 74
+
 /** @} */ /* end of telemetry_tag group */
 
 /* Not a real tag, signifies the last tag in the list.
  * MUST be incremented if new tags are defined.
  */
-#define TAG_COUNT 73
+#define TAG_COUNT 75
 
 /* Telemetry tags are at offset `tag` in the telemetry buffer */
 #define TELEM_OFFSET(tag) (tag)

--- a/lib/tenstorrent/bh_arc/telemetry_internal.c
+++ b/lib/tenstorrent/bh_arc/telemetry_internal.c
@@ -54,8 +54,8 @@ void ReadTelemetryInternal(int64_t max_staleness, TelemetryInternalData *data)
 		internal_data.vcore_power =
 			internal_data.vcore_current * internal_data.vcore_voltage * 0.001f;
 		internal_data.asic_temperature = avg_tmp;
-		internal_data.gddr_io_current_west = GetGddrWestIoCurrent();
-		internal_data.gddr_io_current_east = GetGddrEastIoCurrent();
+		internal_data.gddr_io_power_west = GetGddrWestIoPower();
+		internal_data.gddr_io_power_east = GetGddrEastIoPower();
 
 		(void)get_gddr_temps(&internal_data.gddr_temps);
 

--- a/lib/tenstorrent/bh_arc/telemetry_internal.c
+++ b/lib/tenstorrent/bh_arc/telemetry_internal.c
@@ -54,6 +54,8 @@ void ReadTelemetryInternal(int64_t max_staleness, TelemetryInternalData *data)
 		internal_data.vcore_power =
 			internal_data.vcore_current * internal_data.vcore_voltage * 0.001f;
 		internal_data.asic_temperature = avg_tmp;
+		internal_data.gddr_io_current_west = GetGddrWestIoCurrent();
+		internal_data.gddr_io_current_east = GetGddrEastIoCurrent();
 
 		(void)get_gddr_temps(&internal_data.gddr_temps);
 

--- a/lib/tenstorrent/bh_arc/telemetry_internal.h
+++ b/lib/tenstorrent/bh_arc/telemetry_internal.h
@@ -16,6 +16,8 @@ typedef struct {
 	float vcore_current;          /* A */
 	float asic_temperature;       /* degC */
 	struct gddr_temps gddr_temps; /* per-instance GDDR die temps + max across all dies, degC */
+	float gddr_io_current_west;   /* A */
+	float gddr_io_current_east;   /* A */
 } TelemetryInternalData;
 
 void ReadTelemetryInternal(int64_t max_staleness, TelemetryInternalData *data);

--- a/lib/tenstorrent/bh_arc/telemetry_internal.h
+++ b/lib/tenstorrent/bh_arc/telemetry_internal.h
@@ -16,8 +16,8 @@ typedef struct {
 	float vcore_current;          /* A */
 	float asic_temperature;       /* degC */
 	struct gddr_temps gddr_temps; /* per-instance GDDR die temps + max across all dies, degC */
-	float gddr_io_current_west;   /* A */
-	float gddr_io_current_east;   /* A */
+	float gddr_io_power_west;     /* W */
+	float gddr_io_power_east;     /* W */
 } TelemetryInternalData;
 
 void ReadTelemetryInternal(int64_t max_staleness, TelemetryInternalData *data);


### PR DESCRIPTION
This PR extends the BH ARC firmware telemetry interface to expose GDDR IO rail power (west/east) so host-side monitoring/controls can track IO rail power consumption alongside existing board/GDDR telemetry. This is one of the pre-cursors to potentially using GDDR telemetry to estimate chip level/system level power for BH GLX1

Changes:

Add two new telemetry tags for GDDR west/east IO rail power and bump TAG_COUNT accordingly.
Read GDDR west/east IO rail current over PMBus/I2C and derive IO rail power using a fixed 1.35 V rail assumption.
Plumb the new power readings through internal telemetry caching into the published telemetry buffer.

resolves : https://tenstorrent.atlassian.net/browse/SYS-4709