### PR TITLE
Ccfgovr noppler

### DIFF
--- a/app/smc/pytest/e2e_smoke.py
+++ b/app/smc/pytest/e2e_smoke.py
@@ -118,6 +118,8 @@ ETH_RESET_ERR_INVALID_MASK = 1
 
 # Characterization submessage IDs
 TT_SUB_MSG_SET_HOST_REQUESTED_FMIN = 0x1
+TT_SUB_MSG_SET_KERNEL_THROTTLER_ENABLED = 0x2
+TT_SUB_MSG_SET_KERNEL_THROTTLER_STOP_NOPS_FREQ = 0x3
 
 # Telemetry tags
 TAG_TDP = 7
@@ -127,6 +129,7 @@ TAG_CM_FW_VERSION = 29
 TAG_ENABLED_ETH = 35
 TAG_INPUT_POWER = 54
 TAG_HOST_AICLK_LIMIT = 70
+TAG_KERNEL_THROTTLER = 75
 
 NUM_PD = 16
 NUM_VM = 8
@@ -1679,6 +1682,96 @@ def test_characterisation_host_fmin_out_of_range(arc_chip_dut, asic_id):
     logger.info("Correctly rejected fmin value 100 (too low)")
 
 
+def test_characterisation_kernel_throttler(arc_chip_dut, asic_id):
+    """
+    Validates the runtime kernel-throttler-at-AICLK-floor characterization messages.
+
+    TAG_KERNEL_THROTTLER telemetry encodes the active config:
+    - bit 0: feature enabled
+    - bits [31:16]: stop-NOPs frequency in MHz
+    """
+    arc_chip = pyluwen.detect_chips()[asic_id]
+
+    baseline = read_telem(arc_chip, TAG_KERNEL_THROTTLER)
+    logger.info(f"Baseline TAG_KERNEL_THROTTLER: 0x{baseline:08x}")
+
+    def set_enabled(value):
+        return arc_chip.as_bh().arc_msg_buf(
+            [
+                TT_SMC_MSG_CHARACTERISATION
+                | TT_SUB_MSG_SET_KERNEL_THROTTLER_ENABLED << 8,
+                value,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+            ]
+        )
+
+    def set_stop_freq(value):
+        return arc_chip.as_bh().arc_msg_buf(
+            [
+                TT_SMC_MSG_CHARACTERISATION
+                | TT_SUB_MSG_SET_KERNEL_THROTTLER_STOP_NOPS_FREQ << 8,
+                value,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+            ]
+        )
+
+    # Enable the feature at runtime.
+    response = set_enabled(1)
+    assert response[0] == 0, "Failed to enable kernel throttler at floor"
+    time.sleep(0.2)
+    assert read_telem(arc_chip, TAG_KERNEL_THROTTLER) & 1 == 1, (
+        "TAG_KERNEL_THROTTLER enabled bit not set after enable"
+    )
+
+    # Set a runtime stop frequency within [AICLK_FMIN_MIN=200, AICLK_FMIN_MAX=1400].
+    NEW_STOP_FREQ = 800
+    response = set_stop_freq(NEW_STOP_FREQ)
+    assert response[0] == 0, f"Failed to set stop freq to {NEW_STOP_FREQ} MHz"
+    time.sleep(0.2)
+    measured = read_telem(arc_chip, TAG_KERNEL_THROTTLER)
+    assert (measured >> 16) & 0xFFFF == NEW_STOP_FREQ, (
+        f"TAG_KERNEL_THROTTLER stop freq ({(measured >> 16) & 0xFFFF}) "
+        f"not set to {NEW_STOP_FREQ} MHz"
+    )
+
+    # Out-of-range stop frequencies are rejected.
+    assert set_stop_freq(9999)[0] != 0, (
+        "Expected error for out-of-range stop freq (too high)"
+    )
+    assert set_stop_freq(100)[0] != 0, (
+        "Expected error for out-of-range stop freq (too low)"
+    )
+
+    # Restore the fwtable default stop frequency (value 0).
+    response = set_stop_freq(0)
+    assert response[0] == 0, "Failed to restore default stop freq"
+
+    # Invalid enable value is rejected.
+    assert set_enabled(2)[0] != 0, "Expected error for invalid enable value"
+
+    # Disable the feature again.
+    response = set_enabled(0)
+    assert response[0] == 0, "Failed to disable kernel throttler at floor"
+    time.sleep(0.2)
+    assert read_telem(arc_chip, TAG_KERNEL_THROTTLER) & 1 == 0, (
+        "TAG_KERNEL_THROTTLER enabled bit still set after disable"
+    )
+
+    # Restore the baseline configuration.
+    set_enabled(baseline & 1)
+    set_stop_freq((baseline >> 16) & 0xFFFF)
+
+
 def test_bindesc(arc_chip_dut, asic_id):
     """
     Validates that the version descriptor matches what is running on
@@ -1716,47 +1809,95 @@ def test_bindesc(arc_chip_dut, asic_id):
 
 def test_ccfgovr_bh_mod(unlaunched_dut: DeviceAdapter, asic_id: int):
     """
-    Test bh-mod can correctly set TDP limit, and that it is not overriden
-    by tt-flash.
+    Test bh-mod can persist overrides in SPI flash via the A/B ccfgovr mechanism,
+    and that they are not overridden by tt-flash.
+
+    Covers:
+    - chip_limits.tdp_limit
+    - the kernel-throttler-at-AICLK-floor config
+      (feature_enable.kernel_throttler_at_floor_en and
+      chip_limits.kernel_throttler_stop_nops_freq), exposed through
+      TAG_KERNEL_THROTTLER telemetry:
+        - bit 0: feature enabled
+        - bits [31:16]: stop-NOPs frequency in MHz
     """
     bh_mod = shutil.which("bh-mod") or os.path.expanduser("~/bh-mod")
     if not os.path.isfile(bh_mod):
         pytest.skip("bh-mod not found (PATH or ~/bh-mod)")
 
-    # Get the TDP limit
+    # Capture baselines.
     chip = pyluwen.detect_chips()[asic_id]
-    baseline = chip.get_telemetry().tdp_limit_max
-    target = baseline - 5
+    tdp_baseline = chip.get_telemetry().tdp_limit_max
+    kt_baseline = read_telem(chip, TAG_KERNEL_THROTTLER)
+    logger.info(f"Baseline tdp_limit_max: {tdp_baseline}")
+    logger.info(f"Baseline kernel_throttler: 0x{kt_baseline:08x}")
 
-    # Set new TDP limit
+    tdp_target = tdp_baseline - 5
+    TARGET_STOP_FREQ = 800  # MHz, within [AICLK_FMIN_MIN=200, AICLK_FMIN_MAX=1400]
+    kt_expected = 1 | (TARGET_STOP_FREQ << 16)
+
+    # Persist overrides for both the TDP limit and the kernel throttler config.
     result = subprocess.run(
-        [bh_mod, "--reset-timeout=60s", "set", f"chip_limits.tdp_limit={target}"],
+        [
+            bh_mod,
+            "--reset-timeout=60s",
+            "set",
+            f"chip_limits.tdp_limit={tdp_target}",
+            "feature_enable.kernel_throttler_at_floor_en=true",
+            f"chip_limits.kernel_throttler_stop_nops_freq={TARGET_STOP_FREQ}",
+        ],
         capture_output=True,
         check=False,
     )
     assert result.returncode == 0, f"bh-mod set failed, rc={result.returncode}"
 
-    # Verify TDP limit has been set correctly by bh-mod
+    # Verify the overrides were applied by the running firmware.
     chip = pyluwen.detect_chips()[asic_id]
-    measured = chip.get_telemetry().tdp_limit_max
-    assert measured == target, f"expected tdp_limit_max={target}, got {measured}"
+    measured_tdp = chip.get_telemetry().tdp_limit_max
+    assert measured_tdp == tdp_target, (
+        f"expected tdp_limit_max={tdp_target}, got {measured_tdp}"
+    )
+    measured_kt = read_telem(chip, TAG_KERNEL_THROTTLER)
+    logger.info(f"kernel_throttler after set: 0x{measured_kt:08x}")
+    assert measured_kt == kt_expected, (
+        f"kernel throttler config not applied: expected 0x{kt_expected:08x}, "
+        f"got 0x{measured_kt:08x}"
+    )
 
-    # Re-flash the firmware bundle and confirm the override survives.
+    # Re-flash the firmware bundle and confirm the overrides survive.
     unlaunched_dut.launch()
     del chip  # force re-detection after the flash and reboot
     chip = wait_arc_boot(asic_id, timeout=60)
-    measured_after_flash = chip.get_telemetry().tdp_limit_max
-    assert measured_after_flash == target, (
+    measured_tdp_after_flash = chip.get_telemetry().tdp_limit_max
+    assert measured_tdp_after_flash == tdp_target, (
         f"ccfgovr did not survive tt-flash: "
-        f"expected tdp_limit_max={target}, got {measured_after_flash}"
+        f"expected tdp_limit_max={tdp_target}, got {measured_tdp_after_flash}"
+    )
+    measured_kt_after_flash = read_telem(chip, TAG_KERNEL_THROTTLER)
+    logger.info(f"kernel_throttler after re-flash: 0x{measured_kt_after_flash:08x}")
+    assert measured_kt_after_flash == kt_expected, (
+        f"ccfgovr did not survive tt-flash: expected 0x{kt_expected:08x}, "
+        f"got 0x{measured_kt_after_flash:08x}"
     )
 
-    # Revert TDP limit back to original
-    subprocess.run(
-        [bh_mod, "set", f"chip_limits.tdp_limit={baseline}"],
+    # Restore the baseline configuration. Warn (don't fail) if this does not
+    # succeed, since a stale SPI-flash state can flake later tests / CI runs.
+    restore = subprocess.run(
+        [
+            bh_mod,
+            "set",
+            f"chip_limits.tdp_limit={tdp_baseline}",
+            f"feature_enable.kernel_throttler_at_floor_en={'true' if kt_baseline & 1 else 'false'}",
+            f"chip_limits.kernel_throttler_stop_nops_freq={(kt_baseline >> 16) & 0xFFFF}",
+        ],
         capture_output=True,
         check=False,
     )
+    if restore.returncode != 0:
+        logger.warning(
+            f"Failed to restore baseline config (rc={restore.returncode}); "
+            f"SPI flash may be left modified: {restore.stderr.decode(errors='replace')}"
+        )
 
 
 def test_heartbeat_telemetry(arc_chip_dut, asic_id):

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/GALAXY/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/GALAXY/fw_table.txt
@@ -15,6 +15,7 @@ chip_limits {
   bus_peak_limit: 0
   frequency_margin: 0
   gddr_thm_limit: 89
+  kernel_throttler_stop_nops_freq: 0
   max_tdp_limit: 200
 }
 
@@ -28,6 +29,7 @@ feature_enable {
   fan_ctrl_en: false
   harvesting_en: true
   doppler_en: false
+  kernel_throttler_at_floor_en: false
 }
 
 fan_table {

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/GALAXY_REVC/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/GALAXY_REVC/fw_table.txt
@@ -15,6 +15,7 @@ chip_limits {
   bus_peak_limit: 0
   frequency_margin: 0
   gddr_thm_limit: 89
+  kernel_throttler_stop_nops_freq: 0
   max_tdp_limit: 200
 }
 
@@ -28,6 +29,7 @@ feature_enable {
   fan_ctrl_en: false
   harvesting_en: true
   doppler_en: false
+  kernel_throttler_at_floor_en: false
 }
 
 fan_table {

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/ORION_SLT/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/ORION_SLT/fw_table.txt
@@ -15,6 +15,7 @@ chip_limits {
   bus_peak_limit: 0
   frequency_margin: 0
   gddr_thm_limit: 89
+  kernel_throttler_stop_nops_freq: 0
 }
 
 feature_enable {
@@ -27,6 +28,7 @@ feature_enable {
   fan_ctrl_en: false
   harvesting_en: true
   doppler_en: true
+  kernel_throttler_at_floor_en: false
 }
 
 fan_table {

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P100/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P100/fw_table.txt
@@ -15,6 +15,7 @@ chip_limits {
   bus_peak_limit: 0
   frequency_margin: 0
   gddr_thm_limit: 89
+  kernel_throttler_stop_nops_freq: 0
 }
 
 feature_enable {
@@ -27,6 +28,7 @@ feature_enable {
   fan_ctrl_en: false
   harvesting_en: true
   doppler_en: false
+  kernel_throttler_at_floor_en: false
 }
 
 fan_table {

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P100A/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P100A/fw_table.txt
@@ -15,6 +15,7 @@ chip_limits {
   bus_peak_limit: 0
   frequency_margin: 0
   gddr_thm_limit: 89
+  kernel_throttler_stop_nops_freq: 0
   board_power_limit: 300
   additional_board_power: 20
 }
@@ -29,6 +30,7 @@ feature_enable {
   fan_ctrl_en: true
   harvesting_en: true
   doppler_en: true
+  kernel_throttler_at_floor_en: false
 }
 
 fan_table {

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P150A/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P150A/fw_table.txt
@@ -15,6 +15,7 @@ chip_limits {
   bus_peak_limit: 0
   frequency_margin: 0
   gddr_thm_limit: 89
+  kernel_throttler_stop_nops_freq: 0
   board_power_limit: 300
   additional_board_power: 20
 }
@@ -29,6 +30,7 @@ feature_enable {
   fan_ctrl_en: true
   harvesting_en: true
   doppler_en: true
+  kernel_throttler_at_floor_en: false
 }
 
 fan_table {

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P150B/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P150B/fw_table.txt
@@ -15,6 +15,7 @@ chip_limits {
   bus_peak_limit: 0
   frequency_margin: 0
   gddr_thm_limit: 89
+  kernel_throttler_stop_nops_freq: 0
   board_power_limit: 300
   additional_board_power: 20
 }
@@ -29,6 +30,7 @@ feature_enable {
   fan_ctrl_en: false
   harvesting_en: true
   doppler_en: true
+  kernel_throttler_at_floor_en: false
 }
 
 fan_table {

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P150C/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P150C/fw_table.txt
@@ -15,6 +15,7 @@ chip_limits {
   bus_peak_limit: 0
   frequency_margin: 0
   gddr_thm_limit: 89
+  kernel_throttler_stop_nops_freq: 0
   board_power_limit: 450
   additional_board_power: 20
 }
@@ -29,6 +30,7 @@ feature_enable {
   fan_ctrl_en: false
   harvesting_en: true
   doppler_en: true
+  kernel_throttler_at_floor_en: false
 }
 
 fan_table {

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300A_L/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300A_L/fw_table.txt
@@ -15,6 +15,7 @@ chip_limits {
   bus_peak_limit: 0
   frequency_margin: 0
   gddr_thm_limit: 89
+  kernel_throttler_stop_nops_freq: 0
   board_power_limit: 450
 }
 
@@ -28,6 +29,7 @@ feature_enable {
   fan_ctrl_en: true
   harvesting_en: true
   doppler_en: false
+  kernel_throttler_at_floor_en: false
 }
 
 fan_table {

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300A_R/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300A_R/fw_table.txt
@@ -15,6 +15,7 @@ chip_limits {
   bus_peak_limit: 0
   frequency_margin: 0
   gddr_thm_limit: 89
+  kernel_throttler_stop_nops_freq: 0
   board_power_limit: 450
 }
 
@@ -28,6 +29,7 @@ feature_enable {
   fan_ctrl_en: true
   harvesting_en: true
   doppler_en: false
+  kernel_throttler_at_floor_en: false
 }
 
 fan_table {

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300B_L/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300B_L/fw_table.txt
@@ -15,6 +15,7 @@ chip_limits {
   bus_peak_limit: 0
   frequency_margin: 0
   gddr_thm_limit: 89
+  kernel_throttler_stop_nops_freq: 0
   board_power_limit: 450
 }
 
@@ -28,6 +29,7 @@ feature_enable {
   fan_ctrl_en: false
   harvesting_en: true
   doppler_en: false
+  kernel_throttler_at_floor_en: false
 }
 
 fan_table {

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300B_R/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300B_R/fw_table.txt
@@ -15,6 +15,7 @@ chip_limits {
   bus_peak_limit: 0
   frequency_margin: 0
   gddr_thm_limit: 89
+  kernel_throttler_stop_nops_freq: 0
   board_power_limit: 450
 }
 
@@ -28,6 +29,7 @@ feature_enable {
   fan_ctrl_en: false
   harvesting_en: true
   doppler_en: false
+  kernel_throttler_at_floor_en: false
 }
 
 fan_table {

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300C_L/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300C_L/fw_table.txt
@@ -15,6 +15,7 @@ chip_limits {
   bus_peak_limit: 0
   frequency_margin: 0
   gddr_thm_limit: 89
+  kernel_throttler_stop_nops_freq: 0
   board_power_limit: 550
 }
 
@@ -28,6 +29,7 @@ feature_enable {
   fan_ctrl_en: false
   harvesting_en: true
   doppler_en: false
+  kernel_throttler_at_floor_en: false
 }
 
 fan_table {

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300C_R/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300C_R/fw_table.txt
@@ -15,6 +15,7 @@ chip_limits {
   bus_peak_limit: 0
   frequency_margin: 0
   gddr_thm_limit: 89
+  kernel_throttler_stop_nops_freq: 0
   board_power_limit: 550
 }
 
@@ -28,6 +29,7 @@ feature_enable {
   fan_ctrl_en: false
   harvesting_en: true
   doppler_en: false
+  kernel_throttler_at_floor_en: false
 }
 
 fan_table {

--- a/doc/release/release-notes-19.12.md
+++ b/doc/release/release-notes-19.12.md
@@ -17,9 +17,11 @@ Major enhancements with this release include:
 - Read GDDR temperatures more frequently as part of internal telemetry
 - Add Blackhole Kernel throttler when we reach AICLK floor (disabled by default)
 - Add throttler controls via ARC message to enable/disable kernel throttling at AICLK floor and tune the stop-NOPs frequency threshold (kernel throttling at floor is now disabled by default).
+- Get the kernel throttler defaults (enable and stop-NOPs frequency) from the firmware table so they persist across reboots and firmware upgrades, and can be overridden via `bh-mod`. The ARC message continues to override these defaults at runtime.
 
 ### Telemetry
 - Carve out a region of memory for Metal runtime telemetry and publish its address and size via `SCRATCH_RAM[22:23]`.
+- Add `TAG_KERNEL_THROTTLER` telemetry reporting the active kernel-throttler-at-AICLK-floor configuration (enable bit and stop-NOPs frequency).
 
 ### GDDR
 - Change NOC endpoint used to load GDDR0 MRISC from 0 to 2 (NOC node 0-11)

--- a/drivers/misc/bh_fwtable/bh_fwtable.c
+++ b/drivers/misc/bh_fwtable/bh_fwtable.c
@@ -378,6 +378,22 @@ void tt_bh_fwtable_apply_ccfgovr(const struct device *dev)
 			data->fw_table.chip_limits.tdp_limit = ovr.chip_limits.tdp_limit;
 		}
 
+		if (ovr.has_chip_limits && ovr.chip_limits.has_kernel_throttler_stop_nops_freq) {
+			LOG_INF("CCFGOVR override: chip_limits.kernel_throttler_stop_nops_freq = "
+				"%u",
+				ovr.chip_limits.kernel_throttler_stop_nops_freq);
+			data->fw_table.chip_limits.kernel_throttler_stop_nops_freq =
+				ovr.chip_limits.kernel_throttler_stop_nops_freq;
+		}
+
+		if (ovr.has_feature_enable && ovr.feature_enable.has_kernel_throttler_at_floor_en) {
+			LOG_INF("CCFGOVR override: feature_enable.kernel_throttler_at_floor_en = "
+				"%u",
+				ovr.feature_enable.kernel_throttler_at_floor_en);
+			data->fw_table.feature_enable.kernel_throttler_at_floor_en =
+				ovr.feature_enable.kernel_throttler_at_floor_en;
+		}
+
 		return;
 	}
 

--- a/drivers/misc/bh_fwtable/spirom_protobufs/fw_table.proto
+++ b/drivers/misc/bh_fwtable/spirom_protobufs/fw_table.proto
@@ -36,6 +36,7 @@ message FwTable {
     uint32 board_power_limit = 14;
     uint32 additional_board_power = 15;
     uint32 max_tdp_limit = 16;
+    uint32 kernel_throttler_stop_nops_freq = 17;
   }
 
   message FeatureEnable {
@@ -48,6 +49,7 @@ message FwTable {
     bool harvesting_en = 7;
     bool fan_ctrl_en = 8;
     bool doppler_en = 9;
+    bool kernel_throttler_at_floor_en = 10;
   }
 
   message FanTable{

--- a/drivers/misc/bh_fwtable/spirom_protobufs/fw_table_override.proto
+++ b/drivers/misc/bh_fwtable/spirom_protobufs/fw_table_override.proto
@@ -19,14 +19,23 @@ message FwTableOverride {
    * (FwTable field 1) is deliberately reserved here so tt-mod cannot forge
    * a bundle version.
    */
-  reserved 1, 3, 4, 5, 6, 7, 8, 9, 10;
+  reserved 1, 4, 5, 6, 7, 8, 9, 10;
 
   optional ChipLimits chip_limits = 2;
+  optional FeatureEnable feature_enable = 3;
 
   message ChipLimits {
 
     reserved 1, 2, 3, 4, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16;
 
     optional uint32 tdp_limit = 5;
+    optional uint32 kernel_throttler_stop_nops_freq = 17;
+  }
+
+  message FeatureEnable {
+
+    reserved 1, 2, 3, 4, 5, 6, 7, 8, 9;
+
+    optional bool kernel_throttler_at_floor_en = 10;
   }
 }

--- a/lib/tenstorrent/bh_arc/telemetry.c
+++ b/lib/tenstorrent/bh_arc/telemetry.c
@@ -169,6 +169,7 @@ static struct telemetry_table telemetry_table = {
 		[67] = {TAG_GDDR_MRISC_NOC2AXI_PORT, TELEM_OFFSET(TAG_GDDR_MRISC_NOC2AXI_PORT)},
 		[68] = {TAG_GDDR_WEST_IO_POWER, TELEM_OFFSET(TAG_GDDR_WEST_IO_POWER)},
 		[69] = {TAG_GDDR_EAST_IO_POWER, TELEM_OFFSET(TAG_GDDR_EAST_IO_POWER)},
+		[70] = {TAG_KERNEL_THROTTLER, TELEM_OFFSET(TAG_KERNEL_THROTTLER)},
 	},
 };
 /* clang-format on */
@@ -241,6 +242,11 @@ void UpdateTelemetryThermTripCount(uint16_t therm_trip_count)
 void UpdateTelemetryHostAiclkLimit(uint32_t fmax)
 {
 	telemetry[TAG_HOST_AICLK_LIMIT] = fmax;
+}
+
+void UpdateTelemetryKernelThrottler(bool enabled, uint32_t stop_nops_freq)
+{
+	telemetry[TAG_KERNEL_THROTTLER] = (enabled ? 1U : 0U) | ((stop_nops_freq & 0xFFFFU) << 16U);
 }
 
 bool GetTelemetryTagValid(uint16_t tag)

--- a/lib/tenstorrent/bh_arc/telemetry.h
+++ b/lib/tenstorrent/bh_arc/telemetry.h
@@ -369,12 +369,22 @@
  */
 #define TAG_GDDR_EAST_IO_POWER 74
 
+/**
+ * @brief Kernel-throttler-at-AICLK-floor configuration.
+ *
+ * Reflects the persisted firmware-table configuration (which may be overridden
+ * via the SPI-flash A/B ccfgovr mechanism):
+ * - bit 0: feature enabled (1) or disabled (0)
+ * - bits [31:16]: stop-NOPs frequency in MHz (0 = FW-controlled default)
+ */
+#define TAG_KERNEL_THROTTLER 75
+
 /** @} */ /* end of telemetry_tag group */
 
 /* Not a real tag, signifies the last tag in the list.
  * MUST be incremented if new tags are defined.
  */
-#define TAG_COUNT 75
+#define TAG_COUNT 76
 
 /* Telemetry tags are at offset `tag` in the telemetry buffer */
 #define TELEM_OFFSET(tag) (tag)
@@ -389,6 +399,7 @@ void UpdateTelemetryBoardPowerLimit(uint32_t power_limit);
 void UpdateTelemetryTdpLimit(uint32_t tdp_limit);
 void UpdateTelemetryThermTripCount(uint16_t therm_trip_count);
 void UpdateTelemetryHostAiclkLimit(uint32_t fmax);
+void UpdateTelemetryKernelThrottler(bool enabled, uint32_t stop_nops_freq);
 bool GetTelemetryTagValid(uint16_t tag);
 uint32_t GetTelemetryTag(uint16_t tag);
 

--- a/lib/tenstorrent/bh_arc/throttler.c
+++ b/lib/tenstorrent/bh_arc/throttler.c
@@ -28,8 +28,15 @@ static bool doppler_t2;
 static bool doppler_t3;
 static const bool thermal_throttling = true;
 
+/*
+ * Kernel-throttler-at-AICLK-floor configuration. The defaults are sourced from
+ * the firmware table at init (feature_enable.kernel_throttler_at_floor_en and
+ * chip_limits.kernel_throttler_stop_nops_freq), so they can be persisted in SPI
+ * flash and overridden via bh-mod.
+ */
 static bool kernel_throttler_at_aiclk_floor_enabled;
 static uint32_t kernel_throttler_stop_nops_freq;
+static uint32_t kernel_throttler_stop_nops_freq_default;
 
 #define kThrottlerAiclkScaleFactor 500.0F
 #define DEFAULT_BOARD_POWER_LIMIT  150
@@ -217,6 +224,28 @@ void InitThrottlers(void)
 	doppler_t2 = doppler;
 	doppler_t3 = doppler;
 
+	kernel_throttler_at_aiclk_floor_enabled =
+		tt_bh_fwtable_get_fw_table(fwtable_dev)
+			->feature_enable.kernel_throttler_at_floor_en;
+	kernel_throttler_stop_nops_freq_default =
+		tt_bh_fwtable_get_fw_table(fwtable_dev)
+			->chip_limits.kernel_throttler_stop_nops_freq;
+	/* A non-zero stop frequency must be within the valid AICLK floor range.
+	 * An out-of-range value (e.g. from a board table or ccfgovr override)
+	 * could otherwise leave kernel NOPs permanently engaged, so treat it as
+	 * 0 (fall back to the effective minimum arbiter frequency at runtime).
+	 */
+	if (kernel_throttler_stop_nops_freq_default != 0U &&
+	    (kernel_throttler_stop_nops_freq_default < (uint32_t)AICLK_FMIN_MIN ||
+	     kernel_throttler_stop_nops_freq_default > (uint32_t)AICLK_FMIN_MAX)) {
+		LOG_WRN("Invalid fwtable kernel_throttler_stop_nops_freq=%u MHz; using 0 (auto)",
+			kernel_throttler_stop_nops_freq_default);
+		kernel_throttler_stop_nops_freq_default = 0U;
+	}
+	kernel_throttler_stop_nops_freq = kernel_throttler_stop_nops_freq_default;
+	UpdateTelemetryKernelThrottler(kernel_throttler_at_aiclk_floor_enabled,
+				       kernel_throttler_stop_nops_freq);
+
 	SetThrottlerLimit(kThrottlerTDP,
 			  tt_bh_fwtable_get_fw_table(fwtable_dev)->chip_limits.tdp_limit);
 	SetThrottlerLimit(kThrottlerFastTDC,
@@ -347,13 +376,14 @@ static void UpdateDoppler(const TelemetryInternalData *telemetry)
 	EnableArbMax(aiclk_arb_max_doppler_critical, critical_throttling);
 }
 
-/** @brief Update kernel throttler NOPs state based on power
- * @param[in] current_power Current vcore power in watts
- * @param[in] tdp_limit TDP throttler limit in watts
+/* Update kernel throttler NOPs state when running at the AICLK floor.
+ *
+ * Only active when feature_enable.kernel_throttler_at_floor_en is set. The stop
+ * frequency is taken from chip_limits.kernel_throttler_stop_nops_freq when
+ * non-zero, otherwise it falls back to the effective minimum arbiter frequency.
  */
 static void UpdateKernelThrottler(float current_power, float tdp_limit)
 {
-	/* Kernel throttler at aiclk floor is only active if enabled */
 	bool start_nops = false;
 	bool stop_nops = false;
 	enum aiclk_arb_min arb;
@@ -361,7 +391,6 @@ static void UpdateKernelThrottler(float current_power, float tdp_limit)
 	if (kernel_throttler_at_aiclk_floor_enabled) {
 		start_nops = GetAiclkTarg() == GetAiclkFmin() && current_power > tdp_limit;
 
-		/* Determine stop frequency: use configured value or fall back to effective min */
 		uint32_t stop_freq = kernel_throttler_stop_nops_freq;
 
 		if (stop_freq == 0U) {
@@ -422,15 +451,22 @@ uint8_t ThrottlerSetKernelThrottlerEnabled(uint32_t enabled)
 		SendKernelThrottlingMessage(false);
 	}
 
+	UpdateTelemetryKernelThrottler(kernel_throttler_at_aiclk_floor_enabled,
+				       kernel_throttler_stop_nops_freq);
 	return 0;
 }
 
 uint8_t ThrottlerSetKernelThrottlerStopFreq(uint32_t frequency)
 {
-	/* 0 means use default behavior (get_aiclk_effective_arb_min) */
+	/* 0 restores the fwtable-provided default (which may itself be 0, meaning
+	 * fall back to the effective minimum arbiter frequency at runtime).
+	 */
 	if (frequency == 0) {
-		kernel_throttler_stop_nops_freq = 0;
-		LOG_INF("kernel throttler stop nops frequency reset to default");
+		kernel_throttler_stop_nops_freq = kernel_throttler_stop_nops_freq_default;
+		LOG_INF("kernel throttler stop nops frequency restored to fwtable default %u MHz",
+			kernel_throttler_stop_nops_freq);
+		UpdateTelemetryKernelThrottler(kernel_throttler_at_aiclk_floor_enabled,
+					       kernel_throttler_stop_nops_freq);
 		return 0;
 	}
 
@@ -441,6 +477,8 @@ uint8_t ThrottlerSetKernelThrottlerStopFreq(uint32_t frequency)
 
 	kernel_throttler_stop_nops_freq = frequency;
 	LOG_INF("kernel throttler stop nops frequency set to %u MHz", frequency);
+	UpdateTelemetryKernelThrottler(kernel_throttler_at_aiclk_floor_enabled,
+				       kernel_throttler_stop_nops_freq);
 	return 0;
 }
 

--- a/tests/drivers/fw_table/src/main.c
+++ b/tests/drivers/fw_table/src/main.c
@@ -85,6 +85,34 @@ static size_t encode_tdp_limit_override(uint8_t *out, size_t out_size, uint32_t 
 	return total;
 }
 
+static size_t encode_kernel_throttler_override(uint8_t *out, size_t out_size, bool enabled,
+					       uint32_t stop_freq)
+{
+	FwTableOverride ovr = FwTableOverride_init_zero;
+
+	ovr.has_feature_enable = true;
+	ovr.feature_enable.has_kernel_throttler_at_floor_en = true;
+	ovr.feature_enable.kernel_throttler_at_floor_en = enabled;
+
+	ovr.has_chip_limits = true;
+	ovr.chip_limits.has_kernel_throttler_stop_nops_freq = true;
+	ovr.chip_limits.kernel_throttler_stop_nops_freq = stop_freq;
+
+	pb_ostream_t stream = pb_ostream_from_buffer(out, out_size);
+
+	zassert_true(pb_encode_ex(&stream, FwTableOverride_fields, &ovr, PB_ENCODE_NULLTERMINATED),
+		     "pb_encode_ex failed: %s", PB_GET_ERROR(&stream));
+
+	size_t total = stream.bytes_written;
+
+	/* Pad to 4 byte alignment for ccfgovr header requirement */
+	while ((total % 4U) != 0U) {
+		zassert_true(total < out_size, "padded body overruns buffer");
+		out[total++] = 0x00U;
+	}
+	return total;
+}
+
 static void write_bank(uint32_t addr, struct ccfgovr_bank_hdr *hdr, const uint8_t *body,
 		       size_t body_len)
 {
@@ -172,6 +200,26 @@ ZTEST(bh_fwtable_ccfgovr, test_happy_path_active_bank_applies)
 	tt_bh_fwtable_apply_ccfgovr(fwtable_dev);
 	zassert_equal(tt_bh_fwtable_get_fw_table(fwtable_dev)->chip_limits.tdp_limit, 175,
 		      "expected override to set tdp_limit=175");
+}
+
+/**
+ * @brief Test that the kernel-throttler-at-floor configuration can be overridden
+ */
+ZTEST(bh_fwtable_ccfgovr, test_kernel_throttler_override_applies)
+{
+	uint8_t body[16];
+	size_t body_len = encode_kernel_throttler_override(body, sizeof(body), true, 800U);
+	struct ccfgovr_bank_hdr hdr = {.magic = CCFGOVR_MAGIC, .seq = 2};
+
+	write_bank(BANK_A_ADDR, &hdr, body, body_len);
+
+	tt_bh_fwtable_apply_ccfgovr(fwtable_dev);
+	zassert_true(tt_bh_fwtable_get_fw_table(fwtable_dev)
+			     ->feature_enable.kernel_throttler_at_floor_en,
+		     "expected override to enable kernel_throttler_at_floor_en");
+	zassert_equal(tt_bh_fwtable_get_fw_table(fwtable_dev)
+			      ->chip_limits.kernel_throttler_stop_nops_freq,
+		      800U, "expected override to set kernel_throttler_stop_nops_freq=800");
 }
 
 /**


### PR DESCRIPTION
Persist kernel throttler config via ccfgovr.

Also added to telemetry for extra exposure