### PR TITLE
lib: bh_arc: add runtime telemetry buffer

### DIFF
--- a/doc/release/release-notes-19.12.md
+++ b/doc/release/release-notes-19.12.md
@@ -15,6 +15,9 @@ Major enhancements with this release include:
 ### Power & Performance Improvements
 - Enable process based V/F curve for p300c
 
+### Telemetry
+- Carve out a region of memory for Metal runtime telemetry and publish its address and size via `SCRATCH_RAM[22:23]`.
+
 ## Grendel
 
 <!-- Subsections can break down improvements by (area or board) -->

--- a/doc/services/index.rst
+++ b/doc/services/index.rst
@@ -9,3 +9,4 @@ Firmware Services
    binary_descriptors/index.rst
    tracing/index.rst
    telemetry/index.rst
+   runtime_telemetry/index.rst

--- a/doc/services/runtime_telemetry/index.rst
+++ b/doc/services/runtime_telemetry/index.rst
@@ -1,0 +1,53 @@
+.. _ttzp_runtime_telemetry:
+
+Runtime Telemetry
+=================
+
+Chip Management Firmware reserves a region of memory for Metal runtime use.
+The buffer is zero-initialized at boot, 32-byte aligned, and located in CSM
+(the ``tensix_sm`` / ARC memory space, i.e. within ``NOC0 8-0``).
+
+Scratch Registers
+-----------------
+
+As per the scratch register definitions in `status_reg.h </tt-system-firmware/doxygen/status__reg_8h.html>`_ (``SCRATCH_RAM[0..63]``):
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 20 50
+
+   * - Register
+     - SCRATCH_RAM index
+     - Description
+   * - ``RUNTIME_TELEMETRY_ADDR``
+     - 22 (``0x80030458``)
+     - CSM address of the runtime telemetry buffer
+   * - ``RUNTIME_TELEMETRY_SIZE``
+     - 23 (``0x8003045C``)
+     - Size of the runtime telemetry buffer in bytes
+
+Both values are written once during init and do not change until the
+next chip reset. For a given CMFW build, the size is fixed at compile time
+and the address is fixed at link time.
+
+Procedure to Access Runtime Telemetry
+---------------------------------------
+
+Via NOC Access to ARC Memory
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+1. Read ``reset_unit.SCRATCH_RAM[23]`` to obtain the buffer size in bytes.
+   If the size is 0, assume the buffer is unavailable and stop. Older CMFW
+   builds leave this register at 0.
+2. Read ``reset_unit.SCRATCH_RAM[22]`` to obtain the tile-local address of the buffer.
+3. Read or write the buffer via NOC using the address from step 2 and the
+   size from step 1.
+
+Firmware Details
+----------------
+
+- The buffer is placed in the ``.bss.runtime_telemetry`` linker section and is
+  cleared with the rest of BSS during boot.
+- Size is controlled by ``CONFIG_TT_BH_ARC_RUNTIME_TELEMETRY_SIZE`` (default
+  1024 bytes). The value must be a positive multiple of 32.
+- Address and size are published via ``SYS_INIT_APP`` in ``runtime_telemetry.c``.

--- a/include/tenstorrent/sys_init_defines.h
+++ b/include/tenstorrent/sys_init_defines.h
@@ -34,7 +34,8 @@
 #define gddr_training_PRIO                    111
 #define CATInit_PRIO                          112
 #define init_msgqueue_PRIO                    113
-#define bh_arc_init_end_PRIO                  114
+#define publish_runtime_telemetry_PRIO        114
+#define bh_arc_init_end_PRIO                  115
 
 #define SYS_INIT_APP(func) SYS_INIT(func, POST_KERNEL, func##_PRIO)
 

--- a/lib/tenstorrent/bh_arc/CMakeLists.txt
+++ b/lib/tenstorrent/bh_arc/CMakeLists.txt
@@ -64,6 +64,7 @@ zephyr_library_sources(
 )
 
 zephyr_library_sources_ifdef(CONFIG_TT_BH_ARC_MSGQUEUE msgqueue.c)
+zephyr_library_sources_ifdef(CONFIG_TT_BH_ARC_RUNTIME_TELEMETRY runtime_telemetry.c)
 zephyr_library_sources_ifdef(CONFIG_TT_BH_ARC_EMUL reg_stub.c)
 
 zephyr_library_add_dependencies(nanopb_generated_headers)

--- a/lib/tenstorrent/bh_arc/Kconfig
+++ b/lib/tenstorrent/bh_arc/Kconfig
@@ -92,6 +92,17 @@ config TT_BH_ARC_SCRATCHPAD_SIZE
 	  Size of scratchpad memory in bytes. This is mainly used as a temporary buffer for
 	  loading images from SPI flash.
 
+config TT_BH_ARC_RUNTIME_TELEMETRY_SIZE
+	int "Runtime telemetry reserved BSS size in bytes"
+	default 1024
+	range 0 65536
+	help
+	  Bytes carved from BSS for host runtime telemetry use. Must be a multiple
+	  of 32. Set to 0 to disable runtime telemetry.
+
+config TT_BH_ARC_RUNTIME_TELEMETRY
+	def_bool TT_BH_ARC_RUNTIME_TELEMETRY_SIZE > 0
+
 config TT_BH_ARC_DMFW_PING_TIMEOUT
 	int "Timeout for DMFW ping in milliseconds"
 	default 200

--- a/lib/tenstorrent/bh_arc/runtime_telemetry.c
+++ b/lib/tenstorrent/bh_arc/runtime_telemetry.c
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2025 Tenstorrent AI ULC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "reg.h"
+#include "status_reg.h"
+
+#include <stdint.h>
+#include <tenstorrent/sys_init_defines.h>
+
+#include <zephyr/init.h>
+#include <zephyr/sys/util.h>
+
+#define RUNTIME_TELEMETRY_SIZE CONFIG_TT_BH_ARC_RUNTIME_TELEMETRY_SIZE
+
+BUILD_ASSERT(RUNTIME_TELEMETRY_SIZE > 0);
+BUILD_ASSERT(RUNTIME_TELEMETRY_SIZE % 32 == 0);
+
+uint8_t tt_runtime_telemetry[RUNTIME_TELEMETRY_SIZE] __aligned(32)
+__attribute__((section(".bss.runtime_telemetry")));
+
+static int publish_runtime_telemetry(void)
+{
+	WriteReg(RUNTIME_TELEMETRY_ADDR_REG_ADDR, (uint32_t)tt_runtime_telemetry);
+	WriteReg(RUNTIME_TELEMETRY_SIZE_REG_ADDR, RUNTIME_TELEMETRY_SIZE);
+	return 0;
+}
+
+SYS_INIT_APP(publish_runtime_telemetry);

--- a/lib/tenstorrent/bh_arc/status_reg.h
+++ b/lib/tenstorrent/bh_arc/status_reg.h
@@ -66,6 +66,21 @@
 #define I2C0_TARGET_DEBUG_STATE_REG_ADDR     RESET_UNIT_SCRATCH_RAM_REG_ADDR(19)
 #define I2C0_TARGET_DEBUG_STATE_2_REG_ADDR   RESET_UNIT_SCRATCH_RAM_REG_ADDR(20)
 #define ARC_HANG_PC                          RESET_UNIT_SCRATCH_RAM_REG_ADDR(21)
+/**
+ * @brief Register address of the Metal runtime telemetry buffer.
+ *
+ * Holds the CSM address of tt_runtime_telemetry. Written once during init
+ * and not updated until the next chip reset. Fixed at link time for a
+ * given CMFW build.
+ */
+#define RUNTIME_TELEMETRY_ADDR_REG_ADDR      RESET_UNIT_SCRATCH_RAM_REG_ADDR(22)
+/**
+ * @brief Register holding the size in bytes of the Metal runtime telemetry buffer.
+ *
+ * Written once during init and not updated until the next chip reset.
+ * Fixed at compile time for a given CMFW build.
+ */
+#define RUNTIME_TELEMETRY_SIZE_REG_ADDR      RESET_UNIT_SCRATCH_RAM_REG_ADDR(23)
 
 #define STATUS_FW_VUART_REG_ADDR(n) RESET_UNIT_SCRATCH_RAM_REG_ADDR(40 + (n))
 /* SCRATCH_RAM_40 - SCRATCH_RAM_41 reserved for virtual uarts */

--- a/scripts/dump_smc_state.py
+++ b/scripts/dump_smc_state.py
@@ -45,6 +45,8 @@ SCRATCH_REGS = {
     "I2C target state 0": 0x4C,
     "I2C target state 1": 0x50,
     "ARC hang pc": 0x54,
+    "Runtime telemetry address": 0x58,
+    "Runtime telemetry size": 0x5C,
     "VUART 0 address": 0xA0,
     "VUART 1 address": 0xA4,
     "VUART 2 address": 0xA8,


### PR DESCRIPTION
Carve out a region of memory for Metal runtime to post telemetry to.

fixes: SYS-4149