### PR TITLE
lib: bh_arc: add NOP on-duration telemetry

### DIFF
--- a/lib/tenstorrent/bh_arc/telemetry.c
+++ b/lib/tenstorrent/bh_arc/telemetry.c
@@ -172,6 +172,7 @@ static struct telemetry_table telemetry_table = {
 		[69] = {TAG_GDDR_EAST_IO_POWER, TELEM_OFFSET(TAG_GDDR_EAST_IO_POWER)},
 		[70] = {TAG_KERNEL_THROTTLER, TELEM_OFFSET(TAG_KERNEL_THROTTLER)},
 		[71] = {TAG_NOP_START_COUNT, TELEM_OFFSET(TAG_NOP_START_COUNT)},
+		[72] = {TAG_NOP_ON_DURATION, TELEM_OFFSET(TAG_NOP_ON_DURATION)},
 	},
 };
 /* clang-format on */
@@ -544,6 +545,7 @@ static void update_telemetry(void)
 	/* reported in W, truncated to uint32_t */
 	telemetry[TAG_GDDR_EAST_IO_POWER] = telemetry_internal_data.gddr_io_power_east;
 	telemetry[TAG_NOP_START_COUNT] = GetStartNOPCount();
+	telemetry[TAG_NOP_ON_DURATION] = GetNOPOnDuration(telem_update_interval);
 	telemetry[TAG_TIMER_HEARTBEAT]++; /* Incremented every time the timer is called */
 	SetPostCode(POST_CODE_SRC_CMFW, POST_CODE_TELEMETRY_END);
 }

--- a/lib/tenstorrent/bh_arc/telemetry.h
+++ b/lib/tenstorrent/bh_arc/telemetry.h
@@ -386,12 +386,19 @@
  */
 #define TAG_NOP_START_COUNT 76
 
+/** @brief Time kernel NOP throttling was active during the last telemetry
+ * update window, in milliseconds.
+ *
+ * Reflects how long NOPs were on over the most recent telemetry update interval.
+ */
+#define TAG_NOP_ON_DURATION 77
+
 /** @} */ /* end of telemetry_tag group */
 
 /* Not a real tag, signifies the last tag in the list.
  * MUST be incremented if new tags are defined.
  */
-#define TAG_COUNT 77
+#define TAG_COUNT 78
 
 /* Telemetry tags are at offset `tag` in the telemetry buffer */
 #define TELEM_OFFSET(tag) (tag)

--- a/lib/tenstorrent/bh_arc/throttler.c
+++ b/lib/tenstorrent/bh_arc/throttler.c
@@ -170,6 +170,10 @@ static uint32_t throttle_counter;
 static const uint32_t kKernelThrottleAddress = 0x10;
 static bool tensixes_enabled = true;
 
+static uint32_t nop_on_since_ms;      /* uptime when NOP last turned on */
+static uint32_t nop_on_accum_ms;      /* total ms NOP's been on until now */
+static uint32_t prev_nop_on_accum_ms; /* total ms NOP's been on until prev telemetry update */
+
 static void BroadcastKernelThrottleState(void)
 {
 	const uint8_t kNocRing = 0;
@@ -186,6 +190,9 @@ static void BroadcastKernelThrottleState(void)
 static void InitKernelThrottling(void)
 {
 	throttle_counter = 0;
+	nop_on_since_ms = 0;
+	nop_on_accum_ms = 0;
+	prev_nop_on_accum_ms = 0;
 
 	BroadcastKernelThrottleState();
 }
@@ -200,6 +207,16 @@ static void SendKernelThrottlingMessage(bool throttle)
 	throttle_counter++;
 	if ((throttle_counter & 1) != throttle) {
 		throttle_counter++;
+	}
+
+	/* Accumulate NOP-on time: stamp the start on the rising edge, bank the
+	 * elapsed interval on the falling edge. Centralised here so every edge
+	 * (kernel throttler, Doppler, and feature-disable paths) is accounted for.
+	 */
+	if (throttle) {
+		nop_on_since_ms = k_uptime_get_32();
+	} else {
+		nop_on_accum_ms += k_uptime_get_32() - nop_on_since_ms;
 	}
 
 	BroadcastKernelThrottleState();
@@ -536,6 +553,46 @@ uint32_t GetStartNOPCount(void)
 	 * Need to convert transition count to NOP start count
 	 */
 	return (throttle_counter + 1) >> 1;
+}
+
+uint32_t GetNOPOnAccumulatedTime(void)
+{
+	/* If NOPs are currently enabled, add time since they were last turned on to
+	 * accumulated time. Wraps at ~49.7 days of cumulative NOP-on time; consumers
+	 * must difference samples with unsigned (modular) arithmetic.
+	 */
+	if (kernel_nops_enabled) {
+		return nop_on_accum_ms + (k_uptime_get_32() - nop_on_since_ms);
+	} else {
+		return nop_on_accum_ms;
+	}
+}
+
+uint32_t GetNOPOnDuration(uint32_t window_ms)
+{
+	/* NOP-on time accrued since the previous call. Unsigned subtraction stays
+	 * correct across accumulator wrap, since one window's delta is tiny relative
+	 * to the 32-bit millisecond range.
+	 */
+	uint32_t accumulated_time = GetNOPOnAccumulatedTime();
+	uint32_t duration = accumulated_time - prev_nop_on_accum_ms;
+
+	prev_nop_on_accum_ms = accumulated_time;
+
+	/* On the first call prev_nop_on_accum_ms is still 0 from init, so the delta is
+	 * the entire NOP-on time banked since boot rather than a single window. Clamp
+	 * that bootstrap sample to the window length. `seeded` makes this one-shot:
+	 * later samples are returned unclamped so their running sum stays faithful to
+	 * the true cumulative NOP-on time.
+	 */
+	static bool seeded;
+
+	if (!seeded) {
+		seeded = true;
+		duration = MIN(duration, window_ms);
+	}
+
+	return duration;
 }
 
 REGISTER_MESSAGE(TT_SMC_MSG_SET_TDP_LIMIT, set_tdp_limit_handler);

--- a/lib/tenstorrent/bh_arc/throttler.h
+++ b/lib/tenstorrent/bh_arc/throttler.h
@@ -15,5 +15,8 @@ int32_t Dm2CmSetBoardPowerLimit(const uint8_t *data, uint8_t size);
 uint8_t ThrottlerSetKernelThrottlerEnabled(uint32_t enabled);
 uint8_t ThrottlerSetKernelThrottlerStopFreq(uint32_t frequency);
 uint32_t GetStartNOPCount(void);
+uint32_t GetNOPOnAccumulatedTime(void);
+/* ms NOP was on during the last telemetry update window, clamped to window_ms */
+uint32_t GetNOPOnDuration(uint32_t window_ms);
 
 #endif


### PR DESCRIPTION
Accumulate kernel-NOP on-time at each throttle-state edge in SendKernelThrottlingMessage so every path (kernel throttler, Doppler, feature-disable) is accounted for. Expose it via GetNOPOnAccumulatedTime() and the per-window GetNOPOnDuration(), published as the new TAG_NOP_ON_DURATION telemetry tag.