### PR TITLE
tensix_reset: use noc coord instead of phys coord for clock gate

### DIFF
--- a/app/smc/pytest/e2e_stress.py
+++ b/app/smc/pytest/e2e_stress.py
@@ -505,8 +505,8 @@ def test_power_virus(arc_chip_dut, asic_id):
 )
 def test_tensix_reset_then_burnin(arc_chip_dut, asic_id):
     """
-    Reset every non-harvested tensix tile, then run tt-burnin and check
-    that it exits successfully.
+    Reset every non-harvested Tensix tile, then run tt-burnin and check
+    it exits successfully.
     """
     arc_chip = pyluwen.detect_chips()[asic_id]
 
@@ -517,9 +517,9 @@ def test_tensix_reset_then_burnin(arc_chip_dut, asic_id):
 
     # We want to test the tensix reset message on low power.
     # Set high power after the message to allow NOC read/write to function properly.
+    logger.info(f"Resetting {len(all_tiles)} Tensix tiles")
     arc_chip.set_power_state("low")
     for noc_x, noc_y in all_tiles:
-        logger.info(f"Resetting ({noc_x},{noc_y})")
         response = arc_chip.arc_msg(
             TT_SMC_MSG_TOGGLE_SINGLE_TENSIX_RESET,
             arg0=noc_x | (noc_y << 8),
@@ -528,15 +528,46 @@ def test_tensix_reset_then_burnin(arc_chip_dut, asic_id):
             f"Tensix ({noc_x}, {noc_y}) reset failed with {response[1]}"
         )
     arc_chip.set_power_state("high")
+    logger.info("  Succeeded")
 
-    logger.info(f"Reset {len(all_tiles)} tensix tiles, starting burnin")
+    duration = 180
+    logger.info(f"Running tt-burnin for {duration}s")
 
-    result = subprocess.run(
+    burnin_process = subprocess.Popen(
         ["tt-burnin", "--no-reset"],
-        stdin=subprocess.DEVNULL,
-        capture_output=True,
-        timeout=300,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
     )
 
-    logger.info(f"tt-burnin exited with code {result.returncode}")
-    assert result.returncode == 0, "tt-burnin failed after tensix reset"
+    terminated_early = False
+    try:
+        end_time = time.time() + duration
+        while time.time() < end_time:
+            if burnin_process.poll() is not None:
+                terminated_early = True
+                break
+            time.sleep(1.0)
+    finally:
+        if burnin_process.poll() is None:
+            # Send enter key to stop tt-burnin gracefully
+            try:
+                burnin_process.stdin.write(b"\n")
+                burnin_process.stdin.flush()
+                burnin_process.wait(timeout=5)
+            except (subprocess.TimeoutExpired, BrokenPipeError):
+                logger.warning(
+                    "tt-burnin did not terminate gracefully, killing process"
+                )
+                burnin_process.terminate()
+                try:
+                    burnin_process.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    burnin_process.kill()
+                    burnin_process.wait()
+
+    assert not terminated_early, "tt-burnin terminated early"
+    assert burnin_process.returncode == 0, (
+        f"tt-burnin failed with {burnin_process.returncode}"
+    )
+    logger.info("  Succeeded")

--- a/lib/tenstorrent/bh_arc/noc_init.c
+++ b/lib/tenstorrent/bh_arc/noc_init.c
@@ -221,9 +221,9 @@ int32_t set_tensix_enable(bool enable)
 	return 0;
 }
 
-void SetSingleTileClockGate(uint8_t phys_x, uint8_t phys_y, bool gate)
+void SetSingleTileClockGate(uint8_t noc0_x, uint8_t noc0_y, bool gate)
 {
-	volatile uint32_t *noc_regs = SetupNiuTlbPhys(kTlbIndex, phys_x, phys_y, 0);
+	volatile uint32_t *noc_regs = SetupNiuTlb(kTlbIndex, noc0_x, noc0_y, 0);
 
 	uint32_t niu_cfg_0 = ReadNocCfgReg(noc_regs, NIU_CFG_0);
 

--- a/lib/tenstorrent/bh_arc/reset.c
+++ b/lib/tenstorrent/bh_arc/reset.c
@@ -281,7 +281,10 @@ static __maybe_unused uint8_t ToggleSingleTensixReset(const union request *req,
 
 	bh_power_state_get(BH_POWER_DOMAIN_TENSIX, &power_state);
 	if (!power_state) {
-		SetSingleTileClockGate(phys_x, phys_y, true);
+		/* ARC NOC translation has been restored above, so (like the
+		 * tensix_inject_instruction call) use the logical coordinates.
+		 */
+		SetSingleTileClockGate(noc_x, noc_y, true);
 	}
 
 	rsp->data[0] = 0;


### PR DESCRIPTION
Tensix reset has been failing intermittently in CI. This is due to SetSingleTileClockGate using physical coordinates instead of NOC coordinates, causing improper translation and a random tile being clock gated. This will hang if the random tile is harvested, causing the intermittent CI failure.

Use NOC coords instead of physical coords for SetSingleTileClockGate.