### PR TITLE
lib: bh_arc: matmul characterization msg

### DIFF
--- a/doc/release/release-notes-19.12.md
+++ b/doc/release/release-notes-19.12.md
@@ -15,6 +15,8 @@ Major enhancements with this release include:
 ### Power & Performance Improvements
 - Enable process based V/F curve for p300c
 - Read GDDR temperatures more frequently as part of internal telemetry
+- Add Blackhole Kernel throttler when we reach AICLK floor (disabled by default)
+- Add throttler controls via ARC message to enable/disable kernel throttling at AICLK floor and tune the stop-NOPs frequency threshold (kernel throttling at floor is now disabled by default).
 
 ## Grendel
 

--- a/include/tenstorrent/msgqueue.h
+++ b/include/tenstorrent/msgqueue.h
@@ -776,10 +776,34 @@ struct characterisation_set_fmin_submsg {
 	uint32_t value;
 };
 
+/** @brief Submessage for enabling/disabling kernel throttler at AICLK floor
+ * @details Payload is a single uint32_t:
+ * - Value == 0: Disable kernel throttler at AICLK floor
+ * - Value == 1: Enable kernel throttler at AICLK floor
+ */
+struct char_throttle_enabled_submsg {
+	/** @brief 0 to disable, 1 to enable */
+	uint32_t enabled;
+};
+
+/** @brief Submessage for setting kernel throttler stop NOPs frequency
+ * @details Payload is a single uint32_t with two interpretations:
+ * - Value == 0: Restore the FW-controlled stop limit
+ * - Value in [200, 1400]: Stop NOPs at this frequency in MHz
+ */
+struct char_throttle_stop_freq_submsg {
+	/** @brief 0 to restore FW control, or frequency in MHz where NOPs stop (200-1400) */
+	uint32_t frequency;
+};
+
 /** @brief Union of all possible characterization submessage payloads */
 union characterisation_submsg_data {
 	/** @brief Set host-requested minimum frequency floor */
 	struct characterisation_set_fmin_submsg fmin_value;
+	/** @brief Enable/disable kernel throttler at AICLK floor */
+	struct char_throttle_enabled_submsg throttler_enabled;
+	/** @brief Set frequency limit for stopping kernel throttler */
+	struct char_throttle_stop_freq_submsg throttler_stop_freq;
 	/* add to this union to define more sub-message payloads */
 	/** @brief Generic fallback for raw access */
 	uint8_t raw_data[4];

--- a/include/tenstorrent/smc_msg.h
+++ b/include/tenstorrent/smc_msg.h
@@ -171,6 +171,10 @@ enum tt_smc_msg {
 enum char_submsg_ids {
 	/** @brief Set host-requested minimum frequency (AICLK) */
 	TT_SUB_MSG_SET_HOST_REQUESTED_FMIN = 0x1,
+	/** @brief Enable/disable kernel throttler at AICLK floor */
+	TT_SUB_MSG_SET_KERNEL_THROTTLER_ENABLED = 0x2,
+	/** @brief Set frequency limit for stopping kernel throttler */
+	TT_SUB_MSG_SET_KERNEL_THROTTLER_STOP_NOPS_FREQ = 0x3,
 };
 
 /** @} */

--- a/lib/tenstorrent/bh_arc/aiclk_ppm.c
+++ b/lib/tenstorrent/bh_arc/aiclk_ppm.c
@@ -7,6 +7,7 @@
 #include "aiclk_ppm.h"
 #include "dvfs.h"
 #include "telemetry.h"
+#include "throttler.h"
 #include "voltage.h"
 #include "vf_curve.h"
 
@@ -29,13 +30,6 @@
 LOG_MODULE_REGISTER(aiclk_ppm, CONFIG_TT_APP_LOG_LEVEL);
 
 static const struct device *const pll_dev_0 = DEVICE_DT_GET_OR_NULL(DT_NODELABEL(pll0));
-
-/* Bounds checks for FMAX and FMIN (in MHz) */
-#define AICLK_FMAX_MAX        1400.0F
-#define AICLK_FMAX_MIN        800.0F
-#define AICLK_FMIN_MAX        1400.0F
-#define AICLK_FMIN_MIN        200.0F
-#define AICLK_RESET_SAFE_FREQ 250.0F
 
 /* aiclk control mode */
 typedef enum {
@@ -534,6 +528,14 @@ static uint8_t characterisation_handler(const union request *request, struct res
 	case TT_SUB_MSG_SET_HOST_REQUESTED_FMIN:
 		return handle_char_set_host_fmin(
 			request->characterisation_msg.submsg_data.fmin_value, response);
+
+	case TT_SUB_MSG_SET_KERNEL_THROTTLER_ENABLED:
+		return ThrottlerSetKernelThrottlerEnabled(
+			request->characterisation_msg.submsg_data.throttler_enabled.enabled);
+
+	case TT_SUB_MSG_SET_KERNEL_THROTTLER_STOP_NOPS_FREQ:
+		return ThrottlerSetKernelThrottlerStopFreq(
+			request->characterisation_msg.submsg_data.throttler_stop_freq.frequency);
 
 	default:
 		LOG_WRN("Unknown characterization submessage ID: 0x%02x",

--- a/lib/tenstorrent/bh_arc/aiclk_ppm.h
+++ b/lib/tenstorrent/bh_arc/aiclk_ppm.h
@@ -9,6 +9,13 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+/* Bounds checks for FMAX and FMIN (in MHz) */
+#define AICLK_FMAX_MAX        1400.0F
+#define AICLK_FMAX_MIN        800.0F
+#define AICLK_FMIN_MAX        1400.0F
+#define AICLK_FMIN_MIN        200.0F
+#define AICLK_RESET_SAFE_FREQ 250.0F
+
 /**
  * @brief AICLK maximum frequency arbiters
  *

--- a/lib/tenstorrent/bh_arc/throttler.c
+++ b/lib/tenstorrent/bh_arc/throttler.c
@@ -28,7 +28,7 @@ static bool doppler_t2;
 static bool doppler_t3;
 static const bool thermal_throttling = true;
 
-static bool kernel_throttler_at_aiclk_floor_enabled = true;
+static bool kernel_throttler_at_aiclk_floor_enabled;
 static uint32_t kernel_throttler_stop_nops_freq;
 
 #define kThrottlerAiclkScaleFactor 500.0F

--- a/lib/tenstorrent/bh_arc/throttler.c
+++ b/lib/tenstorrent/bh_arc/throttler.c
@@ -28,6 +28,9 @@ static bool doppler_t2;
 static bool doppler_t3;
 static const bool thermal_throttling = true;
 
+static bool kernel_throttler_at_aiclk_floor_enabled = true;
+static uint32_t kernel_throttler_stop_nops_freq;
+
 #define kThrottlerAiclkScaleFactor 500.0F
 #define DEFAULT_BOARD_POWER_LIMIT  150
 
@@ -344,10 +347,41 @@ static void UpdateDoppler(const TelemetryInternalData *telemetry)
 	EnableArbMax(aiclk_arb_max_doppler_critical, critical_throttling);
 }
 
+/** @brief Update kernel throttler NOPs state based on power
+ * @param[in] current_power Current vcore power in watts
+ * @param[in] tdp_limit TDP throttler limit in watts
+ */
+static void UpdateKernelThrottler(float current_power, float tdp_limit)
+{
+	/* Kernel throttler at aiclk floor is only active if enabled */
+	bool start_nops = false;
+	bool stop_nops = false;
+	enum aiclk_arb_min arb;
+
+	if (kernel_throttler_at_aiclk_floor_enabled) {
+		start_nops = GetAiclkTarg() == GetAiclkFmin() && current_power > tdp_limit;
+
+		/* Determine stop frequency: use configured value or fall back to effective min */
+		uint32_t stop_freq = kernel_throttler_stop_nops_freq;
+
+		if (stop_freq == 0U) {
+			stop_freq = get_aiclk_effective_arb_min(&arb);
+		}
+
+		stop_nops = GetAiclkTarg() >= stop_freq && current_power < tdp_limit;
+	}
+
+	bool new_kernel_nops_enabled = ((kernel_nops_enabled || start_nops) && !stop_nops);
+
+	if (new_kernel_nops_enabled != kernel_nops_enabled) {
+		kernel_nops_enabled = new_kernel_nops_enabled;
+		SendKernelThrottlingMessage(kernel_nops_enabled);
+	}
+}
+
 void CalculateThrottlers(void)
 {
 	TelemetryInternalData telemetry_internal_data;
-	enum aiclk_arb_min arb;
 
 	ReadTelemetryInternal(1, &telemetry_internal_data);
 
@@ -362,16 +396,7 @@ void CalculateThrottlers(void)
 		float current_power = telemetry_internal_data.vcore_power;
 		float tdp_limit = throttler[kThrottlerTDP].limit;
 
-		bool start_nops = GetAiclkTarg() == GetAiclkFmin() && current_power > tdp_limit;
-		bool stop_nops = GetAiclkTarg() == get_aiclk_effective_arb_min(&arb) &&
-				 current_power < tdp_limit;
-
-		bool new_kernel_nops_enabled = ((kernel_nops_enabled || start_nops) && !stop_nops);
-
-		if (new_kernel_nops_enabled != kernel_nops_enabled) {
-			kernel_nops_enabled = new_kernel_nops_enabled;
-			SendKernelThrottlingMessage(kernel_nops_enabled);
-		}
+		UpdateKernelThrottler(current_power, tdp_limit);
 	}
 
 	UpdateThrottler(kThrottlerThm, telemetry_internal_data.asic_temperature);
@@ -380,6 +405,43 @@ void CalculateThrottlers(void)
 	for (ThrottlerId i = 0; i < kThrottlerCount; i++) {
 		UpdateThrottlerArb(i);
 	}
+}
+
+uint8_t ThrottlerSetKernelThrottlerEnabled(uint32_t enabled)
+{
+	if (enabled > 1) {
+		return 1;
+	}
+
+	kernel_throttler_at_aiclk_floor_enabled = (bool)enabled;
+	LOG_INF("kernel throttler at aiclk floor %s", enabled ? "enabled" : "disabled");
+
+	/* Release NOPs immediately if the feature is being disabled while active. */
+	if (!enabled && kernel_nops_enabled) {
+		kernel_nops_enabled = false;
+		SendKernelThrottlingMessage(false);
+	}
+
+	return 0;
+}
+
+uint8_t ThrottlerSetKernelThrottlerStopFreq(uint32_t frequency)
+{
+	/* 0 means use default behavior (get_aiclk_effective_arb_min) */
+	if (frequency == 0) {
+		kernel_throttler_stop_nops_freq = 0;
+		LOG_INF("kernel throttler stop nops frequency reset to default");
+		return 0;
+	}
+
+	/* Reject if outside valid range [AICLK_FMIN_MIN, AICLK_FMIN_MAX] */
+	if (frequency > (uint32_t)AICLK_FMIN_MAX || frequency < (uint32_t)AICLK_FMIN_MIN) {
+		return 1;
+	}
+
+	kernel_throttler_stop_nops_freq = frequency;
+	LOG_INF("kernel throttler stop nops frequency set to %u MHz", frequency);
+	return 0;
 }
 
 int32_t Dm2CmSetBoardPowerLimit(const uint8_t *data, uint8_t size)

--- a/lib/tenstorrent/bh_arc/throttler.h
+++ b/lib/tenstorrent/bh_arc/throttler.h
@@ -6,8 +6,13 @@
 #ifndef THROTTLER_H
 #define THROTTLER_H
 
+#include <stdint.h>
+#include <stdbool.h>
+
 void InitThrottlers(void);
 void CalculateThrottlers(void);
 int32_t Dm2CmSetBoardPowerLimit(const uint8_t *data, uint8_t size);
+uint8_t ThrottlerSetKernelThrottlerEnabled(uint32_t enabled);
+uint8_t ThrottlerSetKernelThrottlerStopFreq(uint32_t frequency);
 
 #endif


### PR DESCRIPTION
Add a characterization msg that allows us to enable/disable the kernel throttler feature when we hit the aiclk floor, and which allows us to change the limit at which the doppler nops are released.

**_This also disables the feature by default._**

tests:

Baseline enable/disables throttler:

<img width="1680" height="566" alt="doppler_at_floor_base" src="https://github.com/user-attachments/assets/c02108d5-e323-4876-9b12-83b797c4416e" />


Disabling the feature causes us not to send the msg:
<img width="1680" height="566" alt="doppler_disabled" src="https://github.com/user-attachments/assets/3962d8c5-af69-4504-b7ee-b141e9f15a0d" />


Changing the release limit causes doppler to be released early:
<img width="1680" height="566" alt="doppler_release_limit" src="https://github.com/user-attachments/assets/cd561e9c-2820-4dbe-9290-cdf057584fab" />


resolves: SYS-4617