### PR TITLE
Recovery split

### DIFF
--- a/app/smc/CMakeLists.txt
+++ b/app/smc/CMakeLists.txt
@@ -8,6 +8,10 @@ project(app LANGUAGES C)
 include(${CMAKE_CURRENT_LIST_DIR}/../../cmake/git_version.cmake)
 
 target_include_directories(app PRIVATE ${ZEPHYR_TT_SYSTEM_FIRMWARE_MODULE_DIR}/lib/tenstorrent/bh_arc)
-target_include_directories(app PRIVATE ${CMAKE_BINARY_DIR}/modules/tt-system-firmware/drivers/misc/bh_fwtable/spirom_protobufs)
-add_dependencies(app nanopb_generated_headers)
+
+if(CONFIG_BH_FWTABLE)
+  target_include_directories(app PRIVATE ${CMAKE_BINARY_DIR}/modules/tt-system-firmware/drivers/misc/bh_fwtable/spirom_protobufs)
+  add_dependencies(app nanopb_generated_headers)
+endif()
+
 target_sources(app PRIVATE src/main.c)

--- a/app/smc/src/main.c
+++ b/app/smc/src/main.c
@@ -23,14 +23,18 @@
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/drivers/watchdog.h>
-#include <zephyr/drivers/misc/bh_fwtable.h>
 #include <zephyr/storage/flash_map.h>
 #include <zephyr/dfu/mcuboot.h>
+#ifdef CONFIG_BH_FWTABLE
+#include <zephyr/drivers/misc/bh_fwtable.h>
+#endif
 
 LOG_MODULE_REGISTER(main, CONFIG_TT_APP_LOG_LEVEL);
 
 static const struct device *const wdt0 = DEVICE_DT_GET(DT_NODELABEL(wdt0));
+#ifdef CONFIG_BH_FWTABLE
 static const struct device *const fwtable_dev = DEVICE_DT_GET(DT_NODELABEL(fwtable));
+#endif
 
 BUILD_ASSERT(PARTITION_EXISTS(cmfw), "cmfw fixed-partition does not exist");
 
@@ -39,39 +43,39 @@ int main(void)
 	SetPostCode(POST_CODE_SRC_CMFW, POST_CODE_ZEPHYR_INIT_DONE);
 	printk("Tenstorrent Blackhole CMFW %s\n", APP_VERSION_STRING);
 
-	if (!IS_ENABLED(CONFIG_TT_SMC_RECOVERY)) {
-		if (tt_bh_fwtable_get_fw_table(fwtable_dev)->feature_enable.aiclk_ppm_en) {
-			uint32_t err0 = ReadReg(STATUS_ERROR_STATUS0_REG_ADDR);
+#ifdef CONFIG_BH_FWTABLE
+	if (tt_bh_fwtable_get_fw_table(fwtable_dev)->feature_enable.aiclk_ppm_en) {
+		uint32_t err0 = ReadReg(STATUS_ERROR_STATUS0_REG_ADDR);
 
-			if (err0 & BIT(INIT_STAGE_REGULATOR)) {
-				LOG_ERR("Not enabling AICLK PPM due to regulator init error");
-			} else {
-				/* DVFS should get enabled if AICLK PPM or L2CPUCLK PPM is enabled
-				 * We currently don't have plans to implement L2CPUCLK PPM,
-				 * so currently, dvfs_enable == aiclk_ppm_enable
-				 */
-				InitDVFS();
-			}
+		if (err0 & BIT(INIT_STAGE_REGULATOR)) {
+			LOG_ERR("Not enabling AICLK PPM due to regulator init error");
+		} else {
+			/* DVFS should get enabled if AICLK PPM or L2CPUCLK PPM is enabled
+			 * We currently don't have plans to implement L2CPUCLK PPM,
+			 * so currently, dvfs_enable == aiclk_ppm_enable
+			 */
+			InitDVFS();
 		}
 	}
+#endif
 
-	if (!IS_ENABLED(CONFIG_TT_SMC_RECOVERY)) {
-		init_telemetry(APPVERSION);
-		if (tt_bh_fwtable_get_fw_table(fwtable_dev)->feature_enable.fan_ctrl_en) {
-			init_fan_ctrl();
-		}
-
-		/* These timers are split out from their init functions since their work tasks have
-		 * i2c conflicts with other init functions.
-		 *
-		 * Note: The above issue would be solved by using Zephyr's driver model.
-		 */
-		StartTelemetryTimer();
-		if (dvfs_enabled) {
-			StartDVFSTimer();
-		}
-		StartGddrThermTripMonitor();
+#ifdef CONFIG_BH_FWTABLE
+	init_telemetry(APPVERSION);
+	if (tt_bh_fwtable_get_fw_table(fwtable_dev)->feature_enable.fan_ctrl_en) {
+		init_fan_ctrl();
 	}
+
+	/* These timers are split out from their init functions since their work tasks have
+	 * i2c conflicts with other init functions.
+	 *
+	 * Note: The above issue would be solved by using Zephyr's driver model.
+	 */
+	StartTelemetryTimer();
+	if (dvfs_enabled) {
+		StartDVFSTimer();
+	}
+	StartGddrThermTripMonitor();
+#endif
 
 	Dm2CmReadyRequest();
 

--- a/drivers/misc/bh_fwtable/Kconfig
+++ b/drivers/misc/bh_fwtable/Kconfig
@@ -4,10 +4,15 @@
 config BH_FWTABLE
 	bool "Tenstorrent Blackhole Firmware Table"
 	default y
-	depends on DT_HAS_TENSTORRENT_BH_FWTABLE_ENABLED
+	depends on DT_HAS_TENSTORRENT_BH_FWTABLE_ENABLED && !TT_SMC_RECOVERY
 	select TT_BOOT_FS
 	help
 		Enable the Tenstorrent Blackhole Firmware Table.
+
+		Disabled in SMC recovery builds: recovery must not depend on
+		reading the SPI firmware tables during bring-up, so it links the
+		static chip-info backend (chip_info_static.c) instead of this
+		driver. See lib/tenstorrent/bh_arc/chip_info.h.
 
 if BH_FWTABLE
 

--- a/include/zephyr/drivers/misc/bh_fwtable.h
+++ b/include/zephyr/drivers/misc/bh_fwtable.h
@@ -6,6 +6,7 @@
 #ifndef BH_FWTABLE_H
 #define BH_FWTABLE_H
 
+#include <stdbool.h>
 #include <stdint.h>
 #include <zephyr/device.h>
 
@@ -14,12 +15,16 @@ extern "C" {
 #endif
 
 /*
- * FIXME: these proto files as well as all of the entities within them need to be namespaced
- * with a tt_bh_fwtable_ prefix (or something unique and similar).
+ * The generated nanopb headers only exist when the bh_fwtable driver is built.
+ * SMC recovery builds disable the driver (see drivers/misc/bh_fwtable/Kconfig),
+ * but still pull in this header transitively for the plain chip enums below
+ * (e.g. PcbType via regulator.h).
  */
+#ifdef CONFIG_BH_FWTABLE
 #include "fw_table.pb.h"
 #include "flash_info.pb.h"
 #include "read_only.pb.h"
+#endif
 
 const struct _FwTable *tt_bh_fwtable_get_fw_table(const struct device *dev);
 const struct _FlashInfoTable *tt_bh_fwtable_get_flash_info_table(const struct device *dev);

--- a/lib/tenstorrent/bh_arc/CMakeLists.txt
+++ b/lib/tenstorrent/bh_arc/CMakeLists.txt
@@ -1,42 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library_named(bh_arc)
+# bh_arc is split into two Zephyr libraries:
+#   - bh_arc_recovery: shared + recovery code, always built.
+#   - bh_arc_mission: mission-only sources, built only for non-recovery images.
+#     It is layered on top of bh_arc_recovery.
 
+zephyr_library_named(bh_arc_recovery)
 zephyr_library_include_directories_ifdef(CONFIG_TT_BH_ARC ${ZEPHYR_CURRENT_MODULE_DIR}/include)
-
-zephyr_library_sources_ifndef(
-  CONFIG_TT_SMC_RECOVERY
-# zephyr-keep-sorted-start
-  aiclk_ppm.c
-  bh_power.c
-  clock_wave.c
-  counter.c
-  dvfs.c
-  efuse.c
-  eth.c
-  fan_ctrl.c
-  functional_efuse.c
-  gddr.c
-  harvesting.c
-  i2c_messages.c
-  led.c
-  noc.c
-  noc_init.c
-  pcie_dma.c
-  pcie_msi.c
-  pvt.c
-  regulator.c
-  regulator_config.c
-  serdes_eth.c
-  telemetry.c
-  telemetry_internal.c
-  tensix.c
-  tensix_init.c
-  throttler.c
-  vf_curve.c
-  voltage.c
-# zephyr-keep-sorted-stop
-)
 
 zephyr_library_sources(
 # zephyr-keep-sorted-start
@@ -67,11 +37,53 @@ zephyr_library_sources_ifdef(CONFIG_TT_BH_ARC_MSGQUEUE msgqueue.c)
 zephyr_library_sources_ifdef(CONFIG_TT_BH_ARC_RUNTIME_TELEMETRY runtime_telemetry.c)
 zephyr_library_sources_ifdef(CONFIG_TT_BH_ARC_EMUL reg_stub.c)
 
-zephyr_library_add_dependencies(nanopb_generated_headers)
+# Backend for the chip-info service: the static (no-SPI) one when fwtable is
+# unavailable (recovery), the fwtable-backed one (bh_arc_mission) otherwise.
+zephyr_library_sources_ifndef(CONFIG_BH_FWTABLE chip_info_static.c)
 
-zephyr_library_sources_ifdef(CONFIG_TT_SHELL tt_shell.c)
+# harvesting.c and telemetry.c include bh_fwtable.h (and thus the generated
+# nanopb headers) behind CONFIG_BH_FWTABLE guards, so when fwtable is enabled
+# this library needs the generated headers to exist before it is compiled.
+if(CONFIG_BH_FWTABLE)
+  zephyr_library_add_dependencies(nanopb_generated_headers)
+endif()
 
 zephyr_linker_sources(DATA_SECTIONS iterables.ld)
 if(CONFIG_ARC)
   zephyr_library_link_libraries(${ZEPHYR_CURRENT_MODULE_DIR}/zephyr/blobs/tt_blackhole_libpciesd.a)
+endif()
+
+if(NOT CONFIG_TT_SMC_RECOVERY)
+  zephyr_library_named(bh_arc_mission)
+  zephyr_library_include_directories_ifdef(CONFIG_TT_BH_ARC ${ZEPHYR_CURRENT_MODULE_DIR}/include)
+
+  zephyr_library_sources(
+    aiclk_ppm.c
+    bh_power.c
+    clock_wave.c
+    counter.c
+    dvfs.c
+    efuse.c
+    eth.c
+    fan_ctrl.c
+    functional_efuse.c
+    gddr.c
+    i2c_messages.c
+    pcie_dma.c
+    pcie_msi.c
+    pvt.c
+    regulator.c
+    regulator_config.c
+    serdes_eth.c
+    telemetry_internal.c
+    tensix.c
+    tensix_init.c
+    throttler.c
+    vf_curve.c
+    voltage.c
+  )
+
+  zephyr_library_sources_ifdef(CONFIG_BH_FWTABLE chip_info_fwtable.c)
+  zephyr_library_sources_ifdef(CONFIG_TT_SHELL tt_shell.c)
+  zephyr_library_add_dependencies(nanopb_generated_headers)
 endif()

--- a/lib/tenstorrent/bh_arc/chip_info.h
+++ b/lib/tenstorrent/bh_arc/chip_info.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026 Tenstorrent AI ULC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef TT_BH_ARC_CHIP_INFO_H
+#define TT_BH_ARC_CHIP_INFO_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+/*
+ * Abstracts chip-configuration values for the recovery and mission bh_arc.
+ * Mission mode reads values from fwtable while recovery returns hardcoded values.
+ */
+
+/* PCIe operating mode. Values intentionally match the protobuf
+ * FwTable_PciPropertyTable_PcieMode enum so the fwtable backend can pass them
+ * through unchanged.
+ */
+typedef enum {
+	BH_PCIE_MODE_DISABLED = 0,
+	BH_PCIE_MODE_EP = 1,
+	BH_PCIE_MODE_RP = 2,
+} bh_pcie_mode_t;
+
+struct bh_pci_property {
+	bh_pcie_mode_t pcie_mode;
+	uint32_t num_serdes;
+	uint32_t max_pcie_speed;
+	uint32_t pcie_bar0_size;
+	uint32_t pcie_bar2_size;
+	uint32_t pcie_bar4_size;
+};
+
+/* True if this is a UBB (Galaxy) board. Used to skip DMC cable-fault checks.
+ * Exposed as a semantic predicate rather than a raw board-type byte so that
+ * recovery code never needs to include the bh_fwtable / protobuf headers.
+ */
+bool bh_chip_info_is_ubb(void);
+
+/* Extra board power budget, in W, added to host-reported power. */
+uint32_t bh_chip_info_additional_board_power(void);
+
+/* Read-only board identity. */
+uint64_t bh_chip_info_board_id(void);
+uint32_t bh_chip_info_vendor_id(void);
+
+/* PCIe property table for instance @p pcie_inst (0 or 1). */
+void bh_chip_info_pci_property(uint8_t pcie_inst, struct bh_pci_property *out);
+
+/* Feature-enable bits. */
+bool bh_chip_info_feature_cg_en(void);
+bool bh_chip_info_feature_noc_translation_en(void);
+
+#endif /* TT_BH_ARC_CHIP_INFO_H */

--- a/lib/tenstorrent/bh_arc/chip_info_fwtable.c
+++ b/lib/tenstorrent/bh_arc/chip_info_fwtable.c
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2026 Tenstorrent AI ULC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Mission (bh_arc_mission) backend for the chip-info service: sources every
+ * value from the SPI firmware tables via the bh_fwtable driver.
+ */
+
+#include "chip_info.h"
+
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/drivers/misc/bh_fwtable.h>
+#include <zephyr/sys/util.h>
+
+static const struct device *const fwtable_dev = DEVICE_DT_GET(DT_NODELABEL(fwtable));
+
+/* bh_chip_info_pci_property() casts the protobuf pcie_mode straight to
+ * bh_pcie_mode_t, so the two enums must stay numerically identical.
+ */
+BUILD_ASSERT((int)BH_PCIE_MODE_DISABLED == FwTable_PciPropertyTable_PcieMode_DISABLED);
+BUILD_ASSERT((int)BH_PCIE_MODE_EP == FwTable_PciPropertyTable_PcieMode_EP);
+BUILD_ASSERT((int)BH_PCIE_MODE_RP == FwTable_PciPropertyTable_PcieMode_RP);
+
+bool bh_chip_info_is_ubb(void)
+{
+	return tt_bh_fwtable_get_board_type(fwtable_dev) == BOARDTYPE_UBB;
+}
+
+uint32_t bh_chip_info_additional_board_power(void)
+{
+	return tt_bh_fwtable_get_fw_table(fwtable_dev)->chip_limits.additional_board_power;
+}
+
+uint64_t bh_chip_info_board_id(void)
+{
+	return tt_bh_fwtable_get_read_only_table(fwtable_dev)->board_id;
+}
+
+uint32_t bh_chip_info_vendor_id(void)
+{
+	return tt_bh_fwtable_get_read_only_table(fwtable_dev)->vendor_id;
+}
+
+void bh_chip_info_pci_property(uint8_t pcie_inst, struct bh_pci_property *out)
+{
+	const FwTable *fw_table = tt_bh_fwtable_get_fw_table(fwtable_dev);
+	const FwTable_PciPropertyTable *t =
+		(pcie_inst == 0) ? &fw_table->pci0_property_table : &fw_table->pci1_property_table;
+
+	*out = (struct bh_pci_property){
+		.pcie_mode = (bh_pcie_mode_t)t->pcie_mode,
+		.num_serdes = t->num_serdes,
+		.max_pcie_speed = t->max_pcie_speed,
+		.pcie_bar0_size = t->pcie_bar0_size,
+		.pcie_bar2_size = t->pcie_bar2_size,
+		.pcie_bar4_size = t->pcie_bar4_size,
+	};
+}
+
+bool bh_chip_info_feature_cg_en(void)
+{
+	return tt_bh_fwtable_get_fw_table(fwtable_dev)->feature_enable.cg_en;
+}
+
+bool bh_chip_info_feature_noc_translation_en(void)
+{
+	return tt_bh_fwtable_get_fw_table(fwtable_dev)->feature_enable.noc_translation_en;
+}

--- a/lib/tenstorrent/bh_arc/chip_info_static.c
+++ b/lib/tenstorrent/bh_arc/chip_info_static.c
@@ -17,8 +17,8 @@
 #include <zephyr/sys/util.h>
 
 /* Serdes count by board: P300 variants and UBB (Galaxy) use 1, P100/P150 use 2. */
-#if defined(CONFIG_BOARD_REVISION_P300A) || defined(CONFIG_BOARD_REVISION_P300B) ||                 \
-	defined(CONFIG_BOARD_REVISION_P300C) || defined(CONFIG_BOARD_REVISION_GALAXY) ||            \
+#if defined(CONFIG_BOARD_REVISION_P300A) || defined(CONFIG_BOARD_REVISION_P300B) ||                \
+	defined(CONFIG_BOARD_REVISION_P300C) || defined(CONFIG_BOARD_REVISION_GALAXY) ||           \
 	defined(CONFIG_BOARD_REVISION_GALAXY_REVC)
 #define RECOVERY_NUM_SERDES 1
 #else

--- a/lib/tenstorrent/bh_arc/chip_info_static.c
+++ b/lib/tenstorrent/bh_arc/chip_info_static.c
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2026 Tenstorrent AI ULC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Recovery (bh_arc_recovery) backend for the chip-info service.
+ *
+ * SMC recovery must come up far enough for the host to re-flash the chip even
+ * when the SPI firmware tables are missing or corrupt, so this backend never
+ * reads SPI. It returns conservative, board-revision-derived defaults instead.
+ */
+
+#include "chip_info.h"
+#include "pcie.h"
+
+#include <zephyr/sys/util.h>
+
+/* Serdes count by board: P300 variants and UBB (Galaxy) use 1, P100/P150 use 2. */
+#if defined(CONFIG_BOARD_REVISION_P300A) || defined(CONFIG_BOARD_REVISION_P300B) ||                 \
+	defined(CONFIG_BOARD_REVISION_P300C) || defined(CONFIG_BOARD_REVISION_GALAXY) ||            \
+	defined(CONFIG_BOARD_REVISION_GALAXY_REVC)
+#define RECOVERY_NUM_SERDES 1
+#else
+#define RECOVERY_NUM_SERDES 2
+#endif
+
+bool bh_chip_info_is_ubb(void)
+{
+#if defined(CONFIG_BOARD_REVISION_GALAXY) || defined(CONFIG_BOARD_REVISION_GALAXY_REVC)
+	return true;
+#else
+	return false;
+#endif
+}
+
+uint32_t bh_chip_info_additional_board_power(void)
+{
+	return 0;
+}
+
+uint64_t bh_chip_info_board_id(void)
+{
+	return 0;
+}
+
+uint32_t bh_chip_info_vendor_id(void)
+{
+	/* Tenstorrent PCI vendor ID. Recovery has no SPI tables to read it from, but
+	 * it must still program the real VID so the device enumerates as Tenstorrent
+	 * and host tooling can re-flash it.
+	 */
+	return 0x1e52;
+}
+
+void bh_chip_info_pci_property(uint8_t pcie_inst, struct bh_pci_property *out)
+{
+	ARG_UNUSED(pcie_inst);
+
+	*out = (struct bh_pci_property){
+		.pcie_mode = BH_PCIE_MODE_EP,
+		.num_serdes = RECOVERY_NUM_SERDES,
+		.max_pcie_speed = 0,
+		.pcie_bar0_size = PCIE_BAR0_SIZE_DEFAULT_MB,
+		.pcie_bar2_size = PCIE_BAR2_SIZE_DEFAULT_MB,
+		.pcie_bar4_size = PCIE_BAR4_SIZE_DEFAULT_MB,
+	};
+}
+
+bool bh_chip_info_feature_cg_en(void)
+{
+	return false;
+}
+
+bool bh_chip_info_feature_noc_translation_en(void)
+{
+	return false;
+}

--- a/lib/tenstorrent/bh_arc/cm2dm_msg.c
+++ b/lib/tenstorrent/bh_arc/cm2dm_msg.c
@@ -12,7 +12,6 @@
 
 #include <string.h>
 #include <zephyr/kernel.h>
-#include <zephyr/drivers/misc/bh_fwtable.h>
 #include <zephyr/drivers/watchdog.h>
 #include <zephyr/drivers/uart.h>
 #include <zephyr/sys/byteorder.h>
@@ -22,13 +21,12 @@
 
 #include "cm2dm_msg.h"
 #include "asic_state.h"
+#include "chip_info.h"
 #include "reg.h"
 #include "status_reg.h"
 #include "fan_ctrl.h"
 #include "telemetry.h"
 #include "dvfs.h"
-
-static const struct device *const fwtable_dev = DEVICE_DT_GET(DT_NODELABEL(fwtable));
 
 typedef struct {
 	atomic_t pending_messages;
@@ -348,8 +346,7 @@ int32_t Dm2CmSendPowerHandler(const uint8_t *data, uint8_t size)
 
 	AdjustDVFSTimer();
 
-	power = sys_get_le16(data) +
-		tt_bh_fwtable_get_fw_table(fwtable_dev)->chip_limits.additional_board_power;
+	power = sys_get_le16(data) + bh_chip_info_additional_board_power();
 
 	return 0;
 }

--- a/lib/tenstorrent/bh_arc/harvesting.c
+++ b/lib/tenstorrent/bh_arc/harvesting.c
@@ -4,14 +4,28 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "functional_efuse.h"
+/*
+ * Harvesting tile-enable state.
+ *
+ * The tile_enable defaults below (everything enabled) are the values SMC
+ * recovery runs with: recovery references tile_enable (e.g. reset.c skips
+ * harvested ETH/GDDR tiles) but never computes harvesting. The fuse- and
+ * firmware-table-driven computation needs the bh_fwtable driver, so it is
+ * compiled only when CONFIG_BH_FWTABLE is set (mission firmware, not recovery).
+ */
+
 #include "harvesting.h"
+
+#include <zephyr/sys/util.h>
+
+#ifdef CONFIG_BH_FWTABLE
+#include "functional_efuse.h"
 #include "noc.h"
 
 #include <tenstorrent/sys_init_defines.h>
 #include <zephyr/drivers/misc/bh_fwtable.h>
 #include <zephyr/init.h>
-#include <zephyr/sys/util.h>
+#endif
 
 TileEnable tile_enable = {
 	.tensix_col_enabled = BIT_MASK(14),
@@ -24,6 +38,7 @@ TileEnable tile_enable = {
 	.pcie_enabled = BIT_MASK(2),
 };
 
+#ifdef CONFIG_BH_FWTABLE
 static const struct device *const fwtable_dev = DEVICE_DT_GET(DT_NODELABEL(fwtable));
 
 static bool FusesValid(void)
@@ -167,7 +182,7 @@ static void HarvestingSLTFuses(void)
 
 static int CalculateHarvesting(void)
 {
-	if (IS_ENABLED(CONFIG_TT_SMC_RECOVERY) || !IS_ENABLED(CONFIG_ARC)) {
+	if (!IS_ENABLED(CONFIG_ARC)) {
 		return 0;
 	}
 
@@ -264,3 +279,4 @@ static int CalculateHarvesting(void)
 	return 0;
 }
 SYS_INIT_APP(CalculateHarvesting);
+#endif /* CONFIG_BH_FWTABLE */

--- a/lib/tenstorrent/bh_arc/harvesting.h
+++ b/lib/tenstorrent/bh_arc/harvesting.h
@@ -9,7 +9,6 @@
 
 #include <stdint.h>
 #include <stdbool.h>
-#include <zephyr/drivers/misc/bh_fwtable.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -26,7 +25,7 @@ typedef struct {
 	uint8_t gddr_enabled;          /* Bitmap 0-7 */
 	uint8_t l2cpu_enabled;         /* Bitmap 0-3. Shows L2CPU cluster enablement */
 	uint8_t pcie_enabled;          /* Bitmap 0-1. Shows PCIe instance enablement */
-	FwTable_PciPropertyTable_PcieMode pcie_usage[2];
+	uint8_t pcie_usage[2];      /* bh_pcie_mode_t per PCIe instance (see chip_info.h) */
 	uint8_t pcie_num_serdes[2]; /* 1 or 2 if enabled */
 } TileEnable;
 

--- a/lib/tenstorrent/bh_arc/harvesting.h
+++ b/lib/tenstorrent/bh_arc/harvesting.h
@@ -25,8 +25,8 @@ typedef struct {
 	uint8_t gddr_enabled;          /* Bitmap 0-7 */
 	uint8_t l2cpu_enabled;         /* Bitmap 0-3. Shows L2CPU cluster enablement */
 	uint8_t pcie_enabled;          /* Bitmap 0-1. Shows PCIe instance enablement */
-	uint8_t pcie_usage[2];      /* bh_pcie_mode_t per PCIe instance (see chip_info.h) */
-	uint8_t pcie_num_serdes[2]; /* 1 or 2 if enabled */
+	uint8_t pcie_usage[2];         /* bh_pcie_mode_t per PCIe instance (see chip_info.h) */
+	uint8_t pcie_num_serdes[2];    /* 1 or 2 if enabled */
 } TileEnable;
 
 extern TileEnable tile_enable;

--- a/lib/tenstorrent/bh_arc/noc_init.c
+++ b/lib/tenstorrent/bh_arc/noc_init.c
@@ -5,6 +5,7 @@
  */
 
 #include "bh_reset.h"
+#include "chip_info.h"
 #include "harvesting.h"
 #include "noc_init.h"
 #include "noc.h"
@@ -21,7 +22,6 @@
 #include <tenstorrent/msgqueue.h>
 #include <tenstorrent/smc_msg.h>
 #include <tenstorrent/sys_init_defines.h>
-#include <zephyr/drivers/misc/bh_fwtable.h>
 #include <zephyr/init.h>
 #include <zephyr/kernel.h>
 #include <zephyr/sys/util.h>
@@ -57,8 +57,6 @@ static const uint32_t kNiuCfg0Offset = 0x100 + 4 * NIU_CFG_0;
 static const uint8_t kTlbIndex;
 
 static const uint32_t kFirstCfgRegIndex = 0x100 / sizeof(uint32_t);
-
-static const struct device *const fwtable_dev = DEVICE_DT_GET(DT_NODELABEL(fwtable));
 
 static bool noc_translation_enabled;
 
@@ -268,7 +266,7 @@ void NocInitSingleTile(uint8_t noc0_x, uint8_t noc0_y)
 	uint32_t niu_cfg_0_updates = BIT(NIU_CFG_0_TILE_HEADER_STORE_OFF);
 	uint32_t router_cfg_0_updates = 0xF << 8;
 
-	bool cg_en = tt_bh_fwtable_get_fw_table(fwtable_dev)->feature_enable.cg_en;
+	bool cg_en = bh_chip_info_feature_cg_en();
 
 	if (cg_en) {
 		niu_cfg_0_updates |= BIT(0);
@@ -607,14 +605,14 @@ int InitNocTranslationFromHarvesting(void)
 		return 0;
 	}
 
-	if (!tt_bh_fwtable_get_fw_table(fwtable_dev)->feature_enable.noc_translation_en) {
+	if (!bh_chip_info_feature_noc_translation_en()) {
 		return 0;
 	}
 
 	/* Set up the EP as pcie instance (at 19-24). If there's no EP, it doesn't matter. */
 	unsigned int pcie_instance;
 
-	if (tile_enable.pcie_usage[0] == FwTable_PciPropertyTable_PcieMode_EP) {
+	if (tile_enable.pcie_usage[0] == BH_PCIE_MODE_EP) {
 		pcie_instance = 0;
 	} else {
 		pcie_instance = 1;
@@ -783,9 +781,10 @@ static uint8_t debug_noc_translation_handler(const union request *req, struct re
 
 	if (enable_translation) {
 		if (!pcie_instance_override) {
-			if (tt_bh_fwtable_get_fw_table(fwtable_dev)
-				    ->pci1_property_table.pcie_mode ==
-			    FwTable_PciPropertyTable_PcieMode_EP) {
+			struct bh_pci_property pci1;
+
+			bh_chip_info_pci_property(1, &pci1);
+			if (pci1.pcie_mode == BH_PCIE_MODE_EP) {
 				pcie_instance = 1;
 			} else {
 				pcie_instance = 0;

--- a/lib/tenstorrent/bh_arc/pcie.c
+++ b/lib/tenstorrent/bh_arc/pcie.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include "chip_info.h"
 #include "cm2dm_msg.h"
 #include "init.h"
 #include "irqnum.h"
@@ -19,17 +20,11 @@
 #include <tenstorrent/post_code.h>
 #include <tenstorrent/sys_init_defines.h>
 #include <zephyr/drivers/gpio.h>
-#include <zephyr/drivers/misc/bh_fwtable.h>
 #include <zephyr/drivers/dma.h>
 #include <zephyr/drivers/dma/dma_arc_hs.h>
 #include <zephyr/init.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/util.h>
-
-/* FIXME: should be done via devicetree */
-#define PCIE_BAR0_SIZE_DEFAULT_MB 512
-#define PCIE_BAR2_SIZE_DEFAULT_MB 1
-#define PCIE_BAR4_SIZE_DEFAULT_MB 32768
 
 #define PCIE_SERDES0_ALPHACORE_TLB 0
 #define PCIE_SERDES1_ALPHACORE_TLB 1
@@ -58,7 +53,6 @@
 
 LOG_MODULE_DECLARE(bh_arc);
 
-static const struct device *const fwtable_dev = DEVICE_DT_GET(DT_NODELABEL(fwtable));
 static const struct device *const arc_dma_dev = DEVICE_DT_GET_OR_NULL(DT_NODELABEL(dma0));
 
 typedef struct {
@@ -192,8 +186,8 @@ static inline void SetupDbiAccess(void)
 	ReadSiiReg(PCIE_NOC_TLB_DATA_REG_OFFSET(DBI_PCIE_TLB_ID));
 }
 
-static void CntlInitV2ParamInit(uint8_t pcie_inst, const ReadOnly *rotable,
-				const struct _FwTable_PciPropertyTable *pcitable,
+static void CntlInitV2ParamInit(uint8_t pcie_inst, uint64_t board_id, uint32_t vendor_id,
+				const struct bh_pci_property *pcitable,
 				struct CntlInitV2Param *param)
 {
 	/* Start with 32-bit bar size in MiB. Round up as needed. Final value is bar mask in B */
@@ -246,8 +240,8 @@ static void CntlInitV2ParamInit(uint8_t pcie_inst, const ReadOnly *rotable,
 	}
 
 	*param = (struct CntlInitV2Param){
-		.board_id = rotable->board_id,
-		.vendor_id = rotable->vendor_id,
+		.board_id = board_id,
+		.vendor_id = vendor_id,
 		.serdes_inst = pcitable->num_serdes,
 		.max_pcie_speed = pcitable->max_pcie_speed,
 		.pcie_inst = pcie_inst,
@@ -461,50 +455,22 @@ static int pcie_init(void)
 		return 0;
 	}
 
-	const ReadOnly *rotable = tt_bh_fwtable_get_read_only_table(fwtable_dev);
-	FwTable_PciPropertyTable pci0_property_table;
-	FwTable_PciPropertyTable pci1_property_table;
+	uint64_t board_id = bh_chip_info_board_id();
+	uint32_t vendor_id = bh_chip_info_vendor_id();
+	struct bh_pci_property pci0_property_table;
+	struct bh_pci_property pci1_property_table;
 	struct CntlInitV2Param param;
 
-	if (IS_ENABLED(CONFIG_TT_SMC_RECOVERY)) {
-		/* Set num_serdes based on board type:
-		 * P300 variants and UBB (Galaxy): 1 serdes
-		 * P100 and P150 variants: 2 serdes
-		 */
-#if defined(CONFIG_BOARD_REVISION_P300A) || defined(CONFIG_BOARD_REVISION_P300B) ||                \
-	defined(CONFIG_BOARD_REVISION_P300C) || defined(CONFIG_BOARD_REVISION_GALAXY) ||           \
-	defined(CONFIG_BOARD_REVISION_GALAXY_REVC)
-		uint8_t recovery_num_serdes = 1;
-#else
-		uint8_t recovery_num_serdes = 2;
-#endif
+	bh_chip_info_pci_property(0, &pci0_property_table);
+	bh_chip_info_pci_property(1, &pci1_property_table);
 
-		pci0_property_table = (FwTable_PciPropertyTable){
-			.pcie_mode = FwTable_PciPropertyTable_PcieMode_EP,
-			.num_serdes = recovery_num_serdes,
-			.pcie_bar0_size = PCIE_BAR0_SIZE_DEFAULT_MB,
-			.pcie_bar2_size = PCIE_BAR2_SIZE_DEFAULT_MB,
-			.pcie_bar4_size = PCIE_BAR4_SIZE_DEFAULT_MB,
-		};
-		pci1_property_table = (FwTable_PciPropertyTable){
-			.pcie_mode = FwTable_PciPropertyTable_PcieMode_EP,
-			.num_serdes = recovery_num_serdes,
-			.pcie_bar0_size = PCIE_BAR0_SIZE_DEFAULT_MB,
-			.pcie_bar2_size = PCIE_BAR2_SIZE_DEFAULT_MB,
-			.pcie_bar4_size = PCIE_BAR4_SIZE_DEFAULT_MB,
-		};
-	} else {
-		pci0_property_table = tt_bh_fwtable_get_fw_table(fwtable_dev)->pci0_property_table;
-		pci1_property_table = tt_bh_fwtable_get_fw_table(fwtable_dev)->pci1_property_table;
-	}
-
-	if (pci0_property_table.pcie_mode != FwTable_PciPropertyTable_PcieMode_DISABLED) {
-		CntlInitV2ParamInit(0, rotable, &pci0_property_table, &param);
+	if (pci0_property_table.pcie_mode != BH_PCIE_MODE_DISABLED) {
+		CntlInitV2ParamInit(0, board_id, vendor_id, &pci0_property_table, &param);
 		PCIeInit(&param);
 	}
 
-	if (pci1_property_table.pcie_mode != FwTable_PciPropertyTable_PcieMode_DISABLED) {
-		CntlInitV2ParamInit(1, rotable, &pci1_property_table, &param);
+	if (pci1_property_table.pcie_mode != BH_PCIE_MODE_DISABLED) {
+		CntlInitV2ParamInit(1, board_id, vendor_id, &pci1_property_table, &param);
 		PCIeInit(&param);
 	}
 

--- a/lib/tenstorrent/bh_arc/pcie.h
+++ b/lib/tenstorrent/bh_arc/pcie.h
@@ -8,7 +8,14 @@
 
 #include <stdint.h>
 #include "noc2axi.h"
-#include <zephyr/drivers/misc/bh_fwtable.h>
+
+/* Default PCIe BAR sizes, in MiB. Shared between pcie.c and the recovery
+ * chip-info backend (chip_info_static.c) so the synthesized recovery defaults
+ * stay in sync with the values pcie.c programs.
+ */
+#define PCIE_BAR0_SIZE_DEFAULT_MB 512
+#define PCIE_BAR2_SIZE_DEFAULT_MB 1
+#define PCIE_BAR4_SIZE_DEFAULT_MB 32768
 
 typedef enum {
 	EndPoint = 0,

--- a/lib/tenstorrent/bh_arc/reset.c
+++ b/lib/tenstorrent/bh_arc/reset.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include "chip_info.h"
 #include "cm2dm_msg.h"
 #include "eth.h"
 #include "gddr.h"
@@ -28,8 +29,6 @@
 #include <tenstorrent/smc_msg.h>
 #include <tenstorrent/post_code.h>
 #include <tenstorrent/sys_init_defines.h>
-#include <tenstorrent/tt_boot_fs.h>
-#include <zephyr/drivers/misc/bh_fwtable.h>
 #include <zephyr/init.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
@@ -47,7 +46,6 @@ static const struct device *const pll_devs[] = {DT_INST_FOREACH_STATUS_OKAY(PLL_
 
 LOG_MODULE_REGISTER(InitHW, CONFIG_TT_APP_LOG_LEVEL);
 
-static const struct device *const fwtable_dev = DEVICE_DT_GET(DT_NODELABEL(fwtable));
 uint32_t error_status0;
 
 void record_init_failure(enum init_stage_id stage)
@@ -308,7 +306,7 @@ static __maybe_unused uint8_t ReinitTensix(const union request *req, struct resp
 	 */
 	NocInit();
 	TensixInit();
-	if (tt_bh_fwtable_get_fw_table(fwtable_dev)->feature_enable.noc_translation_en) {
+	if (bh_chip_info_feature_noc_translation_en()) {
 		InitNocTranslationFromHarvesting();
 	}
 
@@ -331,9 +329,8 @@ static int DeassertTileResets(void)
 	 * - If magic marker absent: legacy DMC, skip cable fault detection
 	 */
 	uint32_t raw_value = ReadReg(DMC_CABLE_POWER_LIMIT_REG_ADDR);
-	uint8_t board_type = tt_bh_fwtable_get_board_type(fwtable_dev);
 
-	if (board_type == BOARDTYPE_UBB) {
+	if (bh_chip_info_is_ubb()) {
 		/* Galaxy boards have no DMC; CPLD never sets cable power limit */
 		LOG_INF("Galaxy board detected, no cable fault check needed");
 	} else if ((raw_value & CABLE_POWER_LIMIT_MAGIC_MASK) == CABLE_POWER_LIMIT_MAGIC) {

--- a/lib/tenstorrent/bh_arc/telemetry.c
+++ b/lib/tenstorrent/bh_arc/telemetry.c
@@ -4,6 +4,26 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/*
+ * Telemetry table plus the small accessors that the always-compiled message
+ * handlers use (e.g. cm2dm_msg reads tags, noc_init records the NOC-translation
+ * state) are built unconditionally so they are available to SMC recovery.
+ *
+ * The periodic collection of dynamic telemetry (clocks, GDDR, ETH, power, fan,
+ * ...) and one-time population of the static values depend on the SPI firmware
+ * tables and many mission-only subsystems, so that code is compiled only when
+ * CONFIG_BH_FWTABLE is set (mission firmware, not recovery).
+ */
+
+#include "telemetry.h"
+
+#include <float.h> /* for FLT_MAX */
+#include <math.h>  /* for floor */
+#include <stdint.h>
+
+#include <zephyr/logging/log.h>
+
+#ifdef CONFIG_BH_FWTABLE
 #include "aiclk_ppm.h"
 #include "cat.h"
 #include "cm2dm_msg.h"
@@ -13,35 +33,22 @@
 #include "reg.h"
 #include "regulator.h"
 #include "status_reg.h"
-#include "telemetry.h"
 #include "telemetry_internal.h"
 #include "gddr.h"
 #include "eth.h"
 
-#include <float.h> /* for FLT_MAX */
-#include <math.h>  /* for floor */
-#include <stdint.h>
 #include <string.h>
 
 #include <tenstorrent/post_code.h>
 #include <tenstorrent/smbus_target.h>
-#include <zephyr/logging/log.h>
 #include <zephyr/drivers/misc/bh_fwtable.h>
 #include <zephyr/device.h>
 #include <zephyr/devicetree.h>
 #include <zephyr/drivers/clock_control/clock_control_tt_bh.h>
 #include <zephyr/drivers/clock_control.h>
+#endif
 
 LOG_MODULE_REGISTER(telemetry, CONFIG_TT_APP_LOG_LEVEL);
-
-#define RESET_UNIT_STRAP_REGISTERS_L_REG_ADDR 0x80030D20
-
-static const struct device *const fwtable_dev = DEVICE_DT_GET(DT_NODELABEL(fwtable));
-static const struct device *const pll_dev_0 = DEVICE_DT_GET_OR_NULL(DT_NODELABEL(pll0));
-static const struct device *const pll_dev_1 = DEVICE_DT_GET_OR_NULL(DT_NODELABEL(pll1));
-static const struct device *const pll_dev_4 = DEVICE_DT_GET_OR_NULL(DT_NODELABEL(pll4));
-static const struct device *const smbus_target_dev =
-	DEVICE_DT_GET_OR_NULL(DT_NODELABEL(smbus_target0));
 
 /**
  * @defgroup telemetry_table Telemetry Table
@@ -89,21 +96,6 @@ struct telemetry_table {
 	 */
 	uint32_t telemetry[TAG_COUNT];
 };
-
-/* Global variables */
-
-/**
- * @brief Documentation for telemetry table variables.
- *
- * This page contains detailed documentation for the telemetry table and its associated buffer.
- */
-
-/**
- * @brief Global telemetry table containing metadata and telemetry data.
- *
- * This table is used to store telemetry information, including tag mappings and data values.
- * The address of this table is published in the @ref TELEMETRY_TABLE_REG_ADDR register.
- */
 
 /* clang-format off */
 static struct telemetry_table telemetry_table = {
@@ -186,12 +178,6 @@ static struct telemetry_table telemetry_table = {
  */
 static uint32_t *telemetry = &telemetry_table.telemetry[0];
 
-/** @} */ /* end of telemetry_table group */
-
-static struct k_timer telem_update_timer;
-static struct k_work telem_update_worker;
-static int telem_update_interval = 100;
-
 uint32_t ConvertFloatToTelemetry(float value)
 {
 	/* Convert float to signed int 16.16 format */
@@ -221,6 +207,63 @@ float ConvertTelemetryToFloat(int32_t value)
 		return value / 65536.0;
 	}
 }
+
+void UpdateDmFwVersion(uint32_t bl_version, uint32_t app_version)
+{
+	telemetry[TAG_DM_BL_FW_VERSION] = bl_version;
+	telemetry[TAG_DM_APP_FW_VERSION] = app_version;
+}
+
+void UpdateTelemetryNocTranslation(bool translation_enabled)
+{
+	/* Note that this may be called before init_telemetry. */
+	telemetry[TAG_NOC_TRANSLATION] = translation_enabled;
+}
+
+void UpdateTelemetryBoardPowerLimit(uint32_t power_limit)
+{
+	telemetry[TAG_BOARD_POWER_LIMIT] = power_limit;
+}
+
+void UpdateTelemetryTdpLimit(uint32_t tdp_limit)
+{
+	telemetry[TAG_TDP_LIMIT_MAX] = tdp_limit;
+}
+
+void UpdateTelemetryThermTripCount(uint16_t therm_trip_count)
+{
+	telemetry[TAG_THERM_TRIP_COUNT] = therm_trip_count;
+}
+
+void UpdateTelemetryHostAiclkLimit(uint32_t fmax)
+{
+	telemetry[TAG_HOST_AICLK_LIMIT] = fmax;
+}
+
+bool GetTelemetryTagValid(uint16_t tag)
+{
+	return tag < TAG_COUNT;
+}
+
+uint32_t GetTelemetryTag(uint16_t tag)
+{
+	if (tag >= TAG_COUNT) {
+		return -1;
+	}
+	return telemetry[tag];
+}
+
+#ifdef CONFIG_BH_FWTABLE
+static const struct device *const fwtable_dev = DEVICE_DT_GET(DT_NODELABEL(fwtable));
+static const struct device *const pll_dev_0 = DEVICE_DT_GET_OR_NULL(DT_NODELABEL(pll0));
+static const struct device *const pll_dev_1 = DEVICE_DT_GET_OR_NULL(DT_NODELABEL(pll1));
+static const struct device *const pll_dev_4 = DEVICE_DT_GET_OR_NULL(DT_NODELABEL(pll4));
+static const struct device *const smbus_target_dev =
+	DEVICE_DT_GET_OR_NULL(DT_NODELABEL(smbus_target0));
+
+static struct k_timer telem_update_timer;
+static struct k_work telem_update_worker;
+static int telem_update_interval = 100;
 
 static void UpdateEthTelemetry(void)
 {
@@ -511,48 +554,4 @@ void StartTelemetryTimer(void)
 	k_timer_start(&telem_update_timer, K_MSEC(telem_update_interval),
 		      K_MSEC(telem_update_interval));
 }
-
-void UpdateDmFwVersion(uint32_t bl_version, uint32_t app_version)
-{
-	telemetry[TAG_DM_BL_FW_VERSION] = bl_version;
-	telemetry[TAG_DM_APP_FW_VERSION] = app_version;
-}
-
-void UpdateTelemetryNocTranslation(bool translation_enabled)
-{
-	/* Note that this may be called before init_telemetry. */
-	telemetry[TAG_NOC_TRANSLATION] = translation_enabled;
-}
-
-void UpdateTelemetryBoardPowerLimit(uint32_t power_limit)
-{
-	telemetry[TAG_BOARD_POWER_LIMIT] = power_limit;
-}
-
-void UpdateTelemetryTdpLimit(uint32_t tdp_limit)
-{
-	telemetry[TAG_TDP_LIMIT_MAX] = tdp_limit;
-}
-
-void UpdateTelemetryThermTripCount(uint16_t therm_trip_count)
-{
-	telemetry[TAG_THERM_TRIP_COUNT] = therm_trip_count;
-}
-
-void UpdateTelemetryHostAiclkLimit(uint32_t fmax)
-{
-	telemetry[TAG_HOST_AICLK_LIMIT] = fmax;
-}
-
-bool GetTelemetryTagValid(uint16_t tag)
-{
-	return tag < TAG_COUNT;
-}
-
-uint32_t GetTelemetryTag(uint16_t tag)
-{
-	if (tag >= TAG_COUNT) {
-		return -1;
-	}
-	return telemetry[tag];
-}
+#endif /* CONFIG_BH_FWTABLE */

--- a/tests/lib/tenstorrent/chip_info/CMakeLists.txt
+++ b/tests/lib/tenstorrent/chip_info/CMakeLists.txt
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(chip_info)
+
+set(BH_ARC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../../../lib/tenstorrent/bh_arc)
+
+target_sources(app PRIVATE
+  src/main.c
+  ${BH_ARC_DIR}/chip_info_static.c
+)
+target_include_directories(app PRIVATE ${BH_ARC_DIR})

--- a/tests/lib/tenstorrent/chip_info/prj.conf
+++ b/tests/lib/tenstorrent/chip_info/prj.conf
@@ -1,0 +1,5 @@
+CONFIG_ZTEST=y
+
+# Intentionally do NOT set CONFIG_TT_BH_ARC or CONFIG_BH_FWTABLE: this test
+# builds only chip_info_static.c (the recovery backend) so it validates the
+# values recovery synthesizes without any SPI firmware table.

--- a/tests/lib/tenstorrent/chip_info/src/main.c
+++ b/tests/lib/tenstorrent/chip_info/src/main.c
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2026 Tenstorrent AI ULC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Unit tests for the recovery (static no-SPI) chip-info backend.
+ *
+ * SMC recovery has no SPI firmware tables to read, so chip_info_static.c
+ * synthesizes conservative defaults.
+ */
+
+#include <stdint.h>
+
+#include <zephyr/ztest.h>
+
+#include "chip_info.h"
+#include "pcie.h"
+
+/* The Tenstorrent PCI vendor ID. Recovery must program this even without SPI
+ * tables, otherwise the device does not enumerate as Tenstorrent and host
+ * tooling cannot re-flash it.
+ */
+#define TT_PCIE_VENDOR_ID 0x1e52
+
+ZTEST(chip_info_static, test_vendor_id_is_tenstorrent)
+{
+	zassert_equal(bh_chip_info_vendor_id(), TT_PCIE_VENDOR_ID,
+		      "recovery must program the Tenstorrent PCI vendor ID (0x1e52)");
+}
+
+ZTEST(chip_info_static, test_board_identity_defaults)
+{
+	zassert_equal(bh_chip_info_board_id(), 0, "recovery has no SPI board_id to report");
+	zassert_equal(bh_chip_info_additional_board_power(), 0,
+		      "recovery reports no extra board power budget");
+}
+
+ZTEST(chip_info_static, test_features_disabled)
+{
+	/* native_sim is not a Galaxy/UBB board revision. */
+	zassert_false(bh_chip_info_is_ubb(), "default board revision is not UBB");
+	zassert_false(bh_chip_info_feature_cg_en(), "clock gating defaults off in recovery");
+	zassert_false(bh_chip_info_feature_noc_translation_en(),
+		      "NOC translation defaults off in recovery");
+}
+
+ZTEST(chip_info_static, test_pci_property_defaults)
+{
+	struct bh_pci_property prop;
+
+	bh_chip_info_pci_property(0, &prop);
+
+	zassert_equal(prop.pcie_mode, BH_PCIE_MODE_EP, "recovery brings PCIe up as an endpoint");
+	/* native_sim is not a P300/Galaxy revision, so two serdes are expected. */
+	zassert_equal(prop.num_serdes, 2, "non-P300/Galaxy boards use two serdes");
+	zassert_equal(prop.max_pcie_speed, 0, "recovery leaves PCIe speed unconstrained");
+	zassert_equal(prop.pcie_bar0_size, PCIE_BAR0_SIZE_DEFAULT_MB, "BAR0 must match pcie.c");
+	zassert_equal(prop.pcie_bar2_size, PCIE_BAR2_SIZE_DEFAULT_MB, "BAR2 must match pcie.c");
+	zassert_equal(prop.pcie_bar4_size, PCIE_BAR4_SIZE_DEFAULT_MB, "BAR4 must match pcie.c");
+}
+
+ZTEST(chip_info_static, test_pci_property_instance_independent)
+{
+	struct bh_pci_property prop0;
+	struct bh_pci_property prop1;
+
+	bh_chip_info_pci_property(0, &prop0);
+	bh_chip_info_pci_property(1, &prop1);
+
+	/* Recovery ignores the instance argument and synthesizes identical defaults. */
+	zassert_mem_equal(&prop0, &prop1, sizeof(prop0),
+			  "both PCIe instances synthesize identical recovery defaults");
+}
+
+ZTEST_SUITE(chip_info_static, NULL, NULL, NULL, NULL, NULL);

--- a/tests/lib/tenstorrent/chip_info/testcase.yaml
+++ b/tests/lib/tenstorrent/chip_info/testcase.yaml
@@ -1,0 +1,4 @@
+tests:
+  lib.tenstorrent.chip_info.recovery:
+    platform_allow: native_sim
+    tags: bh_arc chip_info


### PR DESCRIPTION
Separate recovery firmware from fwtable. An alternative that was considered was to just use #ifdef everywhere for recovery, but I thought this method of separating recovery form mission on a cmake build level is cleaner

resolves: SYS-4642