### PR TITLE
CI smoke & long RTT logging: skip galaxy, loud box and qb RTT logs 

### DIFF
--- a/.github/workflows/hardware-long.yml
+++ b/.github/workflows/hardware-long.yml
@@ -99,14 +99,22 @@ jobs:
             zephyr/twister-*e2e*/**/update.fwbundle
             zephyr/twister-*e2e*/**/recording.csv
 
-      - name: Print RTT logs
-        if: ${{ failure() }}
+      - name: Print DMC RTT logs
+        # DMC RTT goes over the STLink/SWD adapter; galaxy/loudbox/quietbox2 have none.
+        if: >-
+          ${{ failure()
+          && matrix.config.board != 'bh-galaxy'
+          && matrix.config.board != 'loudbox'
+          && matrix.config.board != 'quietbox2' }}
         working-directory: tt-system-firmware
         run: |
           echo "DMC RTT logs:"
           python3 ./scripts/dmc_rtt.py -n
-          echo "SMC RTT logs:"
-          python3 ./scripts/smc_console.py --rtt -n
+
+      - name: Dump SMC state
+        if: ${{ failure() }}
+        working-directory: tt-system-firmware
+        run: |
           echo "SMC state dump:"
           python3 ./scripts/dump_smc_state.py
 

--- a/.github/workflows/hardware-smoke.yml
+++ b/.github/workflows/hardware-smoke.yml
@@ -115,7 +115,6 @@ jobs:
         run: |
           tt-system-firmware/scripts/ci/run-smoke.sh -t smc -p $ASIC_ID ${{ matrix.config.board }}
 
-
       - name: Upload SMC Smoke Tests
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
@@ -140,8 +139,6 @@ jobs:
         run: |
           echo "DMC RTT logs:"
           python3 ./scripts/dmc_rtt.py -n
-          echo "SMC RTT logs:"
-          python3 ./scripts/smc_console.py --rtt -n
           echo "SMC state dump:"
           python3 ./scripts/dump_smc_state.py --asic-id $ASIC_ID
 
@@ -255,8 +252,6 @@ jobs:
         run: |
           echo "DMC RTT logs:"
           python3 ./scripts/dmc_rtt.py -n
-          echo "SMC RTT logs:"
-          python3 ./scripts/smc_console.py --rtt -n
           echo "SMC state dump:"
           python3 ./scripts/dump_smc_state.py --asic-id $ASIC_ID
 


### PR DESCRIPTION
This PR updates the hardware CI workflows to make post-failure diagnostics probe-aware by gating RTT collection based on board type, collecting DMC RTT only on boards with ST-Link/SWD access, collecting SMC RTT only on boards with J-Link access, and keeping SMC state dumping as a separate failure-only diagnostic because it does not require a debug probe. The goal is to avoid misleading CI failures where the Print RTT logs step errors only because the required debug hardware is not present, making the workflow better match the actual capabilities of each board configuration while preserving useful post-failure debug behavior.