### PR TITLE
drivers: smbus: smbus_target: improved logging

### DIFF
--- a/drivers/smbus/target/smbus_target.c
+++ b/drivers/smbus/target/smbus_target.c
@@ -11,11 +11,18 @@
 #include <errno.h>
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/sys/crc.h>
+#include <zephyr/sys/atomic.h>
 #include <tenstorrent/smbus_target.h>
 
 #define LOG_LEVEL CONFIG_I2C_LOG_LEVEL
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(i2c_target);
+
+#define SMBUS_LOG_ERR_RATELIMIT(data, fmt, ...)                                                    \
+	do {                                                                                       \
+		atomic_inc(&(data)->error_count);                                                  \
+		LOG_ERR_RATELIMIT(fmt, ##__VA_ARGS__);                                             \
+	} while (0)
 
 typedef enum {
 	kSmbusStateIdle,
@@ -30,6 +37,7 @@ typedef enum {
 struct smbus_target_data {
 	struct i2c_target_config config;
 	const struct SmbusCmdDef *cmd_defs[256];
+	atomic_t error_count;
 	SmbusState state;
 	uint8_t command;
 	uint8_t blocksize_r;
@@ -83,6 +91,8 @@ static int smbus_write_handler(struct i2c_target_config *config, uint8_t val)
 		curr_cmd = get_cmd_def(smbus_data, smbus_data->command);
 		if (!curr_cmd) {
 			/* Command not implemented */
+			SMBUS_LOG_ERR_RATELIMIT(smbus_data, "SMBUS: command 0x%02x not implemented",
+						val);
 			smbus_data->state = kSmbusStateWaitIdle;
 			return -1;
 		}
@@ -94,7 +104,10 @@ static int smbus_write_handler(struct i2c_target_config *config, uint8_t val)
 		case kSmbusTransBlockWriteBlockRead:
 			smbus_data->blocksize_w = val;
 			if (smbus_data->blocksize_w > CONFIG_SMBUS_MAX_MSG_SIZE) {
-				LOG_ERR("Oversized SMBUS block write: %d", smbus_data->blocksize_w);
+				SMBUS_LOG_ERR_RATELIMIT(
+					smbus_data,
+					"SMBUS: oversized block write: %d bytes (max %d)",
+					smbus_data->blocksize_w, CONFIG_SMBUS_MAX_MSG_SIZE);
 				/* block size too big */
 				smbus_data->state = kSmbusStateWaitIdle;
 				ret = -1;
@@ -122,6 +135,9 @@ static int smbus_write_handler(struct i2c_target_config *config, uint8_t val)
 			break;
 		default:
 			/* Error, invalid command for write */
+			SMBUS_LOG_ERR_RATELIMIT(smbus_data,
+						"SMBUS: invalid transaction type %d for write",
+						curr_cmd->trans_type);
 			smbus_data->state = kSmbusStateWaitIdle;
 			ret = -1;
 		}
@@ -138,6 +154,12 @@ static int smbus_write_handler(struct i2c_target_config *config, uint8_t val)
 				if (ret == 0 &&
 				    curr_cmd->trans_type == kSmbusTransBlockWriteBlockRead) {
 					smbus_data->state = kSmbusStateCmd;
+				} else if (ret != 0) {
+					SMBUS_LOG_ERR_RATELIMIT(
+						smbus_data,
+						"SMBUS: receive handler error (cmd 0x%02x)",
+						smbus_data->command);
+					smbus_data->state = kSmbusStateWaitIdle;
 				} else {
 					smbus_data->state = kSmbusStateWaitIdle;
 				}
@@ -161,20 +183,30 @@ static int smbus_write_handler(struct i2c_target_config *config, uint8_t val)
 		}
 
 		if (pec != rcv_pec) {
-			smbus_data->blocksize_w = kSmbusStateWaitIdle;
+			SMBUS_LOG_ERR_RATELIMIT(
+				smbus_data,
+				"SMBUS: PEC mismatch (cmd 0x%02x): expected 0x%02x, got 0x%02x",
+				smbus_data->command, pec, rcv_pec);
+			smbus_data->state = kSmbusStateWaitIdle;
 			return -1;
 		}
 		ret = curr_cmd->rcv_handler(smbus_data->received_data, smbus_data->blocksize_w);
 
 		if (ret == 0 && curr_cmd->trans_type == kSmbusTransBlockWriteBlockRead) {
 			smbus_data->state = kSmbusStateCmd;
+		} else if (ret != 0) {
+			SMBUS_LOG_ERR_RATELIMIT(smbus_data,
+						"SMBUS: PEC receive handler error (cmd 0x%02x)",
+						smbus_data->command);
+			smbus_data->state = kSmbusStateWaitIdle;
 		} else {
 			smbus_data->state = kSmbusStateWaitIdle;
 		}
 	} else {
-		/* Log something like WriteReg(I2C0_TARGET_DEBUG_STATE_REG_ADDR,
-		 * 0xc2de0000 | ReadReg(I2C0_TARGET_DEBUG_STATE_REG_ADDR));
-		 */
+		/* Invalid state for write handler */
+		SMBUS_LOG_ERR_RATELIMIT(smbus_data,
+					"SMBUS: write handler called in invalid state %d",
+					smbus_data->state);
 		smbus_data->state = kSmbusStateWaitIdle;
 		ret = -1;
 	}
@@ -200,16 +232,19 @@ static int32_t smbus_read_handler(struct i2c_target_config *config, uint8_t *val
 			break;
 		default:
 			/* Error, invalid command for read */
+			SMBUS_LOG_ERR_RATELIMIT(smbus_data,
+						"SMBUS: invalid transaction type %d for read",
+						curr_cmd->trans_type);
 			smbus_data->state = kSmbusStateWaitIdle;
 			*val = 0xFF;
 			return -1;
 		}
 		/* Call the send handler to get the data */
 		if (curr_cmd->send_handler(smbus_data->send_data, &smbus_data->blocksize_r)) {
-			/*Log something like WriteReg(I2C0_TARGET_DEBUG_STATE_REG_ADDR,
-			 * 0xc0de0020);
-			 */
 			/* Send handler returned error */
+			SMBUS_LOG_ERR_RATELIMIT(smbus_data,
+						"SMBUS: send handler error (cmd 0x%02x)",
+						smbus_data->command);
 			smbus_data->state = kSmbusStateWaitIdle;
 			*val = 0xFF;
 			return -1;
@@ -234,10 +269,10 @@ static int32_t smbus_read_handler(struct i2c_target_config *config, uint8_t *val
 			smbus_data->state = kSmbusStateSendData;
 			break;
 		default:
-			/* Log something like WriteReg(I2C0_TARGET_DEBUG_STATE_REG_ADDR,
-			 * 0xc0de0040);
-			 */
 			/* Error, invalid command for read */
+			SMBUS_LOG_ERR_RATELIMIT(
+				smbus_data, "SMBUS: invalid transaction type %d for read response",
+				curr_cmd->trans_type);
 			smbus_data->state = kSmbusStateWaitIdle;
 			*val = 0xFF;
 			return -1;
@@ -284,14 +319,26 @@ static int32_t smbus_read_handler(struct i2c_target_config *config, uint8_t *val
 		*val = pec;
 		smbus_data->state = kSmbusStateWaitIdle;
 	} else {
-		/*Log something like WriteReg(I2C0_TARGET_DEBUG_STATE_REG_ADDR,
-		 *	 0xc1de0000 | ReadReg(I2C0_TARGET_DEBUG_STATE_REG_ADDR));
-		 */
+		/* Invalid state for read handler */
+		SMBUS_LOG_ERR_RATELIMIT(smbus_data,
+					"SMBUS: read handler called in invalid state %d",
+					smbus_data->state);
 		smbus_data->state = kSmbusStateWaitIdle;
 		*val = 0xFF;
 		return -1;
 	}
 	return 0;
+}
+
+uint32_t smbus_target_get_error_count(const struct device *dev)
+{
+	if (dev == NULL || dev->data == NULL) {
+		return 0;
+	}
+
+	struct smbus_target_data *data = dev->data;
+
+	return (uint32_t)atomic_get(&data->error_count);
 }
 
 static void reset_state_machine(struct smbus_target_data *smbus_data)
@@ -347,6 +394,7 @@ static int32_t smbus_target_init(const struct device *dev)
 
 	data->config.address = cfg->bus.addr;
 	data->config.callbacks = &smbus_target_cb_impl;
+	atomic_set(&data->error_count, 0);
 
 	return 0;
 }

--- a/include/tenstorrent/smbus_target.h
+++ b/include/tenstorrent/smbus_target.h
@@ -55,4 +55,11 @@ struct SmbusCmdDef {
  */
 int32_t smbus_target_register_cmd(const struct device *dev, uint8_t cmd_id,
 				  const struct SmbusCmdDef *smbus_cmd);
+
+/**
+ * @brief Get total number of SMBUS target errors
+ * @param dev The SMBUS target device instance.
+ * @return Number of errors that went through the SMBUS ratelimited error macro.
+ */
+uint32_t smbus_target_get_error_count(const struct device *dev);
 #endif

--- a/lib/tenstorrent/bh_arc/telemetry.c
+++ b/lib/tenstorrent/bh_arc/telemetry.c
@@ -24,6 +24,7 @@
 #include <string.h>
 
 #include <tenstorrent/post_code.h>
+#include <tenstorrent/smbus_target.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/drivers/misc/bh_fwtable.h>
 #include <zephyr/device.h>
@@ -39,6 +40,8 @@ static const struct device *const fwtable_dev = DEVICE_DT_GET(DT_NODELABEL(fwtab
 static const struct device *const pll_dev_0 = DEVICE_DT_GET_OR_NULL(DT_NODELABEL(pll0));
 static const struct device *const pll_dev_1 = DEVICE_DT_GET_OR_NULL(DT_NODELABEL(pll1));
 static const struct device *const pll_dev_4 = DEVICE_DT_GET_OR_NULL(DT_NODELABEL(pll4));
+static const struct device *const smbus_target_dev =
+	DEVICE_DT_GET_OR_NULL(DT_NODELABEL(smbus_target0));
 
 /**
  * @defgroup telemetry_table Telemetry Table
@@ -170,6 +173,7 @@ static struct telemetry_table telemetry_table = {
 		[63] = {TAG_ENABLED_MAX_ARB, TELEM_OFFSET(TAG_ENABLED_MAX_ARB)},
 		[64] = {TAG_AICLK_PPM_INFO, TELEM_OFFSET(TAG_AICLK_PPM_INFO)},
 		[65] = {TAG_HOST_AICLK_LIMIT, TELEM_OFFSET(TAG_HOST_AICLK_LIMIT)},
+		[66] = {TAG_SMBUS_ERRORS, TELEM_OFFSET(TAG_SMBUS_ERRORS)},
 	},
 };
 /* clang-format on */
@@ -464,6 +468,7 @@ static void update_telemetry(void)
 	UpdateGddrTelemetry();
 	telemetry[TAG_MAX_GDDR_TEMP] = GetMaxGDDRTemp();
 	telemetry[TAG_INPUT_POWER] = GetInputPower(); /* Input power - reported in W */
+	telemetry[TAG_SMBUS_ERRORS] = smbus_target_get_error_count(smbus_target_dev);
 	telemetry[TAG_TIMER_HEARTBEAT]++; /* Incremented every time the timer is called */
 	SetPostCode(POST_CODE_SRC_CMFW, POST_CODE_TELEMETRY_END);
 }

--- a/lib/tenstorrent/bh_arc/telemetry.h
+++ b/lib/tenstorrent/bh_arc/telemetry.h
@@ -314,12 +314,15 @@
  */
 #define TAG_HOST_AICLK_LIMIT 70
 
+/** @brief Number of SMBUS target errors observed. */
+#define TAG_SMBUS_ERRORS 71
+
 /** @} */ /* end of telemetry_tag group */
 
 /* Not a real tag, signifies the last tag in the list.
  * MUST be incremented if new tags are defined.
  */
-#define TAG_COUNT 71
+#define TAG_COUNT 72
 
 /* Telemetry tags are at offset `tag` in the telemetry buffer */
 #define TELEM_OFFSET(tag) (tag)

--- a/tests/lib/tenstorrent/bh_arc/src/smbus_target.c
+++ b/tests/lib/tenstorrent/bh_arc/src/smbus_target.c
@@ -9,6 +9,7 @@
 #include <zephyr/fff.h>
 #include <tenstorrent/tt_smbus_regs.h>
 #include <zephyr/drivers/i2c.h>
+#include <tenstorrent/smbus_target.h>
 #include "reg_mock.h"
 #include "asic_state.h"
 #include "telemetry.h"
@@ -16,14 +17,17 @@
 #include "cm2dm_msg.h"
 
 static const struct device *const i2c0_dev = DEVICE_DT_GET_OR_NULL(DT_NODELABEL(i2c0));
+static const struct device *const smbus_target_dev =
+	DEVICE_DT_GET_OR_NULL(DT_NODELABEL(smbus_target0));
 static const uint8_t tt_i2c_addr = 0xA;
+
+static uint32_t get_smbus_error_count(void)
+{
+	return smbus_target_get_error_count(smbus_target_dev);
+}
 static void tear_down_tc(void *fixture)
 {
-
 	(void)fixture;
-
-	static const struct device *const smbus_target_dev =
-		DEVICE_DT_GET_OR_NULL(DT_NODELABEL(smbus_target0));
 
 	/*Whiteboxing this isn't great */
 	struct i2c_target_config *smbus_target_cfg =
@@ -36,85 +40,105 @@ ZTEST(smbus_target, test_write_received_bad_cmd_0)
 {
 	/* 0 is not a valid command */
 	uint8_t write_data[] = {0U};
+	uint32_t err_count_before = get_smbus_error_count();
 
 	zassert_equal(-1, i2c_write(i2c0_dev, write_data, sizeof(write_data), tt_i2c_addr));
+	zassert_equal(err_count_before + 1, get_smbus_error_count());
 }
 
 ZTEST(smbus_target, test_write_received_bad_cmd_255)
 {
 	/* 255 is not a valid command */
 	uint8_t write_data[] = {255U};
+	uint32_t err_count_before = get_smbus_error_count();
 
 	zassert_equal(-1, i2c_write(i2c0_dev, write_data, sizeof(write_data), tt_i2c_addr));
+	zassert_equal(err_count_before + 1, get_smbus_error_count());
 }
 
 ZTEST(smbus_target, test_write_received_bad_cmd_msg_max)
 {
 	uint8_t write_data[] = {CMFW_SMBUS_MSG_MAX};
+	uint32_t err_count_before = get_smbus_error_count();
 
 	/* 255 is not a valid command */
 	zassert_equal(-1, i2c_write(i2c0_dev, write_data, sizeof(write_data), tt_i2c_addr));
+	zassert_equal(err_count_before + 1, get_smbus_error_count());
 }
 
 ZTEST(smbus_target, test_write_received_cmd_before_stop)
 {
 	uint8_t write_data[] = {0, CMFW_SMBUS_MSG_MAX};
+	uint32_t err_count_before = get_smbus_error_count();
 
 	/* starting a valid command before stopping the invalid command should fail */
 	zassert_equal(-1, i2c_write(i2c0_dev, write_data, sizeof(write_data), tt_i2c_addr));
+	zassert_equal(err_count_before + 1, get_smbus_error_count());
 }
 
 ZTEST(smbus_target, test_unsolicited_read_received)
 {
 	uint8_t read_data[1];
+	uint32_t err_count_before = get_smbus_error_count();
 
 	/* We always need to get a command to process first. */
 	zassert_equal(-1, i2c_read(i2c0_dev, read_data, sizeof(read_data), tt_i2c_addr));
 	zexpect_equal(0xFF, read_data[0]);
+	zassert_equal(err_count_before + 1, get_smbus_error_count());
 }
 
 ZTEST(smbus_target, test_write_received_bad_blocksize)
 {
 	uint8_t write_data[] = {CMFW_SMBUS_TEST_WRITE_BLOCK, 5U, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 54U};
+	uint32_t err_count_before = get_smbus_error_count();
 
 	/* WRITE_BLOCK is a valid command */
 	zassert_equal(-1, i2c_write(i2c0_dev, write_data, sizeof(write_data), tt_i2c_addr));
+	zassert_equal(err_count_before + 1, get_smbus_error_count());
 }
 
 ZTEST(smbus_target, test_write_received_data_for_read_cmd)
 {
 	/* TEST_READ is a valid command but expects the user to write no additional data */
 	uint8_t write_data[] = {CMFW_SMBUS_TEST_READ, 10U};
+	uint32_t err_count_before = get_smbus_error_count();
 
 	zassert_equal(-1, i2c_write(i2c0_dev, write_data, sizeof(write_data), tt_i2c_addr));
+	zassert_equal(err_count_before + 1, get_smbus_error_count());
 }
 
 ZTEST(smbus_target, test_write_rx_rqst_for_write_cmd)
 {
 	uint8_t write_data[] = {CMFW_SMBUS_TEST_WRITE_BLOCK, 4U};
 	uint8_t read_data[1];
+	uint32_t err_count_before = get_smbus_error_count();
 	/* TEST_WRITE_BLOCK is a valid command but expects data to be written, not read */
 	zassert_equal(-1, i2c_write_read(i2c0_dev, tt_i2c_addr, write_data, sizeof(write_data),
 					 read_data, sizeof(read_data)));
 	zexpect_equal(0xFF, read_data[0]);
+	zassert_equal(err_count_before + 1, get_smbus_error_count());
 }
 
 ZTEST(smbus_target, test_read_byte_test)
 {
 	uint8_t write_data[] = {CMFW_SMBUS_TEST_READ};
 	uint8_t read_data[2];
+	uint32_t err_count_before = get_smbus_error_count();
 
 	ReadReg_fake.return_val = 0x5AU;
 	/* The value received by var should match what the fake stored */
 	zassert_equal(0, i2c_write_read(i2c0_dev, tt_i2c_addr, write_data, sizeof(write_data),
 					read_data, sizeof(read_data)));
 	zexpect_equal(0x5AU, read_data[0]);
+	/* Success - error counter should not change */
+	zassert_equal(err_count_before, get_smbus_error_count());
 }
 
 ZTEST(smbus_target, test_read_word_test)
 {
 	uint8_t write_data[] = {CMFW_SMBUS_TEST_READ_WORD};
 	uint8_t read_data[3];
+	uint32_t err_count_before = get_smbus_error_count();
 
 	ReadReg_fake.return_val = 0x915AU;
 
@@ -123,12 +147,15 @@ ZTEST(smbus_target, test_read_word_test)
 					read_data, sizeof(read_data)));
 	zexpect_equal(0x5AU, read_data[0]);
 	zexpect_equal(0x91U, read_data[1]);
+	/* Success - error counter should not change */
+	zassert_equal(err_count_before, get_smbus_error_count());
 }
 
 ZTEST(smbus_target, test_read_block_test)
 {
 	uint8_t write_data[] = {CMFW_SMBUS_TEST_READ_BLOCK};
 	uint8_t read_data[6];
+	uint32_t err_count_before = get_smbus_error_count();
 
 	ReadReg_fake.return_val = 0x8765915AU;
 	/* The value received by var should match what the fake stored */
@@ -139,12 +166,15 @@ ZTEST(smbus_target, test_read_block_test)
 	zexpect_equal(0x91U, read_data[2]);
 	zexpect_equal(0x65U, read_data[3]);
 	zexpect_equal(0x87U, read_data[4]);
+	/* Success - error counter should not change */
+	zassert_equal(err_count_before, get_smbus_error_count());
 }
 
 ZTEST(smbus_target, test_write_byte_test)
 {
 	uint8_t write_data[] = {CMFW_SMBUS_TEST_WRITE, 0x5BU, 136U};
 	uint8_t set_count = 0U;
+	uint32_t err_count_before = get_smbus_error_count();
 
 	zassert_equal(0, i2c_write(i2c0_dev, write_data, sizeof(write_data), tt_i2c_addr));
 	for (uint8_t i = 0U; i < WriteReg_fake.call_count; i++) {
@@ -154,12 +184,15 @@ ZTEST(smbus_target, test_write_byte_test)
 		}
 	}
 	zexpect_equal(1U, set_count);
+	/* Success - error counter should not change */
+	zassert_equal(err_count_before, get_smbus_error_count());
 }
 
 ZTEST(smbus_target, test_write_word_test)
 {
 	uint8_t write_data[] = {CMFW_SMBUS_TEST_WRITE_WORD, 0x5BU, 0x2AU, 177U};
 	uint8_t set_count = 0U;
+	uint32_t err_count_before = get_smbus_error_count();
 
 	zassert_equal(0, i2c_write(i2c0_dev, write_data, sizeof(write_data), tt_i2c_addr));
 
@@ -170,12 +203,15 @@ ZTEST(smbus_target, test_write_word_test)
 		}
 	}
 	zexpect_equal(1U, set_count);
+	/* Success - error counter should not change */
+	zassert_equal(err_count_before, get_smbus_error_count());
 }
 
 ZTEST(smbus_target, test_write_block_test)
 {
 	uint8_t write_data[] = {CMFW_SMBUS_TEST_WRITE_BLOCK, 0x4, 0x5BU, 0x2AU, 0x13U, 0x99U, 243U};
 	uint8_t set_count = 0U;
+	uint32_t err_count_before = get_smbus_error_count();
 
 	zassert_equal(0, i2c_write(i2c0_dev, write_data, sizeof(write_data), tt_i2c_addr));
 
@@ -186,47 +222,61 @@ ZTEST(smbus_target, test_write_block_test)
 		}
 	}
 	zexpect_equal(1U, set_count);
+	/* Success - error counter should not change */
+	zassert_equal(err_count_before, get_smbus_error_count());
 }
 
 ZTEST(smbus_target, test_update_arc_test_state_3)
 {
 	uint8_t write_data[] = {CMFW_SMBUS_UPDATE_ARC_STATE, 0x3, 0x3U, 0xDEU, 0xAFU};
+	uint32_t err_count_before = get_smbus_error_count();
 
 	zassert_equal(0, i2c_write(i2c0_dev, write_data, sizeof(write_data), tt_i2c_addr));
 	zassert_equal(A3State, get_asic_state());
+	/* Success - error counter should not change */
+	zassert_equal(err_count_before, get_smbus_error_count());
 }
 
 ZTEST(smbus_target, test_update_arc_test_state_0)
 {
 	uint8_t write_data[] = {CMFW_SMBUS_UPDATE_ARC_STATE, 0x3, 0x0U, 0xDEU, 0xAFU};
+	uint32_t err_count_before = get_smbus_error_count();
 
 	zassert_equal(0, i2c_write(i2c0_dev, write_data, sizeof(write_data), tt_i2c_addr));
 	zassert_equal(A0State, get_asic_state());
+	/* Success - error counter should not change */
+	zassert_equal(err_count_before, get_smbus_error_count());
 }
 
 ZTEST(smbus_target, test_telem_read_bad_w_blocksize)
 {
 	uint8_t write_data[] = {CMFW_SMBUS_TELEMETRY_READ, 0x3, 0xAA, 0xBB, 0xCC};
+	uint32_t err_count_before = get_smbus_error_count();
 
 	zassert_equal(-1, i2c_write(i2c0_dev, write_data, sizeof(write_data), tt_i2c_addr));
+	zassert_equal(err_count_before + 1, get_smbus_error_count());
 }
 
 ZTEST(smbus_target, test_telem_read)
 {
 	uint8_t write_data[] = {CMFW_SMBUS_TELEMETRY_READ, 0x1U, TAG_AICLK};
 	uint8_t read_data[8];
+	uint32_t err_count_before = get_smbus_error_count();
 
 	zassert_equal(0, i2c_write_read(i2c0_dev, tt_i2c_addr, write_data, sizeof(write_data),
 					read_data, sizeof(read_data)));
 	zexpect_equal(7U, read_data[0]);
 	zexpect_equal(0U, read_data[1]);
 	/* bytes 2-3 are DC. Bytes 4-7 are telem data but currently aren't emulated */
+	/* Success - error counter should not change */
+	zassert_equal(err_count_before, get_smbus_error_count());
 }
 
 ZTEST(smbus_target, test_telem_write_no_reset)
 {
 	uint8_t write_data[35] = {[0] = CMFW_SMBUS_TELEMETRY_WRITE, [1] = 33U};
 	uint8_t read_data[21];
+	uint32_t err_count_before = get_smbus_error_count();
 
 	zassert_equal(0, i2c_write_read(i2c0_dev, tt_i2c_addr, write_data, sizeof(write_data),
 					read_data, sizeof(read_data)));
@@ -236,16 +286,21 @@ ZTEST(smbus_target, test_telem_write_no_reset)
 
 	(void)memcpy(&ctl, &read_data[12], sizeof(ctl));
 	zexpect_equal(0U, ctl);
+	/* Success - error counter should not change */
+	zassert_equal(err_count_before, get_smbus_error_count());
 }
 
 ZTEST(smbus_target, test_block_write_block_read_with_pec)
 {
 	uint8_t write_data[] = {0xDE, 4, 0xde, 0xad, 0xbe, 0xef};
 	uint8_t read_data[6];
+	uint32_t err_count_before = get_smbus_error_count();
 
 	zassert_equal(0, i2c_write_read(i2c0_dev, tt_i2c_addr, write_data, sizeof(write_data),
 					read_data, sizeof(read_data)));
 	zexpect_equal(4, read_data[0]);
+	/* Success - error counter should not change */
+	zassert_equal(err_count_before, get_smbus_error_count());
 }
 
 ZTEST_SUITE(smbus_target, NULL, NULL, NULL, tear_down_tc, NULL);


### PR DESCRIPTION
Add rate limited log messages to smbus_target driver code. Hopefully this will pop failures in case issues are occurring on the bus.

tests: 
Smoke locally.
~/tt-console doesn't pop any occurances of failure on my p150a

resolves: SYS-4631